### PR TITLE
Add missing default access class definitions.

### DIFF
--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -273,6 +273,12 @@
             <para role="text">List of configurations.</para>
           </listitem>
         </varlistentry> 
+        <varlistentry>
+          <term>access class</term>
+          <listitem>
+            <para role="access">READ_SYSTEM</para>
+          </listitem>
+        </varlistentry>
       </variablelist>
     </section>
     <section>
@@ -292,6 +298,12 @@
           <para role="text">This message is empty</para>
         </listitem>
         </varlistentry> 
+        <varlistentry>
+          <term>access class</term>
+          <listitem>
+            <para role="access">WRITE_SYSTEM</para>
+          </listitem>
+        </varlistentry>
       </variablelist>
     </section>
     <section>
@@ -311,6 +323,12 @@
             <para role="text">This message is empty</para>
           </listitem>
         </varlistentry> 
+        <varlistentry>
+          <term>access class</term>
+          <listitem>
+            <para role="access">WRITE_SYSTEM</para>
+          </listitem>
+        </varlistentry>
       </variablelist>
     </section>
     <section>


### PR DESCRIPTION
Default access class definitions were lacking.

The defaults were chosen according to core specification network configuration settings.