### PR TITLE
Export annex b

### DIFF
--- a/doc/ExportFileFormat.xml
+++ b/doc/ExportFileFormat.xml
@@ -105,30 +105,16 @@ Add suep version 1 and Annex B</revremark>
     <title>Terms and Definitions</title>
     <section>
       <title>Definitions</title>
-      <informaltable>
-        <tgroup cols="2">
-          <colspec colname="c1" colwidth="24*" />
-          <colspec colname="c2" colwidth="76*" />
-          <tbody valign="top">
-            <row>
-              <entry align="left">
-                <para>Certificate </para>
-              </entry>
-              <entry align="left">
-                <para>A certificate as used in this specification binds a public key to a subject entity. The certificate is digitally signed by the certificate issuer to allow for verifying its authenticity </para>
-              </entry>
-            </row>
-            <row>
-              <entry align="left">
-                <para>Signature</para>
-              </entry>
-              <entry align="left">
-                <para>A digital signature or digital signature scheme is a mathematical scheme for demonstrating the authenticity of a digital message or document.</para>
-              </entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </informaltable>
+      <variablelist>
+        <varlistentry>
+          <term>Certificate</term>
+          <listitem><para>A certificate as used in this specification binds a public key to a subject entity. The certificate is digitally signed by the certificate issuer to allow for verifying its authenticity </para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Signature</term>
+          <listitem><para>A digital signature or digital signature scheme is a mathematical scheme for demonstrating the authenticity of a digital message or document.</para></listitem>
+        </varlistentry>
+      </variablelist>
     </section>
     <section>
       <title>Abbreviations</title>

--- a/doc/docbook.xsl
+++ b/doc/docbook.xsl
@@ -20,13 +20,16 @@ text-align: left;
 padding: 30mm 30mm 30mm 30mm; 
 }
 div {
-margin-top: 5mm;
+margin-bottom: 5mm;
 }
 li {
 margin-top: 2.5mm;
 }
 pre {
 font-size:9pt;
+}
+td {
+vertical-align: top
 }
 .heading {
 font-size:20pt;
@@ -47,6 +50,7 @@ font-size:14pt;
 font-weight: bold;
 margin-left: 15mm;
 margin-top: 1.5mm;
+margin-bottom: 1mm;
 }
 .text {
 margin-left: 15mm;
@@ -62,6 +66,7 @@ text-align: center;
 }
 .op {
 text-transform: uppercase;
+margin-bottom: 0mm;
 }
 .table {
 text-align: center;

--- a/doc/docbook.xsl
+++ b/doc/docbook.xsl
@@ -229,6 +229,18 @@ padding: 1mm 3mm 1mm 3mm;
     <xsl:template match="db:para" mode="plain">
         <xsl:apply-templates/>
     </xsl:template>
+
+    <xsl:template match="db:superscript">
+		<sup>
+			<xsl:apply-templates/>
+		</sup>
+    </xsl:template>
+    
+    <xsl:template match="db:emphasis[@role=bold]">
+		<b>
+			<xsl:apply-templates/>
+		</b>
+    </xsl:template>
     
     <xsl:template match="@* | node()">
         <xsl:copy>
@@ -266,7 +278,7 @@ padding: 1mm 3mm 1mm 3mm;
  
     <xsl:template match="db:programlisting">
         <pre>
-            <xsl:value-of select="."/>
+            <xsl:apply-templates/>
         </pre>
     </xsl:template>
  


### PR DESCRIPTION
When looking at Annex B of the Export File Format I realized that neither bold nor superscripts where rendered correctly in html. Additionally I spotted that the definitions were neither bold nor correctly aligned in vertical direction. 

This pull request doesn't contain any textual changes.