### PR TITLE
Deprecate GetWsdlUrl.

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -2577,8 +2577,8 @@ onvif://www.onvif.org/name/ARV-453
     <section>
       <title>Capabilities</title>
       <section>
-        <title>Get WSDL URL</title>
-        <para>It is possible for an endpoint to request a URL that can be used to retrieve the <emphasis>complete</emphasis> schema and WSDL definitions of a device. The command gives in return a URL entry point where all the necessary product specific WSDL and schema definitions can be retrieved. The device shall provide a URL for WSDL and schema download through the GetWsdlUrl command.</para>
+        <title>GetWsdlUrl</title>
+        <para>This method allows to provied an URL where product specific WSDL and schema definitions can be retrieved. This method has been deprecated with version 20.12.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>
@@ -2590,8 +2590,7 @@ onvif://www.onvif.org/name/ARV-453
             <term>response</term>
             <listitem>
               <para role="param">WsdlUrl [xs:anyURI]</para>
-              <para role="text">The requested URL.
-</para>
+              <para role="text">The requested URL.</para>
             </listitem>
           </varlistentry>
           <varlistentry>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -2578,7 +2578,7 @@ onvif://www.onvif.org/name/ARV-453
       <title>Capabilities</title>
       <section>
         <title>GetWsdlUrl</title>
-        <para>This method allows to provied an URL where product specific WSDL and schema definitions can be retrieved. This method has been deprecated with version 20.12.</para>
+        <para>This method allows to provide a URL where product specific WSDL and schema definitions can be retrieved. This method has been deprecated with version 20.12.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -2887,10 +2887,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<wsdl:output message="tds:SetUserResponse"/>
 		</wsdl:operation>
 		<wsdl:operation name="GetWsdlUrl">
-			<wsdl:documentation>It is possible for an endpoint to request a URL that can be used to retrieve the complete
-				schema and WSDL definitions of a device. The command gives in return a URL entry point
-				where all the necessary product specific WSDL and schema definitions can be retrieved. The
-				device shall provide a URL for WSDL and schema download through the GetWsdlUrl command.</wsdl:documentation>
+			<wsdl:documentation>This method allows to provied an URL where product specific WSDL and schema definitions can be retrieved. This method is deprecated.</wsdl:documentation>
 			<wsdl:input message="tds:GetWsdlUrlRequest"/>
 			<wsdl:output message="tds:GetWsdlUrlResponse"/>
 		</wsdl:operation>

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -2887,7 +2887,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<wsdl:output message="tds:SetUserResponse"/>
 		</wsdl:operation>
 		<wsdl:operation name="GetWsdlUrl">
-			<wsdl:documentation>This method allows to provied an URL where product specific WSDL and schema definitions can be retrieved. This method is deprecated.</wsdl:documentation>
+			<wsdl:documentation>This method allows to provide a URL where product specific WSDL and schema definitions can be retrieved. This method is deprecated.</wsdl:documentation>
 			<wsdl:input message="tds:GetWsdlUrlRequest"/>
 			<wsdl:output message="tds:GetWsdlUrlResponse"/>
 		</wsdl:operation>


### PR DESCRIPTION
In conjunction with Profile-M the method GetWsdlUrl doesn't make much sense.

The method is mandatory for older profiles. The requirements stated that it should return the wsdl and schema locations although the method is only capable to return a single url. The WG concluded that the method should be deprecated and testing should be removed from the DTT. 

Since there is no consistent automated way to use the method there shouldn't be any backward compatibility issues.