### PR TITLE
Remove obsolete passphrase reuqirement.

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -3568,7 +3568,6 @@ Added certificate-based client authentication</revremark>
                       <para>UploadKeyPairInPKCS8</para>
                     </listitem>
                   </itemizedlist>
-                  <para>If true, MaximumNumberOfPassphrases &gt;0 shall hold.</para>
                   <para>If true, MaximumNumberOfKeys &gt; 0 shall hold.</para>
                   <para>If true, the list of supported RSA key lengths as indicated by the RSAKeyLenghts capability shall not be empty.</para>
                   <para>If true, the list of supported password-based encryption algorithms as indicated by the PasswordBasedEncryptionAlgorithms capability shall contain at least the algorithm <phrase>pbeWithSHAAnd3-KeyTripleDES-CBC</phrase>.</para>
@@ -3603,7 +3602,6 @@ Added certificate-based client authentication</revremark>
                       <para>DeleteCertificationPath</para>
                     </listitem>
                   </itemizedlist>
-                  <para>If true, MaximumNumberOfPassphrases &gt;0 shall hold.</para>
                   <para>If true, MaximumNumberOfKeys &gt;=2 shall hold.</para>
                   <para>If true, MaximumNumberOfCertificates &gt;=2 shall hold.</para>
                   <para>If true, MaximumNumberOfCertificattionPaths &gt;0 shall hold.</para>


### PR DESCRIPTION
APIs have been extended to provide passphrases diredtly without using passphrase manager.