### PR TITLE
Move any element as last element

### DIFF
--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -851,7 +851,6 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	<!--===============================-->
 	<xs:complexType name="VideoEncoderOptionsExtension">
 		<xs:sequence>
-			<xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="JPEG" type="tt:JpegOptions2" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Optional JPEG encoder settings ranges.</xs:documentation>
@@ -868,6 +867,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Extension" type="tt:VideoEncoderOptionsExtension2" minOccurs="0"/>
+			<xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<!--===============================-->


### PR DESCRIPTION
Moving the any element to the last position is required, otherwise parsers will put the elements specified after into the any element