### PR TITLE
Clarify color weight

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -832,19 +832,19 @@
         <tt:ColorCluster>
           <tt:Color X=”58” Y=”105” Z=”212”/>
           <tt:Covariance XX=”7.2” YY=”6” ZZ=”3”/>
-          <tt:Weight>90</tt:Weight>
+          <tt:Weight>0.5</tt:Weight>
         </tt:ColorCluster>
         <tt:ColorCluster>
           <tt:Color X=”165” Y=”44” Z=”139”/>
           <tt:Covariance XX=”4” YY=”4” ZZ=”4”/>
-          <tt:Weight>5</tt:Weight>
+          <tt:Weight>0.3</tt:Weight>
         </tt:ColorCluster>
       </tt:Color>
     </tt:Appearance>
   </tt:Object>
 </tt:Frame>
 ]]></programlisting>
-          <para>Colour descriptor contains the representative colours in detected object/region. The representative colours are computed from image of detected object/region each time. Each representative colour value is a vector of specified colour space. The representative colour weight (Weight) denotes the fraction of pixels assigned to the representative colour. Colour covariance describes the variation of colour values around the representative colour value in colour space thus representative colour denotes a region in colour space. The following table lists the acceptable values for Colourspace attribute</para>
+          <para>Colour descriptor contains the representative colours in detected object/region. The representative colours are computed from image of detected object/region each time. Each representative colour value is a vector of specified colour space. The representative color weight (Weight) denotes the fraction of pixels assigned to the representative color in the range [0 .. 1]. Colour covariance describes the variation of colour values around the representative colour value in colour space thus representative colour denotes a region in colour space. The following table lists the acceptable values for Colourspace attribute</para>
           <table>
             <title>Colourspace namespace values</title>
             <tgroup cols="2">


### PR DESCRIPTION
The sum of all ColorCluster weights in a ColorDescriptor shall not exceed 100.

Fixes #122.