### PR TITLE
Correct swapped top and bottom coordinates in examples

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -617,7 +617,7 @@
     <tt:Object ObjectId="12">
       <tt:Appearance>
         <tt:Shape>
-          <tt:BoundingBox left="20.0" top="30.0" right="100.0" bottom="80.0"/>
+          <tt:BoundingBox left="20.0" top="80.0" right="100.0" bottom="30.0"/>
           <tt:CenterOfGravity x="60.0" y="50.0"/>
         </tt:Shape>
       </tt:Appearance>
@@ -632,7 +632,7 @@
     <tt:Object ObjectId="12">
       <tt:Appearance>
         <tt:Shape>
-          <tt:BoundingBox left="20.0" top="30.0" right="100.0" bottom="80.0"/>
+          <tt:BoundingBox left="20.0" top="80.0" right="100.0" bottom="30.0"/>
           <tt:CenterOfGravity x="60.0" y="50.0"/>
         </tt:Shape>
       </tt:Appearance>
@@ -657,7 +657,7 @@
     <tt:Object ObjectId="12">
       <tt:Appearance>
         <tt:Shape>
-          <tt:BoundingBox left="25.0" top="30.0" right="105.0" bottom="80.0"/>
+          <tt:BoundingBox left="25.0" top="80.0" right="105.0" bottom="30.0"/>
           <tt:CenterOfGravity x="65.0" y="50.0"/>
         </tt:Shape>
       </tt:Appearance>
@@ -672,7 +672,7 @@
     <tt:Object ObjectId="19">
       <tt:Appearance>
         <tt:Shape>
-          <tt:BoundingBox left="20.0" top="30.0" right="100.0" bottom="80.0"/>
+          <tt:BoundingBox left="20.0" top="80.0" right="100.0" bottom="30.0"/>
           <tt:CenterOfGravity x="60.0" y="50.0"/>
         </tt:Shape>
       </tt:Appearance>
@@ -692,7 +692,7 @@
     <tt:Object ObjectId="12">
       <tt:Appearance>
         <tt:Shape>
-          <tt:BoundingBox left="20.0" top="30.0" right="100.0" bottom="180.0"/>
+          <tt:BoundingBox left="20.0" top="180.0" right="100.0" bottom="30.0"/>
           <tt:CenterOfGravity x="60.0" y="80.0"/>
         </tt:Shape>
         <tt:Class>
@@ -709,7 +709,7 @@
     <tt:Object ObjectId="14" Parent="12">
       <tt:Appearance>
         <tt:Shape>
-          <tt:BoundingBox left="40.0" top="100.0" right="70.0" bottom="150.0" />
+          <tt:BoundingBox left="40.0" top="150.0" right="70.0" bottom="100.0" />
           <tt:CenterOfGravity x="57.0" y="130.0" />
         </tt:Shape>
         <tt:Class>
@@ -787,7 +787,7 @@
   <tt:Object ObjectId="12">
     <tt:Appearance>
       <tt:Shape>
-        <tt:BoundingBox left="20.0" top="30.0" right="100.0" bottom="80.0"/>
+        <tt:BoundingBox left="20.0" top="80.0" right="100.0" bottom="30.0"/>
         <tt:CenterOfGravity x="60.0" y="50.0"/>
         <tt:Polygon>
           <tt:Point x="20.0" y="30.0"/>
@@ -814,7 +814,7 @@
   <tt:Object ObjectId="34">
     <tt:Appearance>
       <tt:Shape>
-        <tt:BoundingBox left="20.0" top="30.0" right="100.0" bottom="80.0"/>
+        <tt:BoundingBox left="20.0" top="80.0" right="100.0" bottom="30.0"/>
         <tt:CenterOfGravity x="60.0" y="50.0"/>
       </tt:Shape>
       <tt:Color>
@@ -898,7 +898,7 @@
   <tt:Object ObjectId="22">
     <tt:Appearance>
       <tt:Shape>
-        <tt:BoundingBox left="20.0" top="30.0" right="100.0" bottom="80.0"/>
+        <tt:BoundingBox left="20.0" top="80.0" right="100.0" bottom="30.0"/>
         <tt:CenterOfGravity x="60.0" y="50.0"/>
       </tt:Shape>
       <tt:Class>


### PR DESCRIPTION
Top coordinates must be higher than bottom since origo is in lower
left corner.

Change-Id: I3a94f89a450313a1cff570c09cd06e94963e095e