### PR TITLE
Clarify recording job configuration edge cases

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -444,9 +444,11 @@ Change Request 2061, 2063, 2065, 2109</revremark>
         <para>
           <emphasis role="bold">SourceToken</emphasis>: This field shall be a reference to the source of the data. The type of the source is determined by the attribute Type in the SourceToken structure. If Type is http://www.onvif.org/ver10/schema/Receiver, the token is a ReceiverReference. In this case the device shall receive the data over the network. If Type is http://www.onvif.org/ver10/schema/Profile, the token identifies a media profile, instructing the device to obtain data from a profile that exists on the local device. </para>
         <para>A device that includes the ONVIF Media Service shall support a Media Profile token and a device that includes the ONVIF Receiver Service shall support a Receiver token.</para>
-        <para>If the <emphasis role="bold">SourceToken</emphasis> is omitted, <emphasis role="bold">AutoCreateRecevier</emphasis> shall be true.</para>
         <para>
-          <emphasis role="bold">AutoCreateReceiver</emphasis>: If this field is TRUE, and if the <emphasis role="bold">SourceToken</emphasis> is omitted, the device shall create a receiver object (through the receiver service) and assign the ReceiverReference to the <emphasis role="bold">SourceToken</emphasis> field. When retrieving the RecordingJobConfiguration from the device, the <emphasis role="bold">AutoCreateReceiver</emphasis> field shall never be present.</para>
+          <emphasis role="bold">AutoCreateReceiver</emphasis>: If a request includes this field set to true and no source token is provided, the device shall create a
+          receiver object (through the receiver service) and assign the ReceiverReference to the
+          <emphasis role="bold">SourceToken</emphasis> field. A device shall never report this parameter in a 
+          RecordingJobConfiguration. A device may reject a request that neither contains a SourceToken nor AutoCreateRecevier set to true.</para>
         <para>
           <emphasis role="bold">SourceTag</emphasis>: If the received RTSP stream contains multiple tracks of the same type, the <emphasis role="bold">SourceTag</emphasis> differentiates between those Tracks.</para>
         <para>

--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -430,7 +430,12 @@ Change Request 2061, 2063, 2065, 2109</revremark>
         <para>
           <emphasis role="bold">Mode</emphasis>: If it is idle, nothing shall happen. If it is active and the recording job has the highest priority, the device shall try to obtain data from the receivers. A client shall use GetRecordingJobState to determine if data transfer is really taking place. The only valid values for Mode shall be “Idle” and “Active”.</para>
         <para>
-          <emphasis role="bold">Priority</emphasis>: This shall be a non-negative number. If there are multiple recording jobs that store data to the same track, the device will only store the data for the recording job with the highest priority. The priority is specified per recording job, but the device shall determine the priority of each track individually. If there are two recording jobs with the same priority, the device shall record the data corresponding to the recording job that was activated the latest.</para>
+          <emphasis role="bold">Priority</emphasis>: This shall be a non-negative number. If there
+          are multiple recording jobs that store data to the same track, the device shall only store
+          data for the recording job with the highest priority. The priority is specified per
+          recording job, but the device shall determine the priority of each track individually. If
+          there are multiple recording jobs with the same highest priority it is undefind which of
+          them is activated.</para>
         <para>The value 0 indicates the lowest priority. Higher values shall indicate a higher priority.</para>
         <para>
           <emphasis role="bold">ScheduleToken:</emphasis> This attribute adds an additional requirement for activating the recording job. If this optional field is provided the job shall only record if the schedule exists and is active.</para>

--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -875,6 +875,8 @@ Change Request 2061, 2063, 2065, 2109</revremark>
     <section>
       <title>CreateRecordingJob</title>
       <para>CreateRecordingJob shall create a new recording job. A device shall support adding a RecordingJob to a recording for which it signals Spare jobs via GetRecordingOptions.</para>
+      <para>A device should reject a configuration that neither includes a source with a source token nor AutoCreateReceiver set to true.</para>
+      <para>If the configuration doesn not include any tracks a device should assign all tracks of the corresponding recording.</para>
       <variablelist role="op">
         <varlistentry>
           <term>request</term>
@@ -912,7 +914,10 @@ Change Request 2061, 2063, 2065, 2109</revremark>
           </listitem>
         </varlistentry>
       </variablelist>
-      <para>The JobConfiguration returned from CreateRecordingJob shall be identical to the JobConfiguration passed into CreateRecordingJob, except for the ReceiverToken and the AutoCreateReceiver. In the returned structure, the ReceiverToken shall be present and valid and the AutoCreateReceiver field shall be omitted.</para>
+      <para>If a request with AutoCreateReceiver is accepted the response shall provide the attached
+        receiver token and the AutoCreateReceiver field shall be omitted.</para>
+      <para>The device response shall include the complete JobConfiguration including the associated
+        job token and the resulting recording track configuration.</para>
     </section>
     <section xml:id="_Toc246137491">
       <title>DeleteRecordingJob</title>


### PR DESCRIPTION
The specification includes two problematic statements:
1. Both create and modify recording job APIs state that the response shall be identical to the request which in fact inhibits any extensions of the existing API.
2. There is a client requirement on how to use the combination of AutoCreateReceiver and source token.
3. Weaken requirement on same priority, since its behavior is hard to guarantee across complex sequences and reboots.

Only the third item includes a possible change in behavior. Assigning same priority to different jobs can be seen as a client side miss configuration. Implementing it seems to be impossible in corner cases.