### PR TITLE
HTTP  Digest Authentication - SHA 256 support as per [RFC 7616]

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -2194,53 +2194,53 @@ DATE: when response was generated
       </section>
 	  <section>
         <title>SHA-256 Support in HTTP and RTSP digest authentication</title>
-        <para>An ONVIF compliant device follows [RFC 7616] to support SHA-256 hashing algorithm in HTTP and RTSP digest authentication. An ONVIF device signals it's supported hashing algorthms via Security Capability HashingAlgorithms parameter.</para>
-		<para>Support of SHA-256 hashing algorithm is optional for ONVIF device and client.</para>      
-      <section>
-	  <title>GetHashingAlgorithm</title>               
-          <para>ONVIF Client can get current hashing algorithm of ONVIF device by sending HTTP or RTSP request without Authorization header. Here ONVIF Device responds with a HTTP or RTSP 401 message that includes a challenge for each digest algorithm currently it was set, in its order of preference.</para>
-          <para>There is no ONVIF API to get current hashing algorithm of a device, ONVIF Client can rely on HTTP or RTSP digest challenge response.</para>
-		  <para>The example HTTP request and response from ONVIF Device when device current hashing algorithm MD5 and SHA-256 is as follows. </para>
-		    <variablelist role="op">
-          <varlistentry>
-            <term>request</term>
-            <listitem>
-              <programlisting><![CDATA[POST /onvif/device_service HTTP/1.1
-Host: 10.XX.XX.XX
-Content-Type: application/soap+xml; charset=utf-8
-Content-Length: 299
-
-<?xml version="1.0" encoding="utf-8"?>
-<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
-<s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-<GetDeviceInformation xmlns="http://www.onvif.org/ver10/device/wsdl"/>
-</s:Body></s:Envelope>]]>
-			</programlisting>             
-            </listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>response</term>
-            <listitem>
-              <programlisting><![CDATA[HTTP/1.1 401 Unauthorized
-WWW-Authenticate: Digest algorithm=MD5, realm="Silvan_http_digest", qop="auth", 
-nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"
-WWW-Authenticate: Digest algorithm=SHA-256, realm="Silvan_http_digest", qop="auth", 
-nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"
-X-Frame-Options: SAMEORIGIN
-Content-Type: application/soap+xml; charset=utf-8
-Content-Length: 2785
-]]>
-			</programlisting>
-            </listitem>
-          </varlistentry>     
-        </variablelist>		  
-			<para>To maintain backward compatibility with old ONVIF Client(s), ONVIF Device by default should do HTTP or RTSP digest challenge with MD5 hashing algorithm  as per RFC[2617].</para>        
-      </section>
-	  <section>
+        <para>To support SHA-256 hashing algorithm in HTTP and RTSP digest authentication, an ONVIF compliant device and client should follow [RFC 7616].</para>
+        <para>Below table explains the default and optional parameters for ONVIF compliant devices:</para>
+		 <table>
+			<title>Device authentication Behavior</title>
+            <tgroup cols="3">
+              <colspec colname="c1" colwidth="49*" />
+              <colspec colname="c2" colwidth="13*" />
+              <colspec colname="c3" colwidth="37*" />
+              <thead>
+                <row>
+                  <entry>
+                    <para>Default Behavior</para>
+                  </entry>
+                  <entry>
+                    <para>Default Hashing Algorithm Used</para>
+                  </entry>
+                  <entry>
+                    <para>Optional(In Digest authentication)</para>
+                  </entry>
+                </row>
+              </thead>
+              <tbody valign="top">
+                <row>
+                  <entry>
+                    <para>An ONVIF compliant device and client should follow [RFC 2617] digest authentication.</para>
+                  </entry>
+                  <entry>
+                    <para>MD5</para>
+                  </entry>
+                  <entry>
+                    <para>Support of SHA-256 hashing algorithm is optional for both ONVIF device and client.</para>
+                  </entry>
+                </row>                
+              </tbody>
+            </tgroup>
+          </table>
+		<para>Client can check the supported hashing algorithms in “HashingAlgorithms” field under “SecurityCapabilities” section of capabilities response. If this field is absent or empty by default only “MD5” is applicable.</para>		
+	 	<section>
         <title>SetHashingAlgorithm</title>
