### PR TITLE
Add Likelihood attribute to color type

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -885,6 +885,49 @@
   </tt:Object>
 </tt:Frame>
 ]]></programlisting>
+          <para>An alternative representation of color can be used by adding a likelihood attribute to the color element.</para>
+          <para>Its likelihood denotes how confident the algorithm is that the color is correct. The
+          range of likelihood is [0 .. 1].</para>
+          <para>When using the likelihood attribute the weight and covariance should not be used
+          as they are missing a meaningful definition in this case.</para>
+          <para>When using the likelihood attribute the meaning of multiple color clusters in the same color descriptor
+          changes. Multiple color clusters with likelihood should be interpreted as different color candidates
+          with different likelihoods, not as different regions of colors on the object.</para>
+          <para>An example metadata containing color information of the detected object using a color cluster with a
+          likelihood attribute is given below.</para>
+          <programlisting><![CDATA[<tt:Frame UtcTime="2010-09-10T12:24:57.721" Colorspace="RGB">
+  <tt:Transformation>
+    <tt:Translate x="-1.0" y="-1.0"/>
+    <tt:Scale x="0.003125" y="0.00416667"/>
+  </tt:Transformation>
+  <tt:Object ObjectId="34">
+    <tt:Appearance>
+      <tt:Shape>
+        <tt:BoundingBox left="20.0" top="80.0" right="100.0" bottom="30.0"/>
+        <tt:CenterOfGravity x="60.0" y="50.0"/>
+      </tt:Shape>
+      <tt:Color>
+        <tt:ColorCluster>
+          <tt:Color X="0" Y="0" Z="255" Likelihood="0.93"/>
+        </tt:ColorCluster>
+        <tt:ColorCluster>
+          <tt:Color X="255" Y="255" Z="255" Likelihood="0.87"/>
+        </tt:ColorCluster>
+        <tt:ColorCluster>
+          <tt:Color X="0" Y="0" Z="0" Likelihood="0.12"/>
+        </tt:ColorCluster>
+        <tt:ColorCluster>
+          <tt:Color X="0" Y="128" Z="0" Likelihood="0.08"/>
+        </tt:ColorCluster>
+        <tt:ColorCluster>
+          <tt:Color X="255" Y="0" Z="0" Likelihood="0.04"/>
+        </tt:ColorCluster>
+      </tt:Color>
+    </tt:Appearance>
+  </tt:Object>
+</tt:Frame>
+]]></programlisting>
+
           <para>The following table lists the acceptable values for colorspace attribute</para>
           <table xml:id="_colorspaces">
             <title>Colorspace namespace values</title>

--- a/wsdl/ver10/schema/common.xsd
+++ b/wsdl/ver10/schema/common.xsd
@@ -190,6 +190,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
+		<xs:attribute name="Likelihood" type="xs:float">
+			<xs:annotation>
+				<xs:documentation>Likelihood that the color is correct.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
 		<xs:anyAttribute processContents="lax"/>
 	</xs:complexType>
 	<xs:complexType name="ColorCovariance">


### PR DESCRIPTION
When using a classifier to determine the color of an object the Likelihood attribute describes how confident the algorithm is that the color is correct.

