### PR TITLE
Make complex ElementItem in event conditional.

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -1501,6 +1501,7 @@ Change Request 2061, 2063, 2065, 2109</revremark>
   </tt:Data> 
 </tt:MessageDescription>
 ]]></programlisting>
+        <para>The ElementItem Information shall be provided whenever the state of the different tracks is not unique. It can be omitted when the state of all tracks of a recording is consistent.</para>
 </section>
       <section>
         <title>Configuration changes</title>


### PR DESCRIPTION
With the introduction of event based recording the event  ```tns1:RecordingConfig/JobState``` may be raised frequently. It's current definition requires to send the following quite extensive amount of mostly redundant information each time for up to three tracks:
```
    RecordingToken [RecordingReference]
    Identification of the recording that the recording job records to.
    State [RecordingJobState]
          Holds the aggregated state over the whole RecordingJobInformation structure.
    Sources - optional, unbounded; [RecordingJobStateSource]
          Identifies the data source of the recording job.
        SourceToken [SourceReference]
               Identifies the data source of the recording job.
            Type - optional; [anyURI]
            Token [ReferenceToken]
        State [RecordingJobState]
               Holds the aggregated state over all substructures of RecordingJobStateSource.
        Tracks [RecordingJobStateTracks]
               ist of track items.
            Track - optional, unbounded; [RecordingJobStateTrack]
                SourceTag [string]
                       Identifies the track of the data source that provides the data.
                Destination [TrackReference]
                       ndicates the destination track.
                Error - optional; [string]
                       Optionally holds an implementation defined string value that describes the error. The string should be in the English language.
                State [RecordingJobState]
                       Provides the job state of the track. The valid values of state shall be “Idle”, “Active” and “Error”. If state equals “Error”, the Error field may be filled in with an implementation defined value.
```
This PR suggests to only require the ElementItem when the State of the tracks differ, because only in this case the element item provides additional information.

Please note that this ticket requires lowering of requirements in DTT test case RECORDING-5-1-19. In case this changes gets positive feedback I would file a related DTT ticket.