### PR TITLE
Clarify behavior in case no hostname has been assigned.

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -3157,7 +3157,8 @@ onvif://www.onvif.org/name/ARV-453
 	  <para> A device shall support the commands defined in this section unless the NetworkConfigNotSupported capability is signalled as 'True' confirming it doesn’t support network configuration. </para>
       <section>
         <title>GetHostname</title>
-        <para>This operation is used by an endpoint to get the hostname from a device. The device shall return its hostname configurations through the GetHostname command.</para>
+        <para>This operation is used by an endpoint to get the hostname from a device. The device shall return its hostname configurations through the GetHostname command. 
+          The device shall return an empty string if no hostname has been assigned.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -2489,12 +2489,12 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 		<xs:sequence>
 			<xs:element name="FromDHCP" type="xs:boolean">
 				<xs:annotation>
-					<xs:documentation>Indicates whether the hostname is obtained from DHCP or not.</xs:documentation>
+					<xs:documentation>Indicates whether the hostname has been obtained from DHCP or not.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Name" type="xs:token" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Indicates the hostname.</xs:documentation>
+					<xs:documentation>Indicates the device hostname or an empty string if no hostname has been assigned.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Extension" type="tt:HostnameInformationExtension" minOccurs="0"/>


### PR DESCRIPTION
Currently it is undefined how a device should respond when no hostname has been assigned to its network interface.