### PR TITLE
fix for ItemListDescription order and namespaces

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -4309,10 +4309,10 @@
       <tt:SimpleItemDescription Name="VideoAnalyticsConfigurationToken" Type="tt:ReferenceToken"/>
       <tt:SimpleItemDescription Name="AnalyticsModuleName" Type="xs:string"/>
     </tt:Source>
-    <xs:Data>
-      <xs:ElementItemDescription Name="Reading" Type="ttr:SpotTemperatureReading"/>
+    <tt:Data>
       <tt:SimpleItemDescription Name="TimeStamp" Type="xs:dateTime"/>
-    </xs:Data>
+      <tt:ElementItemDescription Name="Reading" Type="ttr:SpotTemperatureReading"/>
+    </tt:Data>
     <tt:ParentTopic>
       tns1:VideoAnalytics/Radiometry/SpotTemperatureReading
     </tt:ParentTopic>
@@ -4444,10 +4444,10 @@
       <tt:SimpleItemDescription Name="VideoAnalyticsConfigurationToken" Type="tt:ReferenceToken"/>
       <tt:SimpleItemDescription Name="AnalyticsModuleName" Type="xs:string"/>
     </tt:Source>
-    <xs:Data>
-      <xs:ElementItemDescription Name="Reading" Type="ttr:BoxTemperatureReading"/>
+    <tt:Data>
       <tt:SimpleItemDescription Name="TimeStamp" Type="xs:dateTime"/>
-    </xs:Data>
+      <tt:ElementItemDescription Name="Reading" Type="ttr:BoxTemperatureReading"/>
+    </tt:Data>
     <tt:ParentTopic>
       tns1:VideoAnalytics/Radiometry/BoxTemperatureReading
     </tt:ParentTopic>


### PR DESCRIPTION
In Analytics Specs Annex D1.1 "Spot Measurement Module" and D1.2 "Box Measurement Module" there is a wrong example:
The order inside the Data element is not correct:
1st shall be SimpleItemDescription
2nd hall be ElementItemDescription

This sequence is required by onvif schema. Please, find <xs:complexType name="ItemListDescription"> in onvif.xsd for details.
Besides, the namespace should be tt: for Data and for ElementItemDescription, not xs.