### PR TITLE
Use enumerations for AudioClassType restriction values

### DIFF
--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -8385,7 +8385,12 @@ and sample rate. </xs:documentation>
 		   gun_shot, scream, glass_breaking, tire_screech   
 		</xs:documentation>
 		</xs:annotation>
-	<xs:restriction base="xs:string"/>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="gun_shot"/>
+			<xs:enumeration value="scream"/>
+			<xs:enumeration value="glass_breaking"/>
+			<xs:enumeration value="tire_screech"/>
+		</xs:restriction>
 	</xs:simpleType>
 
 	<xs:complexType name="AudioClassCandidate">


### PR DESCRIPTION
## Proposal

As requested in #72, this PR changes `AudioClassType` to use explicit enumerators rather than relying on documentation to indicate valid values.

## Reason

To allow code generators to know the valid values for `AudioClassType`.

## Compatibility Analysis

I'm not sure. The same values are allowed, but they are now enforced by the schema.

## Open Questions

  * Should the documentation/annotation of `AudioClassType` be removed since it is now redundant and explicit in the schema?
  * Is it OK to fix the indentation like this?

Closes #72