### PR TITLE
Remove CRL requirement on client authentication.

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -3817,7 +3817,6 @@ Added certificate-based client authentication</revremark>
                   </itemizedlist>
                   <para>If true, TLSServerSupported shall not be empty.</para>
                   <para>If true, MaximumNumberOfCertificationPathValidationPolicies&gt;=2 and MaximumNumberOfTLSCertificationPathValidationPolicies&gt;0 shall hold.</para>
-                  <para>If true, MaximumNumberOfCRLs&gt;0 shall hold.</para>
                   <para>If true, the device shall support</para>
                   <itemizedlist>
                     <listitem>


### PR DESCRIPTION
The concept of certificate revocation lists is questionable and partially replaced by OSCP. 
Propose to drop implicit requirement to support CRLs when client authentication is supported.

This PR keeps the CRL APIs unchanged. Also signaling for CRL support via MaximumNumberOfCRLs is unchanged.