### PR TITLE
Do not require to support multiple identical pathes.

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -985,7 +985,8 @@ Added certificate-based client authentication</revremark>
       <section>
         <title>Uniqueness of Objects in the Keystore</title>
         <para>A device shall allow multiple copies of the same passphrase to be present in the keystore under different IDs simultaneously.</para>
-        <para>A device shall allow multiple copies of the same certificate and multiple copies of the same certification path to be present in the keystore under different IDs, respectively.</para>
+        <para>A device shall allow multiple copies of the same certificate to be present in the
+          keystore under different IDs, respectively.</para>
         <para>A device shall allow multiple copies of the same certificate revocation list to be present in the keystore under different IDs, respectively.</para>
         <para>A device shall allow multiple copies of the same certification path validation policy to be present in the keystore under different IDs, respectively.</para>
         <para>A device shall allow multiple copies of the same IEEE 802.1X configuration to be present in the keystore under different IDs simultaneously.</para>


### PR DESCRIPTION
Supporting multiple identical certificate pathes doesn't make any sense and make implementations based on standard cert stores difficult since many of them do not store pathes explicitly but build them based on certificate roles.