-        <para>This operation sets the hashing algorithm(s) used in HTTP and RTSP Digest Authentication. A device follows [RFC 7616] shall support this operation.</para>        
-        <variablelist role="op">
+        <para>How to set HashingAlgorithm for an ONVIF Device/Client</para>
+		<para>•	ONVIF client should use SetHashingAlgorithm API to modify the current hashing algorithm of a device.</para>
+		<para>•	SetHashingAlgorithm API sets the hashing algorithm(s) to be used in HTTP and RTSP Digest Authentication.</para>
+		<para>Note: ONVIF devices that follows [RFC 7616] will support this operation</para>
+		<para>Post changing the Hashing Algorithm:</para>        
+        <para>1.After changing the hashing algorithm of an ONVIF device, the device should use the new hashing algorithm in the digest challenge for the upcoming HTTP and RTSP request.</para>
+		<para>Below request needs to be posted:</para>
+		<variablelist role="op">
           <varlistentry>
             <term>request</term>
             <listitem>
@@ -2269,6 +2269,74 @@ Content-Length: 2785
           </varlistentry>
         </variablelist>
       </section>
+	  <section>
+	  <title>Get Device Hashing Algorithm</title>               
+          <para>Follow the below workflow to get the latest device Hashing Algorithm:</para>
+		  <para>1. The ONVIF client should send a HTTP or RTSP requests without an Authorization header.</para>
+		  <para>2. The device responds with a HTTP or RTSP 401 message, that includes a challenge for each digest algorithm currently it was set, in its order of preference.</para>
+		  <para>Note: There is no ONVIF API to get the current hashing algorithm of a device, ONVIF clients should depend on HTTP or RTSP digest challenge response.</para>
+          <para>Below is the example for HTTP request and response from ONVIF device and client:</para>
+		  <variablelist role="op">
+          <varlistentry>
+            <term>request</term>
+            <listitem>
+              <programlisting><![CDATA[POST /onvif/device_service HTTP/1.1
+Host: 10.XX.XX.XX
+Content-Type: application/soap+xml; charset=utf-8
+Content-Length: 299
+
+<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+<s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<GetDeviceInformation xmlns="http://www.onvif.org/ver10/device/wsdl"/>
+</s:Body></s:Envelope>]]>
+			</programlisting>             
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <para>Response from a device if the hashing algorithm is set to MD5, SHA-256:</para>
+            <listitem>
+              <programlisting><![CDATA[HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Digest algorithm=MD5, realm="Silvan_http_digest", qop="auth", 
+nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"
+WWW-Authenticate: Digest algorithm=SHA-256, realm="Silvan_http_digest", qop="auth", 
+nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"
+X-Frame-Options: SAMEORIGIN
+Content-Type: application/soap+xml; charset=utf-8
+Content-Length: 2785
+]]>
+			</programlisting>
+            </listitem>
+          </varlistentry>
+<varlistentry>
+            <para>Response from a device if the hashing algorithm is set to SHA-256:</para>
+            <listitem>
+              <programlisting><![CDATA[HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Digest algorithm=SHA-256, realm="Silvan_http_digest", qop="auth", 
+nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"
+X-Frame-Options: SAMEORIGIN
+Content-Type: application/soap+xml; charset=utf-8
+Content-Length: 2785
+]]>
+			</programlisting>
+            </listitem>
+          </varlistentry>
+<varlistentry>
+            <para>Response from a device if the hashing algorithm is set to MD5:</para>
+            <listitem>
+              <programlisting><![CDATA[HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Digest algorithm=MD5, realm="Silvan_http_digest", qop="auth", 
+nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"
+X-Frame-Options: SAMEORIGIN
+Content-Type: application/soap+xml; charset=utf-8
+Content-Length: 2785
+]]>
+			</programlisting>
+            </listitem>
+          </varlistentry>		  
+        </variablelist>			       
+      </section>	 
 	  </section>	  
       <section>
         <title>User-based access control</title>
