### PR TITLE
Fix maxOccurrs to maxOccurs typo

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -2406,7 +2406,7 @@
         <section>
           <title>Occurrence</title>
           <para>Configuration parameters may signal their allowed minimal occurrence using the minOccurs attribute. Setting the value to zero signals that the parameter is optional.</para>
-          <para>The maxOccurrs attribute allows to specify how often an element may occur in the
+          <para>The maxOccurs attribute allows to specify how often an element may occur in the
             same instance of a rule or module. </para>
         </section>
         <section>


### PR DESCRIPTION
Occurrence section has typo: maxOccurrs (double 'r')