### PR TITLE
clarified Videosource field as video source configuration token

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -3165,7 +3165,7 @@
             <term>Source</term>
             <listitem>
               <para role="param">VideoSource [tt:ReferenceToken]</para>
-              <para role="text">The token of the video source.</para>
+              <para role="text">The token of the video source configuration.</para>
               <para role="param">AnalyticsConfiguration - optional [tt:ReferenceToken]</para>
               <para role="text">Optional token of the analytics configuration.</para>
               <para role="param">Rule [xs:string]</para>
@@ -3911,19 +3911,21 @@
     <title>Motion detection (normative)</title>
     <section>
       <title>Motion region detector</title>
-      <para>The region motion detector detects any motion against the specified motion region. The rule is configured for an area (region of interest on the image source) which can be armed or disarmed. The region shall be defined by a Polygon structure. Although this rule is defined within the context of the analytics service, it is intended to allow configuration of hardware motion detection as opposed to motion detection from scene description data. For a description of the parameters see <xref linkend="_Ref522789617" />.</para>
+      <para>The region motion detector detects any motion against the specified motion region. The rule is configured for an area (region of interest on the image source) which can be armed or disarmed. The region shall be defined by a Polygon structure. "VideoSource" in the Source of Messages refer to VideoSourceConfiguration token. Although this rule is defined within the context of the analytics service, it is intended to allow configuration of hardware motion detection as opposed to motion detection from scene description data. For a description of the parameters see <xref linkend="_Ref522789617" />.</para>
       <programlisting><![CDATA[<tt:RuleDescription Name="tt:MotionRegionDetector">
-  <tt:Parameters>     <tt:ElementItemDescription Name="MotionRegion" Type="axt:MotionRegionConfig"/>
-</tt:Parameters>
-<tt:Messages IsProperty="true">
-  <tt:Source>
-    <tt:SimpleItemDescription Name="VideoSource" Type="tt:ReferenceToken"/>
-    <tt:SimpleItemDescription Name="RuleName" Type="xs:string"/>
-  </tt:Source>
-  <tt:Key/>
-  <tt:Data>
-    <tt:SimpleItemDescription	Name="State" Type="xs:boolean"/>
-  </tt:Data>     <tt:ParentTopic>tns1:RuleEngine/MotionRegionDetector/Motion</tt:ParentTopic>
+  <tt:Parameters>
+    <tt:ElementItemDescription Name="MotionRegion" Type="axt:MotionRegionConfig"/>
+  </tt:Parameters>
+  <tt:Messages IsProperty="true">
+    <tt:Source>
+      <tt:SimpleItemDescription Name="VideoSource" Type="tt:ReferenceToken"/>
+      <tt:SimpleItemDescription Name="RuleName" Type="xs:string"/>
+    </tt:Source>
+    <tt:Key/>
+    <tt:Data>
+      <tt:SimpleItemDescription	Name="State" Type="xs:boolean"/>
+    </tt:Data>
+    <tt:ParentTopic>tns1:RuleEngine/MotionRegionDetector/Motion</tt:ParentTopic>
 </tt:Messages>
 </tt:RuleDescription>
 ]]></programlisting>


### PR DESCRIPTION
1) Clarified Section A.1.1 VideoSource as Video source configuaration token
2) Clarified VideoSource in MotionRegionDetector as Video source configuaration token
3) Fixed a formatting error (text goes beyond page limits) for XML sample of MotionRegionDetector  Rule description