### PR TITLE
MaxPasswordHistoryLength

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -3068,7 +3068,7 @@ onvif://www.onvif.org/name/ARV-453
                     <para>MaxPasswordHistoryLength</para>
                   </entry>
                   <entry>
-                    <para>Maximum length of the password history. If the device does not support the password history this attribute should be zero or not present</para>
+                    <para>Maximum number of passwords that the device can remember for each user. If the device does not support the password history this attribute should be zero or not present</para>
                   </entry>
                 </row>
                 <row>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -2941,7 +2941,7 @@ onvif://www.onvif.org/name/ARV-453
                   <entry>Indicates no support for user configuration.</entry>
                 </row>
                 <row>
-                  <entry morerows="14">
+                  <entry morerows="15">
                     <para>Security</para>
                   </entry>
                   <entry>
@@ -3060,7 +3060,15 @@ onvif://www.onvif.org/name/ARV-453
                     <para>SecurityPolicies</para>
                   </entry>
                   <entry>
-                    <para>Indicates which security policies are supported. As described in section <xref linkend="_Ref1614781086"/> and <xref linkend="_Ref1614781087"/>, options are: ModifyPassword, PasswordComplexity, PasswordHistory, AuthFailureWarnings</para>
+                    <para>Indicates which security policies are supported. As described in section <xref linkend="_Ref1614781086"/> and <xref linkend="_Ref1614781087"/>, options are: ModifyPassword, PasswordComplexity, AuthFailureWarnings</para>
+                  </entry>
+                </row>
+                <row>
+                  <entry>
+                    <para>MaxPasswordHistoryLength</para>
+                  </entry>
+                  <entry>
+                    <para>Maximum length of the password history. If the device does not support the password history this attribute should be zero or not present</para>
                   </entry>
                 </row>
                 <row>
@@ -5606,7 +5614,7 @@ onvif://www.onvif.org/name/ARV-453
         
       <section>
         <title>GetPasswordHistoryConfiguration</title>
-        <para>If a device signals support for "PasswordHistory" in the SecurityPolicies capability, it shall support this operation to get the current password history settings.</para>
+        <para>If the capability MaxPasswordHistoryLength is signaled and is greater than zero, the device shall support this operation to get the current password history settings.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>
@@ -5622,7 +5630,7 @@ onvif://www.onvif.org/name/ARV-453
             </listitem>
             <listitem>
               <para role="param">Length [xs:integer]</para>
-              <para role="text">The length of the password history, [1, MaxPasswordHistoryLen]</para>
+              <para role="text">The length of the password history, [1, MaxPasswordHistoryLength]</para>
             </listitem>
           </varlistentry>
           <varlistentry>
@@ -5642,7 +5650,7 @@ onvif://www.onvif.org/name/ARV-453
       
       <section>
         <title>SetPasswordHistoryConfiguration</title>
-        <para>If a device signals support for "PasswordHistory" in the SecurityPolicies capability, it shall support this operation to set the password history configuration.</para>
+        <para>If the capability MaxPasswordHistoryLength is signaled and is greater than zero, the device shall support this operation to set the password history configuration.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>
@@ -5652,7 +5660,7 @@ onvif://www.onvif.org/name/ARV-453
             </listitem>
             <listitem>
               <para role="param">Length [xs:integer]</para>
-              <para role="text">The length of the password history, [1, MaxPasswordHistoryLen]</para>
+              <para role="text">The length of the password history, [1, MaxPasswordHistoryLength]</para>
             </listitem>
           </varlistentry>
           <varlistentry>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -3065,7 +3065,7 @@ onvif://www.onvif.org/name/ARV-453
                 </row>
                 <row>
                   <entry>
-                    <para>MaxPasswordHistoryLength</para>
+                    <para>MaxPasswordHistory</para>
                   </entry>
                   <entry>
                     <para>Maximum number of passwords that the device can remember for each user. If the device does not support the password history this attribute should be zero or not present</para>
@@ -5614,7 +5614,7 @@ onvif://www.onvif.org/name/ARV-453
         
       <section>
         <title>GetPasswordHistoryConfiguration</title>
-        <para>If the capability MaxPasswordHistoryLength is signaled and is greater than zero, the device shall support this operation to get the current password history settings.</para>
+        <para>If the capability MaxPasswordHistory is signaled and is greater than zero, the device shall support this operation to get the current password history settings.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>
@@ -5630,7 +5630,7 @@ onvif://www.onvif.org/name/ARV-453
             </listitem>
             <listitem>
               <para role="param">Length [xs:integer]</para>
-              <para role="text">The length of the password history, [1, MaxPasswordHistoryLength]</para>
+              <para role="text">The length of the password history, [1, MaxPasswordHistory]</para>
             </listitem>
           </varlistentry>
           <varlistentry>
@@ -5650,7 +5650,7 @@ onvif://www.onvif.org/name/ARV-453
       
       <section>
         <title>SetPasswordHistoryConfiguration</title>
-        <para>If the capability MaxPasswordHistoryLength is signaled and is greater than zero, the device shall support this operation to set the password history configuration.</para>
+        <para>If the capability MaxPasswordHistory is signaled and is greater than zero, the device shall support this operation to set the password history configuration.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>
@@ -5660,7 +5660,7 @@ onvif://www.onvif.org/name/ARV-453
             </listitem>
             <listitem>
               <para role="param">Length [xs:integer]</para>
-              <para role="text">The length of the password history, [1, MaxPasswordHistoryLength]</para>
+              <para role="text">The length of the password history, [1, MaxPasswordHistory]</para>
             </listitem>
           </varlistentry>
           <varlistentry>

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -257,7 +257,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
                     				<xs:documentation>Indicates which security policies are supported. Options are: ModifyPassword, PasswordComplexity, AuthFailureWarnings</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
-				<xs:attribute name="MaxPasswordHistoryLength" type="xs:int">
+				<xs:attribute name="MaxPasswordHistory" type="xs:int">
 					<xs:annotation>
                     				<xs:documentation>Maximum number of passwords that the device can remember for each user</xs:documentation>
 					</xs:annotation>

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="../../../ver20/util/onvif-wsdl-viewer.xsl"?>
 <!--
 Copyright (c) 2008-2021 by ONVIF: Open Network Video Interface Forum. All rights reserved.
@@ -254,7 +254,12 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:attribute>
 				<xs:attribute name="SecurityPolicies" type="tt:StringList">
 					<xs:annotation>
-                    				<xs:documentation>Indicates which security policies are supported. Options are: ModifyPassword, PasswordComplexity, PasswordHistory, AuthFailureWarnings</xs:documentation>
+                    				<xs:documentation>Indicates which security policies are supported. Options are: ModifyPassword, PasswordComplexity, AuthFailureWarnings</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="MaxPasswordHistoryLength" type="xs:int">
+					<xs:annotation>
+                    				<xs:documentation>Maximum length of the password history</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -259,7 +259,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:attribute>
 				<xs:attribute name="MaxPasswordHistoryLength" type="xs:int">
 					<xs:annotation>
-                    				<xs:documentation>Maximum length of the password history</xs:documentation>
+                    				<xs:documentation>Maximum number of passwords that the device can remember for each user</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>


### PR DESCRIPTION
During the plugfest we realized that there is no way to know what is the maximum password history length that can be stored in the device. So I propose to add this capability.