### PR TITLE
Draft: Begin Addon addition to the spec.

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -1102,9 +1102,9 @@
       <para>A successful discovery provides the device service address. Once a client has the device service address it can receive detailed device information through the device service, see section  <xref linkend="_Toc251333295" /> below.</para>
     </section>
     <section>
-      <title>Profiles</title>
-      <para>Device functionality can be grouped to so called profiles. The profiles themselves are defined in separate specifications. </para>
-      <para>For each profile a number of services and functions are mandatory which are defined in the respective specifications.</para>
+      <title>Profiles and Addons</title>
+      <para>Device functionality can be grouped to so called profiles and addons. Profles and addons themselves are defined in separate specifications. </para>
+      <para>For each profile or addon, a number of services and functions are mandatory which are defined in the respective specifications.</para>
     </section>
     <section xml:id="_Toc251333295">
       <title>Device management</title>
@@ -1213,6 +1213,9 @@
           </listitem>
           <listitem>
             <para>Get and set device discovery parameters.</para>
+          </listitem>
+          <listitem>
+            <para>Get supported addons.</para>
           </listitem>
         </itemizedlist>
       </section>
@@ -2820,7 +2823,7 @@ onvif://www.onvif.org/name/ARV-453
                   </entry>
                 </row>
                 <row>
-                  <entry morerows="16">
+                  <entry morerows="17">
                     <para>System</para>
                   </entry>
                   <entry>
@@ -2948,6 +2951,15 @@ onvif://www.onvif.org/name/ARV-453
                   <entry>UserConfigNotSupported</entry>
                   <entry>Indicates no support for user configuration.</entry>
                 </row>
+                <row>
+                  <entry>
+                    <para>Addons</para>
+                  </entry>
+                  <entry>
+                    <para>Indicates the support for ONVIF Addons. See section TODO.</para>
+                  </entry>
+                </row>
+                <row>
                 <row>
                   <entry morerows="15">
                     <para>Security</para>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -2956,10 +2956,9 @@ onvif://www.onvif.org/name/ARV-453
                     <para>Addons</para>
                   </entry>
                   <entry>
-                    <para>Indicates support for ONVIF Addons.</para>
+                    <para>Indicates support for ONVIF Addons. Strings for each specific addon can be found in its respective specification document.</para>
                   </entry>
                 </row>
-                <row>
                 <row>
                   <entry morerows="15">
                     <para>Security</para>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -1103,7 +1103,7 @@
     </section>
     <section>
       <title>Profiles and Addons</title>
-      <para>Device functionality can be grouped to so called profiles and addons. Profiles and addons themselves are defined in separate specifications. In the case of addons, the must be u</para>
+      <para>Device functionality can be grouped to so called profiles and addons. Profiles and addons themselves are defined in separate specifications.  Addons complement profiles, and you must declare support for one or more profiles to use an addon.</para>
       <para>For each profile or addon, a number of services and functions are mandatory which are defined in the respective specifications.</para>
     </section>
     <section xml:id="_Toc251333295">

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -1103,7 +1103,7 @@
     </section>
     <section>
       <title>Profiles and Addons</title>
-      <para>Device functionality can be grouped to so called profiles and addons. Profles and addons themselves are defined in separate specifications. </para>
+      <para>Device functionality can be grouped to so called profiles and addons. Profiles and addons themselves are defined in separate specifications. In the case of addons, the must be u</para>
       <para>For each profile or addon, a number of services and functions are mandatory which are defined in the respective specifications.</para>
     </section>
     <section xml:id="_Toc251333295">
@@ -2956,7 +2956,7 @@ onvif://www.onvif.org/name/ARV-453
                     <para>Addons</para>
                   </entry>
                   <entry>
-                    <para>Indicates the support for ONVIF Addons. See section TODO.</para>
+                    <para>Indicates support for ONVIF Addons.</para>
                   </entry>
                 </row>
                 <row>

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -356,6 +356,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:documentation>Indicates no support for user configuration.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
+				<xs:attribute name="Addons" type="tt:StringAttrList">
+					<xs:annotation>
+						<xs:documentation>List of supported Addons by the device. Valid items are defined in tds:Addons.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:complexType>
 			<!--===============================-->
@@ -374,6 +379,16 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<xs:enumeration value="Leveling">
 						<xs:annotation>	
 							<xs:documentation>Automatic adjustment of the deviation from the horizon also called pitch and roll.</xs:documentation>
+						</xs:annotation>
+					</xs:enumeration>
+    			</xs:restriction>
+			</xs:simpleType>
+			<!--===============================-->
+			<xs:simpleType name="Addons">
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="TLSConfiguration">
+						<xs:annotation>	
+							<xs:documentation>Device supports the TLS Configuration Adoon.</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
     			</xs:restriction>

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -358,7 +358,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:attribute>
 				<xs:attribute name="Addons" type="tt:StringAttrList">
 					<xs:annotation>
-						<xs:documentation>List of supported Addons by the device. Valid items are defined in tds:Addons.</xs:documentation>
+						<xs:documentation>List of supported Addons by the device.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
@@ -381,17 +381,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 							<xs:documentation>Automatic adjustment of the deviation from the horizon also called pitch and roll.</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
-    			</xs:restriction>
-			</xs:simpleType>
-			<!--===============================-->
-			<xs:simpleType name="Addons">
-				<xs:restriction base="xs:string">
-					<xs:enumeration value="TLSConfiguration">
-						<xs:annotation>	
-							<xs:documentation>Device supports the TLS Configuration Adoon.</xs:documentation>
-						</xs:annotation>
-					</xs:enumeration>
-    			</xs:restriction>
+				</xs:restriction>
 			</xs:simpleType>
 			<!--===============================-->
 			<xs:complexType name="MiscCapabilities">


### PR DESCRIPTION
Wanted to start this to get feedback.  I think we should have an enumeration to describe the valid addons and standardize the naming... however I am not sure where to put it in the core spec.  