### PR TITLE
Related to #3: Make potentially large element item optional.

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -1405,21 +1405,21 @@ Change Request 2061, 2063, 2065, 2109</revremark>
   </tt:Data> 
 </tt:MessageDescription>
 ]]></programlisting>
+        <para>The Information element item is optional due to its potentially large size.</para>
 </section>
       <section>
         <title>Configuration changes</title>
         <para>If the configuration of a recording is changed, a device shall provide the following event:</para>
         <para>Topic: tns1:RecordingConfig/<phrase>RecordingConfiguration</phrase></para>
         <programlisting><![CDATA[<tt:MessageDescription IsProperty="false"> 
-        <para>&lt;tt:MessageDescription IsProperty="false"&gt; </para>
-        <para>  &lt;tt:Source&gt; </para>
-        <para>    &lt;tt:SimpleItemDescription Name="RecordingToken" Type="tt:RecordingReference"/&gt; </para>
-        <para>  &lt;/tt:Source&gt; </para>
-        <para>  &lt;tt:Data&gt; </para>
-        <para>    &lt;tt:ElementItemDescription Name="Configuration" Type="tt:RecordingConfiguration"/&gt; </para>
-        <para>  &lt;/tt:Data&gt; </para>
-        <para>&lt;/tt:MessageDescription&gt;</para>
-]]></programlisting>
+<tt:MessageDescription IsProperty="false"> 
+  <tt:Source> 
+    <tt:SimpleItemDescription Name="RecordingToken" Type="tt:RecordingReference"/> 
+  </tt:Source> 
+  <tt:Data> 
+    <tt:ElementItemDescription Name="Configuration" Type="tt:RecordingConfiguration"/> 
+  </tt:Data> 
+</tt:MessageDescription>]]></programlisting>
         <para>If the configuration of a track is changed, a device shall provide the following event:</para>
         <para>Topic: tns1:RecordingConfig/<phrase>TrackConfiguration</phrase></para>
         <programlisting><![CDATA[<tt:MessageDescription IsProperty="false"> 
@@ -1430,8 +1430,7 @@ Change Request 2061, 2063, 2065, 2109</revremark>
   <tt:Data> 
     <tt:ElementItemDescription Name="Configuration" Type="tt:TrackConfiguration"/> 
   </tt:Data> 
-</tt:MessageDescription>
-]]></programlisting>
+</tt:MessageDescription>]]></programlisting>
         <para>If the configuration of a recording job is changed, a device shall provide the following event:</para>
         <para>Topic: tns1:RecordingConfig/<phrase>RecordingJobConfiguration</phrase></para>
         <programlisting><![CDATA[<tt:MessageDescription IsProperty="false"> 


### PR DESCRIPTION
Additionally fix wrong conversion from word of source listing of next section.