### PR TITLE
Fix order of parameter items in tt:LineCounting

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -3484,12 +3484,12 @@
       </variablelist>
       <para>CountAggregation defined by the following code using the rule description language: </para>
       <programlisting><![CDATA[<tt:RuleDescription Name="tt:LineCounting">
-  <tt:Parameters>
-    <tt:ElementItemDescription Name="Segments" Type="tt:Polyline"/>
+  <tt:Parameters>    
     <tt:SimpleItemDescription Name="ReportTimeInterval" Type="xs:duration"/>
     <tt:SimpleItemDescription Name="ResetTime" Type="xs:time"/>
     <tt:SimpleItemDescription Name="Direction" Type="tt:Direction"/>
     <tt:SimpleItemDescription Name="PassAllPolylines" Type="xs:boolean"/>
+    <tt:ElementItemDescription Name="Segments" Type="tt:Polyline"/>
   </tt:Parameters>
   <tt:Messages IsProperty="true">
     <tt:Source>


### PR DESCRIPTION
Description of tt:LineCounting has invalid order of items inside Parameters.
ElementItemDescription shall follow after all SimpleItemDescription according to xml schema of ItemListDescription type.