### PR TITLE
Specify access class in a uniform way in all docs

### DIFF
--- a/doc/Imaging.xml
+++ b/doc/Imaging.xml
@@ -569,9 +569,13 @@ Change Request 2384, 2431, 2477, 2478</revremark>
               <para role="text">The requested video source does not support imaging settings.</para>
             </listitem>
           </varlistentry>
+          <varlistentry>
+            <term>access class</term>
+            <listitem>
+              <para role="access">READ_MEDIA</para>
+            </listitem>
+          </varlistentry>
         </variablelist>
-        <para>Access Class: </para>
-        <para>	READ_MEDIA</para>
         <para>If the video source supports any of the imaging settings as defined by the ImagingSettings type in the [ONVIF Schema], then it should be possible to retrieve the imaging settings from the device through the GetImagingSettings command.</para>
       </section>
       <section xml:id="_Toc86847688">
@@ -644,9 +648,13 @@ Change Request 2384, 2431, 2477, 2478</revremark>
               <para role="text">The requested VideoSource does not support imaging settings.</para>
             </listitem>
           </varlistentry>
+          <varlistentry>
+            <term>access class</term>
+            <listitem>
+              <para role="access">READ_MEDIA</para>
+            </listitem>
+          </varlistentry>
         </variablelist>
-        <para>Access Class: </para>
-        <para>READ_MEDIA</para>
       </section>
     </section>
     <section xml:id="_Toc214944255">

--- a/doc/RecordingSearch.xml
+++ b/doc/RecordingSearch.xml
@@ -1337,13 +1337,13 @@ http://www.onvif.org/ver10/tptz/ZoomSpaces/PositionGenericSpace
             <para role="text">The search token is invalid.</para>
           </listitem>
         </varlistentry>
+        <varlistentry>
+          <term>access class</term>
+          <listitem>
+            <para role="access">READ_MEDIA</para>
+          </listitem>
+        </varlistentry>
       </variablelist>
-      <para>ACCES CLASS:</para>
-      <itemizedlist>
-        <listitem>
-          <para>READ_MEDIA</para>
-        </listitem>
-      </itemizedlist>
     </section>
     <section>
       <title>GetServiceCapabilities</title>


### PR DESCRIPTION
The access class needs to be specified in the same way in all docs so that it can be automatically parsed to be used in the tests.
