### PR TITLE
Fix inconsistency in Security NoMatchingPrivateKey

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -1648,10 +1648,10 @@ Added certificate-based client authentication</revremark>
                   <para role="text"> The device does not have enough storage space to store the certificate to be uploaded.</para>
                   <para role="param">ter:Receiver - tas:Action - ter:MaximumNumberOfKeysReached</para>
                   <para role="text"> The device does not have enough storage space to store the key pair to be uploaded.</para>
+                  <para role="param">ter:Receiver - tas:Action - ter:NoMatchingPrivateKey </para>
+                  <para role="text">The keystore does not contain a key pair with a private key that matches the public key in the uploaded certificate.</para>
                   <para role="param">ter:Sender - tas:InvalidArgVal - ter:BadCertificate </para>
                   <para role="text">The supplied certificate file cannot be processed by the device.</para>
-                  <para role="param">ter:Sender - tas:InvalidArgVal - ter:NoMatchingPrivateKey </para>
-                  <para role="text">The keystore does not contain a key pair with a private key that matches the public key in the uploaded certificate.</para>
                   <para role="param">ter:Sender - tas:InvalidArgVal - ter:UnsupportedPublicKeyAlgorithm</para>
                   <para role="text"> The public key algorithm of the public key in the certificate is not supported by the device.</para>
                   <para role="param">ter:Sender - tas:InvalidArgVal - ter:UnsupportedSignatureAlgorithm</para>


### PR DESCRIPTION
Fix inconsistency in the Security Configuration Service
Specification for the NoMatchingPrivateKey fault such that
it is consistent with Figure _Ref338934863 and with the table
that lists the Security configuration service specific fault codes.

It can be considered to make the corresponding fault an
Sender error.