@@ -3183,7 +3251,7 @@ onvif://www.onvif.org/name/ARV-453
                     <para>HashingAlgorithms</para>
                   </entry>
                   <entry>
-                    <para>Indicates which hashing algorithms supported as part of HTTP and RTSP Digest authentication.</para>
+                    <para>Indicates which hashing algorithms are supported as part of HTTP and RTSP digest authentication.</para>
                   </entry>
                 </row>
                 <row>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -492,6 +492,8 @@
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc2616.txt"></link>&gt;</para>
     <para>IETF RFC 2617, HTTP Authentication: Basic and Digest Access Authentication</para>
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc2617.txt"></link>&gt;</para>
+	<para>IETF RFC 7616, HTTP Digest Access Authentication</para>
+    <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc7616.txt"></link>&gt;</para>
     <para>IETF RFC 3315, Dynamic Host Configuration Protocol for IPv6 (DHCPv6)</para>
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc3315.txt"></link>&gt;</para>
     <para>IETF RFC 3548, The Base16, Base32, and Base64 Data Encodings</para>
@@ -2165,7 +2167,7 @@ DATE: when response was generated
       <title>Security</title>
       <section>
         <title>Authentication</title>
-        <para>The services defined in this standard shall be protected using digest authentication according to [RFC 2617] with the following exceptions.</para>
+        <para>The services defined in this standard shall be protected using digest authentication according to [RFC 2617]and [RFC 7616] with the following exceptions.</para>
         <itemizedlist>
           <listitem>
             <para>legacy devices supporting [WS-UsernameToken] and</para>
@@ -2174,7 +2176,7 @@ DATE: when response was generated
             <para>TLS client authorization. </para>
           </listitem>
         </itemizedlist>
-        <para>If server supports both digest authentication as specified in [RFC 2617] and the user name token profile as specified in WS-Security the following behavior shall be adapted: a web service request can be authenticated on the HTTP level via digest authentication [RFC 2617] or on the web service level via the WS-Security (WSS) framework. If a client does not supply authentication credentials along with a web service request, the server shall assume that the client intends to use digest authentication [RFC 2617], if required. Hence, if a client does not provide authentication credentials when requesting a service that requires authentication, it will receive an HTTP 401 error according to [RFC 2617]. Note that this behaviour on the server’s side differs from the case of supporting only username token profile, which requires for this case an HTTP 400 error on the HTTP level and a SOAP:Fault env:Sender ter:NotAuthorized error on the WS level.</para>
+        <para>If server supports both digest authentication as specified in [RFC 2617]and [RFC 7616] and the user name token profile as specified in WS-Security the following behavior shall be adapted: a web service request can be authenticated on the HTTP level via digest authentication [RFC 2617]and [RFC 7616] or on the web service level via the WS-Security (WSS) framework. If a client does not supply authentication credentials along with a web service request, the server shall assume that the client intends to use digest authentication [RFC 2617]and [RFC 7616], if required. Hence, if a client does not provide authentication credentials when requesting a service that requires authentication, it will receive an HTTP 401 error according to [RFC 2617]and [RFC 7616]. Note that this behaviour on the server’s side differs from the case of supporting only username token profile, which requires for this case an HTTP 400 error on the HTTP level and a SOAP:Fault env:Sender ter:NotAuthorized error on the WS level.</para>
         <para>A client should not simultaneously supply authentication credentials on both the HTTP level and the WS level. If a server receives a web service request that contains authentication credentials on both the HTTP level and the WS level, it shall first validate the credentials provided on the HTTP layer. If this validation was successful, the server shall finally validate the authentication credentials provided on the WS layer.</para>
         <para>
           <xref linkend="AuthenticationFlow" /> summarizes the authentication of a web service request by a server.</para>
@@ -2188,7 +2190,61 @@ DATE: when response was generated
         </figure>
         <para>Both digest authentication and the user name token profile give only a rudimentary level of security. In a system where security is important, it is recommended to always configure the device for TLS-based access (see Advanced Security Service). Digest authentication or the user name token message level security combined with TLS, with client and server authentication, protected transport level security give an acceptable level of security in many systems.</para>
         <para>An ONVIF compliant device should authenticate an RTSP request at the RTSP level. If HTTP is used to tunnel the RTSP request the device shall not authenticate on the HTTP level.</para>
