### PR TITLE
Add RGB and mark deprecated color spaces

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -815,7 +815,7 @@
         <section xml:id="_Toc214944464">
           <title>Colour descriptor</title>
           <para>A colour descriptor is defined as an optional element of the appearance node of an object node. The colour descriptor is defined by a list of colour clusters, each consisting of a colour value, an optional weight and an optional covariance matrix. The colour descriptor does not specify, how the colour clusters are created. They can represent bins of a colour histogram or the result of a clustering algorithm.</para>
-          <para>Colours are represented by three-dimensional vectors. Additionally, the colourspace of each colour vector can be specified by a colourspace attribute. If the colourspace attribute is missing, the YcbCr colourspace is assumed. It refers to the 'sRGB' gamut with the RGB to YcbCr transformation as of ISO/IEC 10918-1 (Information technology -- Digital compression and coding of continuous-tone still images: Requirements and guidelines), a.k.a. JPEG. The Colourspace URI for the YcbCr colourspace is <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.onvif.org/ver10/colorspace/YCbCr"/>.</para>
+          <para>Colours are represented by three-dimensional vectors. Additionally, the colourspace of each colour vector can be specified by a Colorspace attribute. If the Colorspace attribute is missing, the YCbCr colourspace is assumed. It refers to the 'sRGB' gamut with the RGB to YcbCr transformation as of ISO/IEC 10918-1 (Information technology -- Digital compression and coding of continuous-tone still images: Requirements and guidelines), a.k.a. JPEG. The Colourspace URI for the YCbCr colourspace is <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.onvif.org/ver10/colorspace/YCbCr"/>.</para>
           <para>An example metadata containing colour information of the detected object is given below.  </para>
           <programlisting><![CDATA[<tt:Frame UtcTime="2010-09-10T12:24:57.721">
   <tt:Transformation>
@@ -844,7 +844,7 @@
   </tt:Object>
 </tt:Frame>
 ]]></programlisting>
-          <para>Colour descriptor contains the representative colours in detected object/region. The representative colours are computed from image of detected object/region each time. Each representative colour value is a vector of specified colour space. The representative colour weight (Weight) denotes the fraction of pixels assigned to the representative colour. Colour covariance describes the variation of colour values around the representative colour value in colour space thus representative colour denotes a region in colour space. The following table lists the acceptable values for Colourspace attribute</para>
+          <para>Colour descriptor contains the representative colours in detected object/region. The representative colours are computed from image of detected object/region each time. Each representative colour value is a vector of specified colour space. The representative colour weight (Weight) denotes the fraction of pixels assigned to the representative colour. Colour covariance describes the variation of colour values around the representative colour value in colour space thus representative colour denotes a region in colour space. The following table lists the acceptable values for Colorspace attribute.</para>
           <table>
             <title>Colourspace namespace values</title>
             <tgroup cols="2">
@@ -863,37 +863,45 @@
               <tbody valign="top">
                 <row>
                   <entry>
-                    <para>http://www.onvif.org/ver10/colorspace/YcbCr</para>
+                    <para>http://www.onvif.org/ver10/colorspace/YCbCr</para>
                   </entry>
                   <entry>
-                    <para>YcbCr colourspace</para>
+                    <para>YCbCr colourspace</para>
                   </entry>
                 </row>
                 <row>
                   <entry>
-                    <para>http://www.onvif.org/ver10/colorspace/CIELUV</para>
+                    <para>http://www.onvif.org/ver10/colorspace/RGB</para>
                   </entry>
                   <entry>
-                    <para>CIE LUV</para>
+                    <para>RGB colourspace</para>
                   </entry>
                 </row>
                 <row>
                   <entry>
-                    <para>http://www.onvif.org/ver10/colorspace/CIELAB</para>
+                   <para>http://www.onvif.org/ver10/colorspace/CIELUV</para>
                   </entry>
                   <entry>
-                    <para>CIE 1976 (L*a*b*)</para>
+                   <para><emphasis role="bold">Deprecated</emphasis> CIE LUV</para>
+                 </entry>
+               </row>
+               <row>
+                 <entry>
+                   <para>http://www.onvif.org/ver10/colorspace/CIELAB</para>
+                 </entry>
+                 <entry>
+                   <para><emphasis role="bold">Deprecated</emphasis> CIE 1976 (L*a*b*)</para>
+                 </entry>
+               </row>
+               <row>
+                 <entry>
+                   <para>http://www.onvif.org/ver10/colorspace/HSV</para>
+                 </entry>
+                 <entry>
+                   <para><emphasis role="bold">Deprecated</emphasis> HSV colourspace</para>
                   </entry>
                 </row>
-                <row>
-                  <entry>
-                    <para>http://www.onvif.org/ver10/colorspace/HSV</para>
-                  </entry>
-                  <entry>
-                    <para>HSV colourspace</para>
-                  </entry>
-                </row>
-              </tbody>
+             </tbody>
             </tgroup>
           </table>
         </section>


### PR DESCRIPTION
The RGB color space is in the schema but not in the spec. Also certain color spaces are marked as deprecated in the schema but not in the spec. This PR synchronizes the spec with the schema.
