### PR TITLE
Compact color space definitions.

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -826,10 +826,25 @@
         </section>
         <section xml:id="_Toc214944464">
           <title>Color descriptor</title>
-          <para>A color descriptor is defined as an optional element of the appearance node of an object node. The color descriptor is defined by a list of color clusters, each consisting of a color value, an optional weight and an optional covariance matrix. The color descriptor does not specify, how the color clusters are created. They can represent bins of a color histogram or the result of a clustering algorithm.</para>
-          <para>Colors are represented by three-dimensional vectors. Additionally, the color space of each color vector can be specified by a Colorspace attribute. If the Colorspace attribute is missing, the YCbCr color space is assumed. It refers to the 'sRGB' gamut with the RGB to YcbCr transformation as of ISO/IEC 10918-1 (Information technology -- Digital compression and coding of continuous-tone still images: Requirements and guidelines), a.k.a. JPEG. The Colorspace URI for the YCbCr color space is <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.onvif.org/ver10/colorspace/YCbCr"/>.</para>
+          <para>The optional color descriptor allows to describe the representative colors of the
+            detected object or region. Each color is represented as vectors based on a color space.
+            Its weight denotes the fraction of pixels assigned to the representative color in the
+            range [0 .. 1]. Color covariance describes the variation of color values around the
+            representative color value in color space thus representative color denotes a region in
+            color space.</para>
+          <para>Nate that the color descriptor does not specify, how color clusters are created.
+            They can represent bins of a color histogram or the result of a clustering
+            algorithm.</para>
+          <para>The color space defaults to the YCbCr color space which refers to the 'sRGB' gamut
+            with the RGB to YcbCr transformation as of ISO/IEC 10918-1 (Information technology --
+            Digital compression and coding of continuous-tone still images: Requirements and
+            guidelines), a.k.a. JPEG. The Colorspace URI for the YCbCr color space is <link
+              xmlns:xlink="http://www.w3.org/1999/xlink"
+              xlink:href="http://www.onvif.org/ver10/colorspace/YCbCr"/>. Alternate color spaces as
+            defined in <xref linkend="_colorspaces"/> can be defined on frame level and individually 
+            for earch object.</para> 
           <para>An example metadata containing color information of the detected object is given below.  </para>
