### PR TITLE
Fix for  #162: Remove obsolete exi default compression and replace .g…

### DIFF
--- a/doc/Streaming.xml
+++ b/doc/Streaming.xml
@@ -1157,10 +1157,7 @@ server-&gt;client:   RTSP/1.0 200 OK
                 <para>“vnd.onvif.metadata” for uncompressed</para>
               </listitem>
               <listitem>
-                <para>“vnd.onvif.metadata.gzip” for GZIP compressed</para>
-              </listitem>
-              <listitem>
-                <para>"vnd.onvif.metadata.exi.onvif" for EXI using ONVIF default compression parameters</para>
+                <para>“vnd.onvif.metadata+gzip” for GZIP compressed</para>
               </listitem>
               <listitem>
                 <para>"vnd.onvif.metadata.exi.ext" for EXI using compression parameters that are sent in-band</para>


### PR DESCRIPTION
…zip by +gzip to standardize IANA registration.