### PR TITLE
Fix for onvif-ext 2088: Support for media service without video encoder.

### DIFF
--- a/doc/Media2.xml
+++ b/doc/Media2.xml
@@ -1134,7 +1134,9 @@ Added Multitrack Streaming</revremark>
       </section>
       <section>
         <title>GetVideoEncoderInstances</title>
-        <para>This command provides information on how many video encoders a device can instantiate concurrently for a VideoSourceConfiguration. A device shall support this command. </para>
+        <para>This command provides information on how many video encoders a device can instantiate
+          concurrently for a VideoSourceConfiguration. A device signaling support for VideoEncoder
+          via the ConfigurationsSupported capability shall support this command. </para>
         <para>The Info response contains the following information:</para>
         <itemizedlist>
           <listitem>


### PR DESCRIPTION
Make GetVideoEncoderInstances optional for devices not supporting video encoders. Proposal related to DTT ticket [2088]{https://wush.net/trac/onvif-ext/ticket/2088)