-          <programlisting><![CDATA[<tt:Frame UtcTime="2010-09-10T12:24:57.721">
+          <programlisting><![CDATA[<tt:Frame UtcTime="2010-09-10T12:24:57.721" Colorspace="RGB">
   <tt:Transformation>
     <tt:Translate x="-1.0" y="-1.0"/>
     <tt:Scale x="0.003125" y="0.00416667"/>
@@ -856,14 +871,16 @@
   </tt:Object>
 </tt:Frame>
 ]]></programlisting>
-          <para>Colour descriptor contains the representative colours in detected object/region. The representative colours are computed from image of detected object/region each time. Each representative colour value is a vector of specified colour space. The representative color weight (Weight) denotes the fraction of pixels assigned to the representative color in the range [0 .. 1]. Colour covariance describes the variation of colour values around the representative colour value in colour space thus representative colour denotes a region in colour space. The following table lists the acceptable values for Colourspace attribute</para>
-          <table>
+          <para>The following table lists the acceptable values for colorspace attribute</para>
+          <table xml:id="_colorspaces">
             <title>Colorspace namespace values</title>
-            <tgroup cols="2">
-              <colspec colname="c1" colwidth="60*" />
-              <colspec colname="c2" colwidth="40*" />
+            <tgroup cols="3">
+              <colspec colname="c1" colwidth="1*"/>
+              <colspec colname="newCol2" colwidth="4.19*"/>
+              <colspec colname="c2" colwidth="3.33*"/>
               <thead>
                 <row>
+                  <entry>Colorspace</entry>
                   <entry>
                     <para>Namespace URI</para>
                   </entry>
@@ -874,6 +891,7 @@
               </thead>
               <tbody valign="top">
                 <row>
+                  <entry><para>YCbCr</para></entry>
                   <entry>
                     <para>http://www.onvif.org/ver10/colorspace/YCbCr</para>
                   </entry>
@@ -882,6 +900,7 @@
                   </entry>
                 </row>
                 <row>
+                  <entry><para>RGB</para></entry>
                   <entry>
                     <para>http://www.onvif.org/ver10/colorspace/RGB</para>
                   </entry>
@@ -890,30 +909,33 @@
                   </entry>
                 </row>
                 <row>
+                  <entry><para>CIELUV</para></entry>
                   <entry>
-                   <para>http://www.onvif.org/ver10/colorspace/CIELUV</para>
+                    <para>http://www.onvif.org/ver10/colorspace/CIELUV</para>
                   </entry>
                   <entry>
-                   <para><emphasis role="bold">Deprecated</emphasis> CIE LUV</para>
-                 </entry>
-               </row>
-               <row>
-                 <entry>
-                   <para>http://www.onvif.org/ver10/colorspace/CIELAB</para>
-                 </entry>
-                 <entry>
-                   <para><emphasis role="bold">Deprecated</emphasis> CIE 1976 (L*a*b*)</para>
-                 </entry>
-               </row>
-               <row>
-                 <entry>
-                   <para>http://www.onvif.org/ver10/colorspace/HSV</para>
-                 </entry>
-                 <entry>
-                   <para><emphasis role="bold">Deprecated</emphasis> HSV color space</para>
+                    <para><emphasis role="bold">Deprecated</emphasis> CIE LUV</para>
                   </entry>
                 </row>
-             </tbody>
+                <row>
+                  <entry><para>CIELAB</para></entry>
+                  <entry>
+                    <para>http://www.onvif.org/ver10/colorspace/CIELAB</para>
+                  </entry>
+                  <entry>
+                    <para><emphasis role="bold">Deprecated</emphasis> CIE 1976 (L*a*b*)</para>
+                  </entry>
+                </row>
+                <row>
+                  <entry><para>HSV</para></entry>
+                  <entry>
+                    <para>http://www.onvif.org/ver10/colorspace/HSV</para>
+                  </entry>
+                  <entry>
+                    <para><emphasis role="bold">Deprecated</emphasis> HSV color space</para>
+                  </entry>
+                </row>
+              </tbody>
             </tgroup>
           </table>
         </section>

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -832,7 +832,7 @@
             range [0 .. 1]. Color covariance describes the variation of color values around the
             representative color value in color space thus representative color denotes a region in
             color space.</para>
-          <para>Nate that the color descriptor does not specify, how color clusters are created.
+          <para>Note that the color descriptor does not specify, how color clusters are created.
             They can represent bins of a color histogram or the result of a clustering
             algorithm.</para>
           <para>The color space defaults to the YCbCr color space which refers to the 'sRGB' gamut
@@ -841,8 +841,8 @@
             guidelines), a.k.a. JPEG. The Colorspace URI for the YCbCr color space is <link
               xmlns:xlink="http://www.w3.org/1999/xlink"
               xlink:href="http://www.onvif.org/ver10/colorspace/YCbCr"/>. Alternate color spaces as
-            defined in <xref linkend="_colorspaces"/> can be defined on frame level and individually 
-            for earch object.</para> 
+            defined in <xref linkend="_colorspaces"/> can be defined on frame level and individually
+            for each object.</para> 
           <para>An example metadata containing color information of the detected object is given below.  </para>
           <programlisting><![CDATA[<tt:Frame UtcTime="2010-09-10T12:24:57.721" Colorspace="RGB">
   <tt:Transformation>

--- a/wsdl/ver10/schema/common.xsd
+++ b/wsdl/ver10/schema/common.xsd
@@ -179,7 +179,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 								<li>Z attribute = B value</li></ul>
 						</li>
 					</ul>
-					If the Colorspace attribute is absent, YCbCr is implied.
+					If the Colorspace attribute is absent and not defined on higher level, YCbCr is implied.
 
 					Deprecated values:
 					<ul>

--- a/wsdl/ver10/schema/metadatastream.xsd
+++ b/wsdl/ver10/schema/metadatastream.xsd
@@ -221,6 +221,9 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- reserved for ONVIF -->
 		</xs:sequence>
 		<xs:attribute name="UtcTime" type="xs:dateTime" use="required"/>
+		<xs:attribute name="Colorspace" type="xs:string">
+			<xs:annotation><xs:documentation>Default color space of Color definitions in frame. Valid values are "RGB" and "YCbCr". Defaults to "YCbCr".</xs:documentation></xs:annotation>
+		</xs:attribute>
 		<xs:attribute name="Source" type="xs:string">
 			<xs:annotation>
 				<xs:documentation>Optional name of the analytics module that generated this frame.</xs:documentation>


### PR DESCRIPTION
The default color space is defined as YCbCr. Any implementations using e.g. RGB need to add a full URL like http://www.onvif.org/ver10/colorspace/RGB to each color definition which bloats the metadata stream.

This proposal allows to define a frame wide default.

Backward compatibility consideration: 
 * Without this definition all defaults stay as is. 
 * With definition older clients may not understand the default and misinterpret the color value.
Since color isn't widely used - partly due to prohibit bad encoding this change seems to be acceptable.