-        <para>When authenticating RTSP or HTTP methods, an ONVIF compliant device shall use digest authentication [RFC 2617]. The credentials shall be managed with the GetUsers, CreateUsers, DeleteUsers and SetUser methods. If the device also supports WS-Security, the same set of credentials shall be used.</para>
+        <para>When authenticating RTSP or HTTP methods, an ONVIF compliant device shall use digest authentication [RFC 2617]and [RFC 7616. The credentials shall be managed with the GetUsers, CreateUsers, DeleteUsers and SetUser methods. If the device also supports WS-Security, the same set of credentials shall be used.</para>
+      </section>
+	  <section>
+	  <title>GetHashingAlgorithm</title>
+        <section>          
+          <para>ONVIF Client gets current hashing algorithm of ONVIF device by sending ONVIF HTTP or RTSP request with out Authorization header.Here ONVIF Device responds with a HTTP or RTSP 401 message according to [RFC 2617] [RFC 7616] that includes a challenge for each digest algorithm currently it was set, in its order of preference.</para>
+          <para>The example HTTP digest challenge response from ONVIF Device when ONVIF Device current hashing algorithams is MD5 and SHA-256 is as follows.</para>
+		  <programlisting><![CDATA[HTTP/1.1 401 Unauthorized
+				WWW-Authenticate: Digest
+					realm="http-auth@test.org",
+					qop="auth, auth-int",
+					algorithm=MD5,
+					nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v",
+					opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"
+				WWW-Authenticate: Digest
+					realm="http-auth@test.org",
+					qop="auth, auth-int",
+					algorithm=SHA-256,
+					nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v",
+					opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"]]>
+			</programlisting>
+			<para>To maintain backward compatability with old ONVIF Client(s), ONVIF Device by default should do HTTP or RTSP digest challenge with MD5 hashing alogorithm as per RFC[2617].</para>
+        </section>
+      </section>
+	  <section>
+        <title>SetHashingAlgorithm</title>
+        <para>This operation sets the hashing algorithm(s) used in HTTP and RTSP Digest Authentication.</para>        
+        <variablelist role="op">
+          <varlistentry>
+            <term>request</term>
+            <listitem>
+              <para role="param">Algorithm [tds:StringList]</para>
+              <para role="text">Hashing algorithm(s) used in HTTP and RTSP Digest Authentication</para>              
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>response</term>
+            <listitem>
+              <para role="text">This is an empty message.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>faults</term>
+            <listitem>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:Argument Value Invalid</para>
+              <para role="text">The requested hashing algorithm(s) is invalid.</para>            
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>access class</term>
+            <listitem>
+              <para role="access">WRITE_SYSTEM</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
       </section>
       <section>
         <title>User-based access control</title>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -2167,7 +2167,7 @@ DATE: when response was generated
       <title>Security</title>
       <section>
         <title>Authentication</title>
-        <para>The services defined in this standard shall be protected using digest authentication according to [RFC 2617]and [RFC 7616] with the following exceptions.</para>
+        <para>The services defined in this standard shall be protected using digest authentication according to [RFC 2617] with the following exceptions.</para>
         <itemizedlist>
           <listitem>
             <para>legacy devices supporting [WS-UsernameToken] and</para>
@@ -2176,7 +2176,7 @@ DATE: when response was generated
             <para>TLS client authorization. </para>
           </listitem>
         </itemizedlist>
-        <para>If server supports both digest authentication as specified in [RFC 2617]and [RFC 7616] and the user name token profile as specified in WS-Security the following behavior shall be adapted: a web service request can be authenticated on the HTTP level via digest authentication [RFC 2617]and [RFC 7616] or on the web service level via the WS-Security (WSS) framework. If a client does not supply authentication credentials along with a web service request, the server shall assume that the client intends to use digest authentication [RFC 2617]and [RFC 7616], if required. Hence, if a client does not provide authentication credentials when requesting a service that requires authentication, it will receive an HTTP 401 error according to [RFC 2617]and [RFC 7616]. Note that this behaviour on the server’s side differs from the case of supporting only username token profile, which requires for this case an HTTP 400 error on the HTTP level and a SOAP:Fault env:Sender ter:NotAuthorized error on the WS level.</para>
+        <para>If server supports both digest authentication as specified in [RFC 2617] and the user name token profile as specified in WS-Security the following behavior shall be adapted: a web service request can be authenticated on the HTTP level via digest authentication [RFC 2617] or on the web service level via the WS-Security (WSS) framework. If a client does not supply authentication credentials along with a web service request, the server shall assume that the client intends to use digest authentication [RFC 2617], if required. Hence, if a client does not provide authentication credentials when requesting a service that requires authentication, it will receive an HTTP 401 error according to [RFC 2617]. Note that this behaviour on the server’s side differs from the case of supporting only username token profile, which requires for this case an HTTP 400 error on the HTTP level and a SOAP:Fault env:Sender ter:NotAuthorized error on the WS level.</para>
         <para>A client should not simultaneously supply authentication credentials on both the HTTP level and the WS level. If a server receives a web service request that contains authentication credentials on both the HTTP level and the WS level, it shall first validate the credentials provided on the HTTP layer. If this validation was successful, the server shall finally validate the authentication credentials provided on the WS layer.</para>
         <para>
           <xref linkend="AuthenticationFlow" /> summarizes the authentication of a web service request by a server.</para>
@@ -2190,33 +2190,56 @@ DATE: when response was generated
         </figure>
         <para>Both digest authentication and the user name token profile give only a rudimentary level of security. In a system where security is important, it is recommended to always configure the device for TLS-based access (see Advanced Security Service). Digest authentication or the user name token message level security combined with TLS, with client and server authentication, protected transport level security give an acceptable level of security in many systems.</para>
         <para>An ONVIF compliant device should authenticate an RTSP request at the RTSP level. If HTTP is used to tunnel the RTSP request the device shall not authenticate on the HTTP level.</para>
-        <para>When authenticating RTSP or HTTP methods, an ONVIF compliant device shall use digest authentication [RFC 2617]and [RFC 7616. The credentials shall be managed with the GetUsers, CreateUsers, DeleteUsers and SetUser methods. If the device also supports WS-Security, the same set of credentials shall be used.</para>
+        <para>When authenticating RTSP or HTTP methods, an ONVIF compliant device shall use digest authentication [RFC 2617]. The credentials shall be managed with the GetUsers, CreateUsers, DeleteUsers and SetUser methods. If the device also supports WS-Security, the same set of credentials shall be used.</para>
       </section>
 	  <section>
-	  <title>GetHashingAlgorithm</title>
-        <section>          
-          <para>ONVIF Client gets current hashing algorithm of ONVIF device by sending ONVIF HTTP or RTSP request with out Authorization header.Here ONVIF Device responds with a HTTP or RTSP 401 message according to [RFC 2617] [RFC 7616] that includes a challenge for each digest algorithm currently it was set, in its order of preference.</para>
-          <para>The example HTTP digest challenge response from ONVIF Device when ONVIF Device current hashing algorithams is MD5 and SHA-256 is as follows.</para>
-		  <programlisting><![CDATA[HTTP/1.1 401 Unauthorized
-				WWW-Authenticate: Digest
-					realm="http-auth@test.org",
-					qop="auth, auth-int",
-					algorithm=MD5,
-					nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v",
-					opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"
-				WWW-Authenticate: Digest
-					realm="http-auth@test.org",
-					qop="auth, auth-int",
-					algorithm=SHA-256,
-					nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v",
-					opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"]]>
+        <title>SHA-256 Support in HTTP and RTSP digest authentication</title>
+        <para>An ONVIF compliant device follows [RFC 7616] to support SHA-256 hashing algorithm in HTTP and RTSP digest authentication. An ONVIF device signals it's supported hashing algorthms via Security Capability HashingAlgorithms parameter.</para>
+		<para>Support of SHA-256 hashing algorithm is optional for ONVIF device and client.</para>      
+      <section>
+	  <title>GetHashingAlgorithm</title>               
+          <para>ONVIF Client can get current hashing algorithm of ONVIF device by sending HTTP or RTSP request without Authorization header. Here ONVIF Device responds with a HTTP or RTSP 401 message that includes a challenge for each digest algorithm currently it was set, in its order of preference.</para>
+          <para>There is no ONVIF API to get current hashing algorithm of a device, ONVIF Client can rely on HTTP or RTSP digest challenge response.</para>
+		  <para>The example HTTP request and response from ONVIF Device when device current hashing algorithm MD5 and SHA-256 is as follows. </para>
+		    <variablelist role="op">
+          <varlistentry>
+            <term>request</term>
+            <listitem>
+              <programlisting><![CDATA[POST /onvif/device_service HTTP/1.1
+Host: 10.XX.XX.XX
+Content-Type: application/soap+xml; charset=utf-8
+Content-Length: 299
+
+<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+<s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<GetDeviceInformation xmlns="http://www.onvif.org/ver10/device/wsdl"/>
+</s:Body></s:Envelope>]]>
+			</programlisting>             
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>response</term>
+            <listitem>
+              <programlisting><![CDATA[HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Digest algorithm=MD5, realm="Silvan_http_digest", qop="auth", 
+nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"
+WWW-Authenticate: Digest algorithm=SHA-256, realm="Silvan_http_digest", qop="auth", 
+nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"
+X-Frame-Options: SAMEORIGIN
+Content-Type: application/soap+xml; charset=utf-8
+Content-Length: 2785
+]]>
 			</programlisting>
-			<para>To maintain backward compatability with old ONVIF Client(s), ONVIF Device by default should do HTTP or RTSP digest challenge with MD5 hashing alogorithm as per RFC[2617].</para>
-        </section>
+            </listitem>
+          </varlistentry>     
+        </variablelist>		  
+			<para>To maintain backward compatibility with old ONVIF Client(s), ONVIF Device by default should do HTTP or RTSP digest challenge with MD5 hashing algorithm  as per RFC[2617].</para>        
       </section>
 	  <section>
         <title>SetHashingAlgorithm</title>
-        <para>This operation sets the hashing algorithm(s) used in HTTP and RTSP Digest Authentication.</para>        
+        <para>This operation sets the hashing algorithm(s) used in HTTP and RTSP Digest Authentication. A device follows [RFC 7616] shall support this operation.</para>        
         <variablelist role="op">
           <varlistentry>
             <term>request</term>
@@ -2246,6 +2269,7 @@ DATE: when response was generated
           </varlistentry>
         </variablelist>
       </section>
+	  </section>	  
       <section>
         <title>User-based access control</title>
         <section>
@@ -3024,7 +3048,7 @@ onvif://www.onvif.org/name/ARV-453
                   </entry>
                 </row>
                 <row>
-                  <entry morerows="15">
+                  <entry morerows="16">
                     <para>Security</para>
                   </entry>
                   <entry>
@@ -3152,6 +3176,14 @@ onvif://www.onvif.org/name/ARV-453
                   </entry>
                   <entry>
                     <para>Maximum number of passwords that the device can remember for each user. If the device does not support the password history this attribute should be zero or not present</para>
+                  </entry>
+                </row>
+				 <row>
+                  <entry>
+                    <para>HashingAlgorithms</para>
+                  </entry>
+                  <entry>
+                    <para>Indicates which hashing algorithms supported as part of HTTP and RTSP Digest authentication.</para>
                   </entry>
                 </row>
                 <row>

--- a/doc/media/Core/image5.svg
+++ b/doc/media/Core/image5.svg
@@ -273,7 +273,7 @@
          dx="0"
          dy="0"
          style="font-style:normal;font-variant:normal;font-weight:400;font-size:8.3125px;font-family:Arial;fill:#000000"
-         id="tspan93">2617</tspan></tspan></text>
+         id="tspan93">2617 and 7616</tspan></tspan></text>
   <path
      style="fill:none;stroke:#4677bf;stroke-width:0.23622048px;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      d="M 242.17323,109.39539 V 356.67098"

--- a/doc/media/Core/image5.svg
+++ b/doc/media/Core/image5.svg
@@ -273,7 +273,7 @@
          dx="0"
          dy="0"
          style="font-style:normal;font-variant:normal;font-weight:400;font-size:8.3125px;font-family:Arial;fill:#000000"
-         id="tspan93">2617 and 7616</tspan></tspan></text>
+         id="tspan93">2617</tspan></tspan></text>
   <path
      style="fill:none;stroke:#4677bf;stroke-width:0.23622048px;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      d="M 242.17323,109.39539 V 356.67098"

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -262,6 +262,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
                     				<xs:documentation>Maximum number of passwords that the device can remember for each user</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
+				<xs:attribute name="HashingAlgorithms" type="tt:StringList">
+					<xs:annotation>
+                    				<xs:documentation>Supported hashing algorithms as part of HTTP and RTSP Digest authentication.Example: MD5,SHA-256</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:complexType>
 			<!--===============================-->
@@ -2054,6 +2059,26 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:complexType>
 			</xs:element>
 			<!--===============================-->
+			<xs:element name="SetHashingAlgorithm">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Algorithm" type="tt:StringList">
+							<xs:annotation>
+								<xs:documentation>
+									Hashing algorithm(s) used in HTTP and RTSP Digest Authentication.
+								</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="SetHashingAlgorithmResponse">
+				<xs:complexType>
+					<xs:sequence>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<!--===============================-->
 			
 			<xs:complexType name="UserCredential">
 				<xs:sequence>
@@ -2860,6 +2885,12 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	<wsdl:message name="DeleteGeoLocationResponse">
 		<wsdl:part name="parameters" element="tds:DeleteGeoLocationResponse"/>
 	</wsdl:message>	
+	<wsdl:message name="SetHashingAlgorithmRequest">
+		<wsdl:part name="parameters" element="tds:SetHashingAlgorithm"/>
+	</wsdl:message>
+	<wsdl:message name="SetHashingAlgorithmResponse">
+		<wsdl:part name="parameters" element="tds:SetHashingAlgorithmResponse"/>
+	</wsdl:message>
 	
 	<wsdl:portType name="Device">
 		<wsdl:operation name="GetServices">
@@ -3472,6 +3503,13 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<wsdl:input message="tds:DeleteGeoLocationRequest"/>
 			<wsdl:output message="tds:DeleteGeoLocationResponse"/>
 		</wsdl:operation>
+		<wsdl:operation name="SetHashingAlgorithm">
+		<wsdl:documentation>
+				This operation sets the hashing algorithm(s) used in HTTP and RTSP Digest Authentication.
+			</wsdl:documentation>
+			<wsdl:input message="tds:SetHashingAlgorithmRequest"/>
+			<wsdl:output message="tds:SetHashingAlgorithmResponse"/>
+		</wsdl:operation>
 
 		<!--===============================-->
 		<!--The definition and interfaces for the Security have been deprecated with release 16.12
@@ -3549,7 +3587,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<wsdl:operation name="DeleteDot1XConfiguration">
 			<wsdl:input message="tds:DeleteDot1XConfigurationRequest"/>
 			<wsdl:output message="tds:DeleteDot1XConfigurationResponse"/>
-		</wsdl:operation>
+		</wsdl:operation>		
 		<!--===============================-->
 
 	</wsdl:portType>
@@ -4432,6 +4470,15 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		</wsdl:operation>
 		<wsdl:operation name="DeleteGeoLocation">
 			<soap:operation soapAction="http://www.onvif.org/ver10/device/wsdl/DeleteGeoLocation"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="SetHashingAlgorithm">
+			<soap:operation soapAction="http://www.onvif.org/ver10/device/wsdl/SetHashingAlgorithm"/>
 			<wsdl:input>
 				<soap:body use="literal"/>
 			</wsdl:input>


### PR DESCRIPTION
HTTP Digest Authentication - SHA 256 support as per RFC 7616.