### PR TITLE
Correct illegal attribute syntax in examples

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -2420,7 +2420,7 @@
             </listitem>
           </itemizedlist>
           <para>The following code snipped shows the options returned by GetAnalyticsModuleOptions for myModule:</para>
-          <programlisting><![CDATA[<tan:Options AnalyticsModule ="nn:myModule" Name="Mode">
+          <programlisting><![CDATA[<tan:Options AnalyticsModule="nn:myModule" Name="Mode">
   <tt:StringItems>
     <tt:Item>Motion Detection</tt:Item>
     <tt:Item>Object Tracking</tt:Item>
@@ -2429,20 +2429,20 @@
 <tan:Options AnalyticsModule="nn:myModule" Name="Targets">
   <tt:StringList>Car Bike Pedestrian</tt:StringList>
 </tan:Options>
-<tan:Options AnalyticsModule ="nn:myModule" Name="Speed">
+<tan:Options AnalyticsModule="nn:myModule" Name="Speed">
   <tt:IntRange>
     <tt:Min>0</tt:Min>
     <tt:Max>120</tt:Max>
   </tt:IntRange >
 </tan:Options>
-<tan:Options AnalyticsModule ="nn:myModule" Name="Latency">
+<tan:Options AnalyticsModule="nn:myModule" Name="Latency">
   <tt:DurationRange>
     <tt:Min>PT1S</tt:Min>
     <tt:Max>PT1M</tt:Max>
   </tt:DurationRange>
 </tan:Options>]]></programlisting>
           <para>A device only supporting three concrete values for the speed parameter may instead return for the respective option:</para>
-          <programlisting><![CDATA[<tan:Options AnalyticsModule ="nn:myModule" Name="Speed">
+          <programlisting><![CDATA[<tan:Options AnalyticsModule="nn:myModule" Name="Speed">
   <tt:IntList>15 30 80</tt:IntList>
 </tan:Options>]]></programlisting>
         </section>
@@ -5946,13 +5946,13 @@
       <tt:SimpleItemDescription Name=”RuleName” Type=”xs:string”/>
     </tt:Source>
     <tt:Data>
-      <tt:SimpleItemDescription Name ="Likelihood" Type="xs:float"/>
-      <tt:SimpleItemDescription Name ="Label" Type="xs:string "/>
-      <tt:SimpleItemDescription Name ="ImageUri" Type="xs:anyURI"/>
+      <tt:SimpleItemDescription Name="Likelihood" Type="xs:float"/>
+      <tt:SimpleItemDescription Name="Label" Type="xs:string "/>
+      <tt:SimpleItemDescription Name="ImageUri" Type="xs:anyURI"/>
       <tt:SimpleItemDescription Name="EnrollmentID" Type="xs:string"/>
-      <tt:SimpleItemDescription Name ="RefImageUri" Type="xs:anyURI"/>
-      <tt:ElementItemDescription Name ="Image" Type="xs:base64Binary"/>
-      <tt:ElementItemDescription Name ="BoundingBox" Type="tt:Rectangle"/>
+      <tt:SimpleItemDescription Name="RefImageUri" Type="xs:anyURI"/>
+      <tt:ElementItemDescription Name="Image" Type="xs:base64Binary"/>
+      <tt:ElementItemDescription Name="BoundingBox" Type="tt:Rectangle"/>
     </tt:Data>
     <tt:ParentTopic>
       tns1:RuleEngine/Recognition/Face


### PR DESCRIPTION
Remove space in front of equals character.

Change-Id: Ie852d20aa52f783660e3d03479e2b7c88563aa5a