### PR TITLE
Rotate (VSC) behavior clarification

### DIFF
--- a/doc/Media2.xml
+++ b/doc/Media2.xml
@@ -911,6 +911,7 @@
           Bounds and VideoSource define the image that is streamed to a client. The origin of the
           bounds is located in the upper left corner of the video source.</para>
         <para>The Rotate option specifies an optional rotation of the area defined by the Bounds parameters. Note that in case of e.g. a 90 degree rotation the width parameter corresponds to the height of the Video and vice versa.</para>
+        <para>A device that supports Rotation shall return current rotaion state in correspondig VideoSourceConfiguration.</para>
         <para>All coordinate systems (e.g. Normalized coordinate system of Privacy Masks in the Media2 Service and pixel based coordinate system of Motion Regions in the Analytics service) that apply to a video source configuration are based on the resulting image after applying the bounds and rotation to the source image.</para>
         <para>The Lens Description option allows to describe the geometric distortion of the Video Source. For details see <xref linkend="_Ref425846456" />.</para>
         <para>The Scene Orientation options allow a description of the orientation of the scene the video source is capturing. The Scene Orientation can be Below (from the ceiling), Above (from the floor or a table) and Horizon (on a wall). Some devices may support detecting the Scene Orientation automatically.</para>
@@ -1150,6 +1151,7 @@
         </variablelist>
         <para>Note for the VideoEncoderConfiguration: if necessary the device may adapt parameter values for Quality and RateControl elements without returning an error. A device shall adapt an out of range BitrateLimit instead of returning a fault.</para>
         <para>Note for the AudioSourceConfiguration: If the new settings invalidate any parameters already negotiated using RTSP, for example by changing codec type, the device must not apply these settings to existing streams. Instead it must either continue to stream using the old settings or stop sending data on the affected streams.</para>
+        <para>Note for the VideoSourceConfiguration: If a Device supports Rotation and the new settings do not contain Rotate element, a device shall keep current rotation state.</para>
       </section>
       <section>
         <title>Get&lt;entity&gt;ConfigurationOptions</title>


### PR DESCRIPTION
This PR contains clarification of Rotate behave
- Device requirement to return Rotate element in VSC if rotation is supported.
- Clarification how a device shall behave when SetVSC request does not contain Rotate element. 