### PR TITLE
Generalize the audio classification event

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -3753,7 +3753,7 @@ xmlns:acme="http://www.acme.com/schema"&gt;
       <section>
         <title>Audio Detected (deprecated)</title>
         <para>Analytics engine can send the following event for analyzed audio data. This event is
-          deprecated in favor events described in <xref linkend="appendix_hw3_vnr_nwb"/>.</para>
+          deprecated in favor of events described in <xref linkend="appendix_hw3_vnr_nwb"/>.</para>
         <programlisting><![CDATA[<tt:MessageDescription IsProperty=“false">
   <tt:Source>
     <tt:SimpleItemDescription Name=“AudioSourceConfigurationToken"
@@ -7289,8 +7289,7 @@ xmlns:acme="http://www.acme.com/schema"&gt;
     <title>Audio analytics (normative)</title>
     <section>
       <title>Audio Classification</title>
-      <para>An analytics or rule engine can send the following event for detected audio
-        classes.</para>
+      <para>A rule engine can send the following event for detected audio classes.</para>
       <programlisting><![CDATA[<tt:RuleDescription Name="tt:AudioClassDetector">
   <tt:Parameters>
     <tt:SimpleItemDescription Name="ClassFilter" Type="tt:StringList"/>

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -3751,8 +3751,9 @@ xmlns:acme="http://www.acme.com/schema"&gt;
     <section>
       <title>Events</title>
       <section>
-        <title>Audio Detected</title>
-        <para>Analytics engine can send the following event for analyzed audio data.</para>
+        <title>Audio Detected (deprecated)</title>
+        <para>Analytics engine can send the following event for analyzed audio data. This event is
+          deprecated in favor events described in <xref linkend="appendix_hw3_vnr_nwb"/>.</para>
         <programlisting><![CDATA[<tt:MessageDescription IsProperty=“false">
   <tt:Source>
     <tt:SimpleItemDescription Name=“AudioSourceConfigurationToken"
@@ -3769,8 +3770,7 @@ xmlns:acme="http://www.acme.com/schema"&gt;
   </tt:Data >
   <tt:ParentTopic>tns1:AudioAnalytics/Audio/DetectedSound
   </tt:ParentTopic>
-</tt:MessageDescription>
-]]></programlisting>
+</tt:MessageDescription>]]></programlisting>
         <para>The Rule field is optional and contains the Rule instance name that generated the audio detected event.</para>
       </section>
     </section>
@@ -7283,6 +7283,74 @@ xmlns:acme="http://www.acme.com/schema"&gt;
       <para>If the IncludeImage configuration parameter is set to an empty string, device shall not include VehicleImage and VehicleImageURI event fields in the event message.</para>
       <para>If the IncludeImage configuration parameter is set as Embedded, device shall include VehicleImage event field in the event message.</para>
       <para>If the IncludeImage configuration parameter is set as LocalStorage or RemoteStorage, device shall include VehicleImageURI event field in the event message.</para>
+    </section>
+  </appendix>
+  <appendix xml:id="appendix_hw3_vnr_nwb">
+    <title>Audio analytics (normative)</title>
+    <section>
+      <title>Audio Classification</title>
+      <para>An analytics or rule engine can send the following event for detected audio
+        classes.</para>
+      <programlisting><![CDATA[<tt:RuleDescription Name="tt:AudioClassDetector">
+  <tt:Parameters>
+    <tt:SimpleItemDescription Name="ClassFilter" Type="tt:StringList"/>
+    <tt:SimpleItemDescription Name="ConfidenceLevel" Type="xs:float"/>
+  </tt:Parameters>
+  <tt:Messages>
+    <tt:MessageDescription IsProperty="false">
+      <tt:Source>
+        <tt:SimpleItemDescription Name="AudioSource" Type="tt:ReferenceToken"/>
+        <tt:SimpleItemDescription Name="AnalyticsConfiguration" Type="tt:ReferenceToken"/>
+        <tt:SimpleItemDescription Name="Rule" Type="xs:string"/>
+      </tt:Source>
+      <tt:Data>
+        <tt:SimpleItemDescription Name="Class" Type="tt:StringList"/>
+        <tt:SimpleItemDescription Name="Score" Type="tt:FloatList"/>
+      </tt:Data >
+      <tt:ParentTopic>tns1:RuleEngine/AudioDetector/Class</tt:ParentTopic>
+    </tt:MessageDescription>
+  <tt:Messages>
+</tt:RuleDescription>
+]]></programlisting>
+      <variablelist role="op">
+        <varlistentry>
+          <term>Parameters</term>
+          <listitem>
+            <para role="param">ClassFilter - optional [tt:StringList]</para>
+            <para role="text">List of classes that the rule should operate on chosen from
+              tt:AudioClassification.</para>
+            <para role="param">ConfidenceLevel - optional [xs:float]</para>
+            <para role="text">Minimum confidence level for accepting a classification. </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Topic</term>
+          <listitem>
+            <para role="text">tns1:RuleEngine/AudioDetector/Class</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Source</term>
+          <listitem>
+            <para role="param">AudioSource [tt:ReferenceToken]</para>
+            <para role="text">The token of the audio source.</para>
+            <para role="param">AnalyticsConfiguration - optional [tt:ReferenceToken]</para>
+            <para role="text">Optional token of the analytics configuration this rule belongs
+              to.</para>
+            <para role="param">Rule - optional [xs:string]</para>
+            <para role="text">Optional name of the Rule that generated the event.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Data</term>
+          <listitem>
+            <para role="param">Class [tt:StringList]</para>
+            <para role="text">List of detected audio classifications of type tt:AudioClassification. </para>
+            <para role="param">Score - optional [tt:FloatList]</para>
+            <para role="text">Optional list of scores of detected audio classifications. </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
     </section>
   </appendix>
   <appendix role="revhistory">

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -622,7 +622,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="tt:Fisheye">
-				<xs:annotation>	
+				<xs:annotation>
 					<xs:documentation>Undewarped viewmode from device supporting fisheye lens.</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
@@ -652,7 +652,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="tt:RightHalf">
-				<xs:annotation>	
+				<xs:annotation>
 					<xs:documentation>Viewmode combining the right side sensors, applicable for devices supporting multiple sensors.</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
@@ -4430,7 +4430,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 				<xs:documentation>
 					The list of acceleration ramps supported by the device. The
 					smallest acceleration value corresponds to the minimal index, the
-					highest acceleration corresponds to the maximum index.					
+					highest acceleration corresponds to the maximum index.
 				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
@@ -4993,7 +4993,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			<xs:enumeration value="PTZVector"/>
 			<xs:enumeration value="ObjectID"/>
 		</xs:restriction>
-	</xs:simpleType>			
+	</xs:simpleType>
 	<!--===============================-->
 	<!--     End, PTZ Related Types    -->
 	<!--===============================-->
@@ -6530,7 +6530,7 @@ If set to 0.0, infinity will be used.</xs:documentation>
 			<xs:enumeration value="LocalStorage"/>
 			<xs:enumeration value="RemoteStorage"/>
 		</xs:restriction>
-	</xs:simpleType>			
+	</xs:simpleType>
 	<!--===============================-->
 	<xs:simpleType name="PropertyOperation">
 		<xs:restriction base="xs:string">
@@ -8405,11 +8405,12 @@ and sample rate. </xs:documentation>
         <!--=========================================-->
 	<!--  Begin, Audio event types               -->
 	<!--=========================================-->
+	<!-- Old audio classification types, non-extensible. -->
 	<xs:simpleType name="AudioClassType">
 		<xs:annotation>
 		<xs:documentation>
 		  AudioClassType acceptable values are;
-		   gun_shot, scream, glass_breaking, tire_screech   
+		   gun_shot, scream, glass_breaking, tire_screech
 		</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
@@ -8417,6 +8418,17 @@ and sample rate. </xs:documentation>
 			<xs:enumeration value="scream"/>
 			<xs:enumeration value="glass_breaking"/>
 			<xs:enumeration value="tire_screech"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<!-- New audio classification types, extensible, for documentation purpose only. -->
+	<xs:simpleType name="AudioClassification">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="GunShot"/>
+			<xs:enumeration value="Scream"/>
+			<xs:enumeration value="GlassBreaking"/>
+			<xs:enumeration value="TireScreech"/>
+			<xs:enumeration value="Alarm"/>
 		</xs:restriction>
 	</xs:simpleType>
 
@@ -8431,7 +8443,7 @@ and sample rate. </xs:documentation>
 			<xs:annotation>
 			<xs:documentation>A likelihood/probability that the corresponding audio event belongs to this class. The sum of the likelihoods shall NOT exceed 1</xs:documentation>
 			</xs:annotation>
-		</xs:element>  
+		</xs:element>
 		<xs:any namespace="##targetNamespace" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 	</xs:sequence>
 	<xs:anyAttribute processContents="lax"/>


### PR DESCRIPTION
The audio classification event tns1:AudioAnalytics/Audio/DetectedSound includes an AudioClassDescriptor which includes 0 or more AudioClassCandidate. AudioClassCandidate has a Type and Likelihood but the Type is an enum which could be problematic to extend because some XML parsers would break. So this limits us to only detect the types that are defined in the enum: gun_shot, scream, glass_breaking and tire_screetch. Because of this I suggest to add a new Type element in AudioClassDescriptor in the same way as we did for the video ClassDescriptor, thus allowing us to use a string instead of an enum.