### PR TITLE
Add missing attribute extension points

### DIFF
--- a/wsdl/ver10/schema/common.xsd
+++ b/wsdl/ver10/schema/common.xsd
@@ -190,6 +190,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
+		<xs:anyAttribute processContents="lax"/>
 	</xs:complexType>
 	<xs:complexType name="ColorCovariance">
 		<xs:attribute name="XX" type="xs:float" use="required"/>
@@ -205,6 +206,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
+		<xs:anyAttribute processContents="lax"/>
 	</xs:complexType>
 	<xs:complexType name="ColorDescriptor">
 		<xs:sequence>
@@ -217,6 +219,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- reserved for ONVIF -->
 					</xs:sequence>
 				</xs:complexType>
+				<xs:anyAttribute processContents="lax"/>
 			</xs:element>
 			<xs:element name="Extension" type="xs:anyType" minOccurs="0"/>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- reserved for ONVIF -->

--- a/wsdl/ver10/schema/common.xsd
+++ b/wsdl/ver10/schema/common.xsd
@@ -218,8 +218,8 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:element name="Covariance" type="tt:ColorCovariance" minOccurs="0"/>
 						<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- reserved for ONVIF -->
 					</xs:sequence>
+					<xs:anyAttribute processContents="lax"/>
 				</xs:complexType>
-				<xs:anyAttribute processContents="lax"/>
 			</xs:element>
 			<xs:element name="Extension" type="xs:anyType" minOccurs="0"/>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- reserved for ONVIF -->


### PR DESCRIPTION
Extension points had been added to metadatastream.xsd for XML 1.1 compatibility, but the included color types weren't updated.