### PR TITLE
JSON Example: Add missing "Type" key and array token for "Class".

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -2635,8 +2635,10 @@ xmlns:acme="http://www.acme.com/schema"&gt;
           }]
         },
         "Class": {
-          "@Likelihood": "0.8",
-          "#text": "Human"
+          "Type": [{
+            "@Likelihood": 0.8,
+            "#text": "Human"
+          }]
         },
         "HumanFace": {
           "Gender:": "Male",


### PR DESCRIPTION
According to [metadatastream.xsd](https://github.com/onvif/specs/blob/22.12/wsdl/ver10/schema/metadatastream.xsd), there seem to be some discrepancies in the JSON example:

The "Type" Key that contains an array of tt:StringLikelihood is 
a) missing and
b) missing its array token
as defined here
```
<xs:complexType name="ClassDescriptor">
		<xs:sequence>
[...]
			<xs:element name="Type" type="tt:StringLikelihood" minOccurs="0" maxOccurs="unbounded">
[...]
```

Furthermore,
c) Likelihood should be a float, not a string as defined here:
```
[...]
<xs:complexType name="StringLikelihood">
		<xs:simpleContent>
			<xs:extension base="xs:string">
				<xs:attribute name="Likelihood" type="xs:float"/>
[...]
```

