### PR TITLE
Add object movement direction in Behavior

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -1211,7 +1211,7 @@
         </section>
         <section>
           <title>Speed descriptor</title>
-          <para>The SpeedDescriptor describes the speed value of the object. The unit is meters per second.</para>
+          <para>The Speed element describes the speed value of the object. The unit is meters per second.</para>
           <para>An example metadata containing speed information of the detected object is given below.</para>
           <programlisting><![CDATA[<tt:VideoAnalytics>
   <tt:Frame UtcTime="2016-9-10T12:24:57.321">
@@ -1225,6 +1225,36 @@
 ]]></programlisting>
         </section>
         <section>
+          <title>Direction descriptor</title>
+          <para>The Direction element describes the movement direction of the object as a
+          GeoOrientation type with the angles yaw (ψ) and pitch (θ). Roll (ϕ) is not used. The range
+          for yaw is between -180 and +180 degrees. Where 0 is towards the right of the viewer and
+          90 is away from the viewer. The range for pitch is between 90 and -90 degrees where 90 is
+          upwards.</para>
+        <figure>
+          <title>Orientation on earth surface<footnote>
+              <para>Source: By Qniemiec, CC BY-SA 3.0,
+                https://commons.wikimedia.org/w/index.php?curid=10893168</para>
+            </footnote></title>
+          <mediaobject>
+            <imageobject>
+              <imagedata fileref="media/Core/image4.png" contentwidth="79.59mm"/>
+            </imageobject>
+          </mediaobject>
+        </figure>
+          <para>An example metadata containing direction information of the detected object is given below.</para>
+          <programlisting><![CDATA[<tt:VideoAnalytics>
+<tt:Frame UtcTime="2016-9-10T12:24:57.321">
+  <tt:Object ObjectId="23">
+    <tt:Behaviour>
+      <tt:Direction yaw=38.8 pitch=15.5/>
+    </tt:Behaviour>
+  </tt:Object>
+</tt:Frame>
+</tt:VideoAnalytics>
+]]></programlisting>
+      </section>
+      <section>
           <title>License plate information descriptor</title>
           <para>The license plate detail descriptor defines an optional extension of the object appearance node. It is used to extend the details of the vehicle license plate information. The details are shown in <xref linkend="_Ref517429752" />. For each element, there is a class, which is asscociated with a likelihood. A likelihood/probability means the corresponding object belongs to this class. The default value is 1. Missing likelihood attribute means 100%.</para>
           <table xml:id="_Ref517429752">

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -1227,11 +1227,13 @@
         <section>
           <title>Direction descriptor</title>
           <para>The Direction element describes the movement direction of the object as a
-          GeoOrientation type with the angles yaw (ψ) and pitch (θ). Roll (ϕ) is not used. The range
-          for yaw is between -180 and +180 degrees. Where 0 is towards the right of the viewer and
-          90 is away from the viewer. The range for pitch is between 90 and -90 degrees where 90 is
-          upwards.</para>
-        <figure>
+          GeoOrientation type with the angles yaw (ψ) and pitch (θ). The origin is the device itself
+          and the x axis is rightwards, the y axis is away from the device and the z axis is
+          upwards, i.e. "body frame" coordinate system according to <xref
+            linkend="figure_bqn_z5f_fvb"/>. The range for yaw is between -180 and +180 degrees,
+          where 0 is rightwards and 90 is away from the device. The range for pitch is between 90
+          and -90 degrees where 90 is upwards.</para>
+        <figure xml:id="figure_bqn_z5f_fvb">
           <title>Orientation on earth surface<footnote>
               <para>Source: By Qniemiec, CC BY-SA 3.0,
                 https://commons.wikimedia.org/w/index.php?curid=10893168</para>

--- a/wsdl/ver10/schema/metadatastream.xsd
+++ b/wsdl/ver10/schema/metadatastream.xsd
@@ -284,7 +284,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:element name="Speed" type="xs:float" minOccurs="0"/>
 			<xs:element name="Direction" type="tt:GeoOrientation" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Direction the object is moving. Yaw describes the horizontal direction in the range [-180..180] where 0 is towards the right of the viewer and 90 is away from the viewer. Pitch describes the vertical direction in the range [-90..90] where 90 is upwards.</xs:documentation>
+					<xs:documentation>Direction the object is moving. Yaw describes the horizontal direction in the range [-180..180] where 0 is towards the right of the device and 90 is away from the device. Pitch describes the vertical direction in the range [-90..90] where 90 is upwards.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- reserved for ONVIF -->

--- a/wsdl/ver10/schema/metadatastream.xsd
+++ b/wsdl/ver10/schema/metadatastream.xsd
@@ -282,6 +282,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:element name="Extension" type="tt:BehaviourExtension" minOccurs="0"/>
 			<xs:element name="Speed" type="xs:float" minOccurs="0"/>
+			<xs:element name="Direction" type="tt:GeoOrientation" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Direction the object is moving. Yaw describes the horizontal direction in the range [-180..180] where 0 is towards the right of the viewer and 90 is away from the viewer. Pitch describes the vertical direction in the range [-90..90] where 90 is upwards.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- reserved for ONVIF -->
 		</xs:sequence>
 		<xs:anyAttribute processContents="lax"/>


### PR DESCRIPTION
Add object movement direction as tt:GeoOrientation in Behavior. Yaw describes the horizontal direction in the range [-180..180] where 0 is towards the right of the viewer and 90 is away from the viewer. Pitch describes the vertical direction in the range [-90..90] where 90 is upwards.