### PR TITLE
Replace text with xref in links to 5.2.3 section

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -6076,7 +6076,7 @@
           </tbody>
         </tgroup>
       </table>
-      <para>Options for the rule parameters are described by the generic mechanism defined in section 5.2.3.</para>
+      <para>Options for the rule parameters are described by the generic mechanism defined in section <xref linkend="_Ref9001629" />.</para>
       <table xml:id="OR_Gen_fields">
         <title>Generic recognition event fields</title>
         <tgroup cols="3">
@@ -6341,7 +6341,7 @@
           </tbody>
         </tgroup>
       </table>
-      <para>Options for the rule parameters are described by the generic mechanism defined in section 5.2.3.</para>
+      <para>Options for the rule parameters are described by the generic mechanism defined in section <xref linkend="_Ref9001629" />.</para>
       <para>The License Plate Recognition event consists of the generic event fields from <xref linkend="OR_Gen_fields"/> as well as the specific event fields listed in <xref linkend="OR_LPR_fields"/>.</para>
       <table xml:id="OR_LPR_fields">
         <title>License Plate Recognition event fields</title>


### PR DESCRIPTION
Some places with links to 5.2.3 section in Analytic service spec are designed as a text instead of <xref linkend="_Ref9001629" />.