### PR TITLE
Add capability to signal no support for discovery.

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -2382,14 +2382,15 @@ DATE: when response was generated
     <title>Device discovery</title>
     <section>
       <title>General</title>
-      <para>A client searches for available devices using the dynamic Web Services discovery protocol [WS-Discovery].</para>
-      <para>A device compliant with this specification shall implement the Target Service role as specified in [WS-Discovery].</para>
-      <para>If necessary a client compliant with this specification shall implement the Client role as specified in [WS-Discovery].</para>
+      <para>A client may search for available devices using the dynamic Web Services discovery
+        protocol [WS-Discovery].</para>
+      <para>A device compliant with this specification shall implement the Target Service role as
+        specified in [WS-Discovery] unless it signals DiscoveryNotSupported via its capabilities.</para>
       <para> [WS-Discovery] describes the Universally Unique Identifier (UUID): URI format recommendation for endpoint references in Section 2.6, but this specification overrides this recommendation. Instead, the Uniform Resource Name: Universally Unique Identifier (URN:UUID) format is used [RFC4122] (see Section <xref linkend="_Ref204503939" />).</para>
     </section>
     <section xml:id="_Toc204774611">
       <title>Modes of operation</title>
-      <para>The device shall be able to operate in <emphasis>two </emphasis>modes:</para>
+      <para>A device supporting discovery shall be able to operate in two modes:</para>
       <itemizedlist>
         <listitem>
           <para>Discoverable</para>
@@ -2784,7 +2785,7 @@ onvif://www.onvif.org/name/ARV-453
                   </entry>
                 </row>
                 <row>
-                  <entry morerows="15">
+                  <entry morerows="16">
                     <para>System</para>
                   </entry>
                   <entry>
@@ -2801,6 +2802,10 @@ onvif://www.onvif.org/name/ARV-453
                   <entry>
                     <para>Indication if the device sends bye messages as described in Section <xref linkend="_Toc204774618" /></para>
                   </entry>
+                </row>
+                <row>
+                  <entry>DiscoveryNotSupported</entry>
+                  <entry>Indicates that the device does not support network discovery.</entry>
                 </row>
                 <row>
                   <entry>
@@ -4873,7 +4878,10 @@ onvif://www.onvif.org/name/ARV-453
       </section>
       <section xml:id="_Toc213907675">
         <title>SetDiscoveryMode</title>
-        <para>This operation sets the discovery mode operation of a device. See Section <xref linkend="_Toc204774611" /> for the definition of the different device discovery modes. The device shall support configuration of the discovery mode setting through the SetDiscoveryMode command.</para>
+        <para>This operation sets the discovery mode operation of a device. See Section <xref
+            linkend="_Toc204774611"/> for the definition of the different device discovery modes. A
+          device shall support configuration of the discovery mode setting through the
+          SetDiscoveryMode command unless it signals DiscoveryNotSupported via its capabilities.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -334,6 +334,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:documentation>Enumerates the supported StorageTypes, see tds:StorageType.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
+				<xs:attribute name="DiscoveryNotSupported" type="xs:boolean">
+					<xs:annotation>
+						<xs:documentation>Indicates no support for network discovery.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:attribute name="NetworkConfigNotSupported" type="xs:boolean">
 					<xs:annotation>
 						<xs:documentation>Indicates no support for network configuration.</xs:documentation>


### PR DESCRIPTION
As discussed in relationship with Profile M the core spec needs a mechanism to not signal support for discovery.