### PR TITLE
Clarify color value range.

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -835,7 +835,7 @@
         <section xml:id="_Toc214944464">
           <title>Color descriptor</title>
           <para>The optional color descriptor allows to describe the representative colors of the
-            detected object or region. Each color is represented as vectors based on a color space.
+            detected object or region. Each color is represented as a three-dimensional vector based on a color space with component values in the range [0 .. 255].
             Its weight denotes the fraction of pixels assigned to the representative color in the
             range [0 .. 1]. Color covariance describes the variation of color values around the
             representative color value in color space thus representative color denotes a region in

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -835,7 +835,7 @@
         <section xml:id="_Toc214944464">
           <title>Color descriptor</title>
           <para>The optional color descriptor allows to describe the representative colors of the
-            detected object or region. Each color is represented as a three-dimensional vector based on a color space with component values in the range [0 .. 255].
+            detected object or region. Each color is represented as a three-dimensional vector based on a color space.
             Its weight denotes the fraction of pixels assigned to the representative color in the
             range [0 .. 1]. Color covariance describes the variation of color values around the
             representative color value in color space thus representative color denotes a region in
@@ -941,6 +941,41 @@
                   </entry>
                   <entry>
                     <para><emphasis role="bold">Deprecated</emphasis> HSV color space</para>
+                  </entry>
+                </row>
+              </tbody>
+            </tgroup>
+          </table>
+          <para><xref linkend="_colorranges"/> lists the acceptable value ranges for prominent color
+            spaces.</para>
+          <table xml:id="_colorranges">
+            <title>Colorspace value ranges</title>
+            <tgroup cols="2">
+              <colspec colname="c1" colwidth="1*"/>
+              <colspec colname="newCol2" colwidth="4.19*"/>
+              <thead>
+                <row>
+                  <entry>Colorspace</entry>
+                  <entry>
+                    <para>Range</para>
+                  </entry>
+                </row>
+              </thead>
+              <tbody valign="top">
+                <row>
+                  <entry>
+                    <para>YCbCr</para>
+                  </entry>
+                  <entry>
+                    <para>Y [16 to 235] and Cb/Cr[16 to 240]</para>
+                  </entry>
+                </row>
+                <row>
+                  <entry>
+                    <para>RGB</para>
+                  </entry>
+                  <entry>
+                    <para>For all component values [0...255]</para>
                   </entry>
                 </row>
               </tbody>


### PR DESCRIPTION
The range of the color values is currently not defined in the analytics specification. There is an example using values between zero and 255.

The color components are defined as float values. For those ONVIF typically uses the range zero to one.  

For the sake of backward compatibility I suggest to not change the example and define the range to [0...255]. 

Note that the same color struct is also used for OSD.