### PR TITLE
Add PasswordPolicySupported capability

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -2914,7 +2914,7 @@ onvif://www.onvif.org/name/ARV-453
                   <entry>Indicates no support for user configuration.</entry>
                 </row>
                 <row>
-                  <entry morerows="13">
+                  <entry morerows="14">
                     <para>Security</para>
                   </entry>
                   <entry>
@@ -3026,6 +3026,14 @@ onvif://www.onvif.org/name/ARV-453
                   </entry>
                   <entry>
                     <para>Maximum number of characters supported for the password by CreateUsers and SetUser.</para>
+                  </entry>
+                </row>
+                <row>
+                  <entry>
+                    <para>PasswordPolicySupported</para>
+                  </entry>
+                  <entry>
+                    <para>Indication if the device supports the password policy</para>
                   </entry>
                 </row>
                 <row>
@@ -5241,6 +5249,7 @@ onvif://www.onvif.org/name/ARV-453
         <title>Set users settings</title>
         <para>This operation updates the settings for one or several users on a device for authentication, see Sect. <xref linkend="_Ref208379139" /> for details. The device shall support update of device users and their credentials through the SetUser command.  A device shall support this command unless support signalled via the UserConfigNotSupported capability is ‘True’. Either all change requests are processed successfully or a fault message shall be returned and no change requests be processed.</para>
         <para>In case the optional password value is omitted the device will consider to clear the password. If the device can not accept the password of zero length, the fault message of "ter:PasswordTooWeak" will be returned.</para>
+        <para>If the device signals support for PasswordPolicySupported an authorized user shall be entitled to change his own password independently of the default access policy. In this case a device shall ignore the UserLevel field for any client not fulfilling access class WRITE_SYSTEM.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -3030,10 +3030,10 @@ onvif://www.onvif.org/name/ARV-453
                 </row>
                 <row>
                   <entry>
-                    <para>PasswordPolicySupported</para>
+                    <para>SecurityPolicies</para>
                   </entry>
                   <entry>
-                    <para>Indication if the device supports the password policy</para>
+                    <para>Indicates which security policies are supported. Options are: ModifyPassword, according to section <xref linkend="_Ref1614781086"/></para>
                   </entry>
                 </row>
                 <row>
@@ -5245,11 +5245,11 @@ onvif://www.onvif.org/name/ARV-453
           </varlistentry>
         </variablelist>
       </section>
-      <section>
+      <section xml:id="_Ref1614781086">
         <title>Set users settings</title>
         <para>This operation updates the settings for one or several users on a device for authentication, see Sect. <xref linkend="_Ref208379139" /> for details. The device shall support update of device users and their credentials through the SetUser command.  A device shall support this command unless support signalled via the UserConfigNotSupported capability is ‘True’. Either all change requests are processed successfully or a fault message shall be returned and no change requests be processed.</para>
         <para>In case the optional password value is omitted the device will consider to clear the password. If the device can not accept the password of zero length, the fault message of "ter:PasswordTooWeak" will be returned.</para>
-        <para>If the device signals support for PasswordPolicySupported an authorized user shall be entitled to change his own password independently of the default access policy. In this case a device shall ignore the UserLevel field for any client not fulfilling access class WRITE_SYSTEM.</para>
+        <para>If the device signals support for "ModifyPassword" in the SecurityPolicies capability, an authorized user shall be entitled to change his own password independently of the default access policy. In this case a device shall ignore the UserLevel field for any client not fulfilling access class WRITE_SYSTEM.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -252,9 +252,9 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:documentation>Maximum number of characters supported for the password by CreateUsers and SetUser.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
-				<xs:attribute name="PasswordPolicySupported" type="xs:boolean">
+				<xs:attribute name="SecurityPolicies" type="tt:StringList">
 					<xs:annotation>
-						<xs:documentation>Indication if the device supports the password policy.</xs:documentation>
+                    				<xs:documentation>Indicates which security policies are supported. Options are: ModifyPassword (to be extended with: PasswordComplexity, PasswordHistory, AuthFailureWarning)</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -252,6 +252,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:documentation>Maximum number of characters supported for the password by CreateUsers and SetUser.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
+				<xs:attribute name="PasswordPolicySupported" type="xs:boolean">
+					<xs:annotation>
+						<xs:documentation>Indication if the device supports the password policy.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:complexType>
 			<!--===============================-->


### PR DESCRIPTION
Modifications to SetUser to allow an user without privileges to modify its own password
The introduction of the PasswordPolicySupported capability it is also needed.