### PR TITLE
Add support for event recording

### DIFF
--- a/doc/ActionEngine.xml
+++ b/doc/ActionEngine.xml
@@ -1086,7 +1086,8 @@
       </section>
       <section>
         <title>Camera Local Recording Action </title>
-        <para>Camera Local Recording Action definition allows application to initiate recording of data to the camera local storage. The content is provided during the execution.. </para>
+        <para>Note, that this interface has been deprecated since the same functionality can be configured directly via the recording control service.</para>
+        <para>Camera Local Recording Action definition allows application to initiate recording of data to the camera local storage. The content is provided during the execution. </para>
         <programlisting><![CDATA[<tt:ActionDescription Name="tt:RecordingAction">
   <tt:ParameterDescription>
     <tt:ElementItemDescription Name="RecordingConfiguration"

--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -353,7 +353,7 @@ Change Request 2061, 2063, 2065, 2109</revremark>
         <para>If a device supports scheduled recording, clients may configure scheduled recording by adding a scheduler token to the recording job. A recording job with a scheduler token will only record when the associated schedule is active. If the associated schedule of a recording job is inactive a job with lower recording priority may record.</para>
         <para>By default a recording job is continuously recording. Devices supporting the
           EventFilter can be configured such that they only record events. To provide some context
-          time intervalls before and after the event may be captured.</para>
+          time intervals before and after the event may be captured.</para>
         <para>The recording job relies on the receiver service for receiving the data from other devices through receiver objects identified by ReceiverTokens</para>
       </section>
     </section>
@@ -477,11 +477,11 @@ Change Request 2061, 2063, 2065, 2109</revremark>
           </varlistentry>
         </variablelist>
         <para>A device shall support Before and After durations when their limit is signalled via
-          the respective capability. A device may adapt Before and After duration values to internal
+          the respective capability. A device may adapt the Before and After duration values to internal
           quantization. </para>
-        <para>A  device shall at least record the event duration and the specified before and after
+        <para>A device shall at least record the event duration and the specified before and after
           timesspans. Due to the nature of GOP structures it may record more.</para>
-        <para>Note that none-property events result in an infinite short timespan optionally
+        <para>Note that non-property events result in an infinite short timespan. In such cases at least one I-Frame shall be recorded, optionally
           extended by before and after timespans. </para>
         <para>A recording job of a device supporting both EventFilter and ScheduledRecording shall
           become active if both conditions are met.</para>

--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -1458,7 +1458,7 @@ Change Request 2061, 2063, 2065, 2109</revremark>
         </varlistentry>
         <varlistentry>
           <term>EventRecording</term>
-          <listitem><para>Indication that the device supports scheduled recording.</para></listitem>
+          <listitem><para>Indication that the device supports event triggered recording.</para></listitem>
         </varlistentry>
         <varlistentry>
           <term>BeforeEventLimit</term>

--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -448,17 +448,10 @@ Change Request 2061, 2063, 2065, 2109</revremark>
           </para>
         <variablelist>
           <varlistentry>
-            <term>TopicFilter</term>
+            <term>Filter</term>
             <listitem>
-              <para>Topic filter as defined in section 9.6.3 of the ONVIF Core Specification.</para>
-            </listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>ContentFilter</term>
-            <listitem>
-              <para>Optional message content filter as defined in section 9.4.4 of the ONVIF Core
-                Specification. When this parameter is absent any message Data parameter with value
-                other than 'false', zero or empty shall result in a match. </para>
+              <para>One or more filter pairs containing a mandatory topic filter as defined in section 9.6.3 of the ONVIF Core Specification. It may be associated with an optional message content filter as defined in section 9.4.4 of the ONVIF Core
+                Specification. </para>
             </listitem>
           </varlistentry>
           <varlistentry>
@@ -476,6 +469,7 @@ Change Request 2061, 2063, 2065, 2109</revremark>
             </listitem>
           </varlistentry>
         </variablelist>
+        <para>A device shall support filtering on topics and message source parameters. Filtering on message data values doesn't need to be supported since it may cause malfunctions.</para>
         <para>A device shall support Before and After durations when their limit is signalled via
           the respective capability. A device may adapt the Before and After duration values to internal
           quantization. </para>

--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -351,6 +351,9 @@ Change Request 2061, 2063, 2065, 2109</revremark>
         <para>To save data to a recording, a client first creates a recording and ensures that the recording has the necessary tracks. Then the client creates a recording job that pulls data from one or more sources and stores the data to the tracks in the recording. </para>
         <para>Clients may set up multiple recording jobs that all record into the same recording. If multiple recording jobs are active, the device uses a priority scheme to select between the tracks defined in the recording jobs. Clients may change the mode of recording jobs at any time, thereby providing means to implement features like alarm recording or manual recording.</para>
         <para>If a device supports scheduled recording, clients may configure scheduled recording by adding a scheduler token to the recording job. A recording job with a scheduler token will only record when the associated schedule is active. If the associated schedule of a recording job is inactive a job with lower recording priority may record.</para>
+        <para>By default a recording job is continuously recording. Devices supporting the
+          EventFilter can be configured such that they only record events. To provide some context
+          time intervalls before and after the event may be captured.</para>
         <para>The recording job relies on the receiver service for receiving the data from other devices through receiver objects identified by ReceiverTokens</para>
       </section>
     </section>
@@ -424,6 +427,8 @@ Change Request 2061, 2063, 2065, 2109</revremark>
         <para>
           <emphasis role="bold">ScheduleToken:</emphasis> This attribute adds an additional requirement for activating the recording job. If this optional field is provided the job shall only record if the schedule exists and is active.</para>
         <para>
+          <emphasis role="bold">EventFilter:</emphasis> This set of parameters allows to control recording depending on a given set of event condititions.</para>
+        <para>
           <emphasis role="bold">SourceToken</emphasis>: This field shall be a reference to the source of the data. The type of the source is determined by the attribute Type in the SourceToken structure. If Type is http://www.onvif.org/ver10/schema/Receiver, the token is a ReceiverReference. In this case the device shall receive the data over the network. If Type is http://www.onvif.org/ver10/schema/Profile, the token identifies a media profile, instructing the device to obtain data from a profile that exists on the local device. </para>
         <para>A device that includes the ONVIF Media Service shall support a Media Profile token and a device that includes the ONVIF Receiver Service shall support a Receiver token.</para>
         <para>If the <emphasis role="bold">SourceToken</emphasis> is omitted, <emphasis role="bold">AutoCreateRecevier</emphasis> shall be true.</para>
@@ -434,6 +439,52 @@ Change Request 2061, 2063, 2065, 2109</revremark>
         <para>
           <emphasis role="bold">Destination</emphasis>: The destination is the track token of the track to which the device shall store the received data. All tracks must belong to the recording identified by the RecordingToken.</para>
         <para>The TrackInformation field for a Track holds a single Source. In case multiple RecordingJobs with differing Source are recording to the same Track it is undefined which of them is reported in the corresponding TrackInformation of the the RecordingSearch API.</para>
+      </section>
+      <section>
+        <title>Event recording</title>
+        <para>A device signalling support for EventRecording via its capabilities shall support
+          controling recording job activity via the EventFilter with the following set of
+          parameters: 
+          </para>
+        <variablelist>
+          <varlistentry>
+            <term>TopicFilter</term>
+            <listitem>
+              <para>Topic filter as defined in section 9.6.3 of the ONVIF Core Specification.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>ContentFilter</term>
+            <listitem>
+              <para>Optional message content filter as defined in section 9.4.4 of the ONVIF Core
+                Specification. When this parameter is absent any message Data parameter with value
+                other than 'false', zero or empty shall result in a match. </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>Before</term>
+            <listitem>
+              <para>Optional timespan to record before the actual event condition became active.
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>After</term>
+            <listitem>
+              <para>Optional timespan to record after the actual event condition becomes
+                inactive.</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+        <para>A device shall support Before and After durations when their limit is signalled via
+          the respective capability. A device may adapt Before and After duration values to internal
+          quantization. </para>
+        <para>A  device shall at least record the event duration and the specified before and after
+          timesspans. Due to the nature of GOP structures it may record more.</para>
+        <para>Note that none-property events result in an infinite short timespan optionally
+          extended by before and after timespans. </para>
+        <para>A recording job of a device supporting both EventFilter and ScheduledRecording shall
+          become active if both conditions are met.</para>
       </section>
     </section>
     <section>
@@ -1404,6 +1455,18 @@ Change Request 2061, 2063, 2065, 2109</revremark>
         <varlistentry>
           <term>ScheduledRecording</term>
           <listitem><para>Indication that the device supports scheduled recording.</para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>EventRecording</term>
+          <listitem><para>Indication that the device supports scheduled recording.</para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>BeforeEventLimit</term>
+          <listitem><para>Indicates that the device supports before event durations up to the given value.</para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>AfterEventLimit</term>
+          <listitem><para>Indicates that the device supports after event durations up to the given value.</para></listitem>
         </varlistentry>
       </variablelist>
     </section>

--- a/wsdl/ver10/recording.wsdl
+++ b/wsdl/ver10/recording.wsdl
@@ -89,6 +89,25 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
+				<xs:attribute name="EventRecording" type="xs:boolean">
+					<xs:annotation>
+						<xs:documentation>Indication that the device supports event triggered recording.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="BeforeEventLimit" type="xs:duration">
+					<xs:annotation>
+						<xs:documentation> 
+							If present a device shall support configuring before event durations up to the given value.
+						</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="AfterEventLimit" type="xs:duration">
+					<xs:annotation>
+						<xs:documentation> 
+							If present a device shall support configuring after event durations up to the given value.
+						</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:complexType>
 			<xs:element name="Capabilities" type="trc:Capabilities"/>

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -7987,7 +7987,7 @@ and sample rate. </xs:documentation>
 			<xs:element name="TopicFilter" type="xs:string">
 				<xs:annotation><xs:documentation>Topic filter as defined in section 9.6.3 of the ONVIF Core Specification.</xs:documentation></xs:annotation>
 			</xs:element>
-			<xs:element name="ContentFilter" type="xs:string">
+			<xs:element name="ContentFilter" type="xs:string" minOccurs="0">
 				<xs:annotation><xs:documentation>Optional message content filter as defined in section 9.4.4 of the ONVIF Core Specification. 
 					When this parameter is absent any message Data parameter with value other than 'false', zero or empty shall result in a match.</xs:documentation></xs:annotation>
 			</xs:element>

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -7984,12 +7984,19 @@ and sample rate. </xs:documentation>
 
 	<xs:complexType name="RecordingEventFilter">
 		<xs:sequence>
-			<xs:element name="TopicFilter" type="xs:string">
-				<xs:annotation><xs:documentation>Topic filter as defined in section 9.6.3 of the ONVIF Core Specification.</xs:documentation></xs:annotation>
-			</xs:element>
-			<xs:element name="ContentFilter" type="xs:string" minOccurs="0">
-				<xs:annotation><xs:documentation>Optional message content filter as defined in section 9.4.4 of the ONVIF Core Specification. 
-					When this parameter is absent any message Data parameter with value other than 'false', zero or empty shall result in a match.</xs:documentation></xs:annotation>
+			<xs:element name="Filter" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Topic" type="xs:string">
+							<xs:annotation><xs:documentation>Topic filter as defined in section 9.6.3 of the ONVIF Core Specification.</xs:documentation></xs:annotation>
+						</xs:element>
+						<xs:element name="Source" type="xs:string" minOccurs="0">
+							<xs:annotation><xs:documentation>Optional message source content filter as defined in section 9.4.4 of the ONVIF Core Specification.</xs:documentation></xs:annotation>
+						</xs:element>
+						<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then vendor -->
+					</xs:sequence>
+					<xs:anyAttribute processContents="lax"/>
+				</xs:complexType>
 			</xs:element>
 			<xs:element name="Before" type="xs:duration" minOccurs="0">
 				<xs:annotation><xs:documentation>Optional timespan to record before the actual event condition became active.</xs:documentation></xs:annotation>

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -7967,6 +7967,10 @@ and sample rate. </xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Extension" type="tt:RecordingJobConfigurationExtension" minOccurs="0"/>
+			<xs:element name="EventFilter" type="tt:RecordingEventFilter" minOccurs="0">
+				<xs:annotation><xs:documentation>Optional filter defining on which event condition a recording job gets active.</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- ONVIF only -->
 		</xs:sequence>
 		<xs:attribute name="ScheduleToken">
 			<xs:annotation>
@@ -7977,6 +7981,26 @@ and sample rate. </xs:documentation>
 		</xs:attribute>
 		<xs:anyAttribute processContents="lax"/>
 	</xs:complexType>
+
+	<xs:complexType name="RecordingEventFilter">
+		<xs:sequence>
+			<xs:element name="TopicFilter" type="xs:string">
+				<xs:annotation><xs:documentation>Topic filter as defined in section 9.6.3 of the ONVIF Core Specification.</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="ContentFilter" type="xs:string">
+				<xs:annotation><xs:documentation>Optional message content filter as defined in section 9.4.4 of the ONVIF Core Specification. 
+					When this parameter is absent any message Data parameter with value other than 'false', zero or empty shall result in a match.</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="Before" type="xs:duration" minOccurs="0">
+				<xs:annotation><xs:documentation>Optional timespan to record before the actual event condition became active.</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="After" type="xs:duration" minOccurs="0">
+				<xs:annotation><xs:documentation>Optional timespan to record after the actual event condition becomes inactive.</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then vendor -->
+		</xs:sequence>
+		<xs:anyAttribute processContents="lax"/>
+	</xs:complexType>
 	<!--===============================-->
 	<xs:simpleType name="RecordingJobMode">
 		<xs:restriction base="xs:string"/>
@@ -7984,7 +8008,7 @@ and sample rate. </xs:documentation>
 	<!--===============================-->
 	<xs:complexType name="RecordingJobConfigurationExtension">
 		<xs:sequence>
-			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- Vendor only -->
 		</xs:sequence>
 	</xs:complexType>
 	<!--===============================-->


### PR DESCRIPTION
Add event recording configuration to RecordingJobConfiguration.

Note to the chosen XML 1.1 extension mechanism: using the existing XML 1.0 extension point would require to add Extension2 because of the order vendor before onvif and most parser do not support two xs:any with different namespaces. All this would result in ugly design.
Backward compatibility analysis: 
- Device side: only devices signalling support via their capabilities are required to parse requests with extension point. Hence fully backward compatible.
- Client side:  only new clients can configure event recording. Issues may only occur in case of mixed new and old client usage. 