### PR TITLE
Fix inconsistencies between appmgmt schema and doc

### DIFF
--- a/doc/AppMgmt.xml
+++ b/doc/AppMgmt.xml
@@ -517,7 +517,7 @@
       </section>
     </section>
     <section>
-      <title>GetCapabilities</title>
+      <title>GetServiceCapabilities</title>
       <para>The capabilities reflect optional functions and functionality of a service. The information is static and does not change during device operation.</para>
       <variablelist role="op">
         <varlistentry>

--- a/wsdl/ver10/appmgmt/wsdl/appmgmt.wsdl
+++ b/wsdl/ver10/appmgmt/wsdl/appmgmt.wsdl
@@ -248,11 +248,6 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
                 <xs:sequence>
                     <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	 <!-- first Vendor then ONVIF -->
                 </xs:sequence>
-                <xs:attribute name="DeviceID" type="xs:string">
-                    <xs:annotation>
-                        <xs:documentation>Unique device identifier allowing to tie a license to a hardware device.</xs:documentation>
-                    </xs:annotation>
-                </xs:attribute>
                 <xs:attribute name="FormatsSupported" type="tt:StringAttrList">
                     <xs:annotation>
                         <xs:documentation>List of supported app container formats that can be uploaded via this service.</xs:documentation>


### PR DESCRIPTION
- Remove DeviceID cap from schema as there is GetDeviceId call now.
- GetCapabilities -> GetServiceCapabilities in doc.