### PR TITLE
Editorial layout fixes without textual changes.

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -2423,7 +2423,7 @@ Added certificate-based client authentication</revremark>
               <term>request</term>
               <listitem>
                 <para role="param">CertificationPathID - [tas:CertificationPathID] </para>
-                <para role="param">The ID of the certification path to assign to the TLS
+                <para role="text">The ID of the certification path to assign to the TLS
                   server.</para>
               </listitem>
             </varlistentry>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -2422,7 +2422,9 @@ Added certificate-based client authentication</revremark>
             <varlistentry>
               <term>request</term>
               <listitem>
-                <para role="param">CertificationPathID - [tas:CertificationPathID] The ID of the certification path to assign to the TLS server.</para>
+                <para role="param">CertificationPathID - [tas:CertificationPathID] </para>
+                <para role="param">The ID of the certification path to assign to the TLS
+                  server.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
@@ -2434,9 +2436,12 @@ Added certificate-based client authentication</revremark>
             <varlistentry>
               <term>faults</term>
               <listitem>
-                <para role="param">env:Sender - ter:InvalidArgVal - ter:CertificationPathID No certification path is stored in the keystore under the given certification path ID.</para>
-                <para role="param">env:Sender - ter:InvalidArgVal - ter:NoPrivateKey The key pair that is associated with the first certificate in the certificate chain does not have an associated private key.</para>
-                <para role="param">env: Receiver - ter: Action - ter:MaximumNumberOfTLSCertificationPathsReached The maximum number of certification paths that may be assigned to the TLS server simultaneously is reached.</para>
+                <para role="param">env:Sender - ter:InvalidArgVal - ter:CertificationPathID </para>
+                <para role="text">No certification path is stored in the keystore under the given certification path ID.</para>
+                <para role="param">env:Sender - ter:InvalidArgVal - ter:NoPrivateKey </para>
+                <para role="text">The key pair that is associated with the first certificate in the certificate chain does not have an associated private key.</para>
+                <para role="param">env: Receiver - ter: Action - ter:MaximumNumberOfTLSCertificationPathsReached </para>
+                <para role="text">The maximum number of certification paths that may be assigned to the TLS server simultaneously is reached.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
@@ -2633,7 +2638,8 @@ Added certificate-based client authentication</revremark>
             <varlistentry>
               <term>request</term>
               <listitem>
-                <para role="param">cnMapsToUser - [xs:boolean] A request for the device to enable or disable Common Name Mapping to User.</para>
+                <para role="param">cnMapsToUser - [xs:boolean]</para>
+                <para role="text">A request for the device to enable or disable Common Name Mapping to User.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
@@ -2645,7 +2651,8 @@ Added certificate-based client authentication</revremark>
             <varlistentry>
               <term>faults</term>
               <listitem>
-                <para role="param">env:Receiver - ter:ActionNotSupported - ter:CnMapsToUserFailed The device does not support TLS client authentication, or TLS client authentication is not configured appropriately.</para>
+                <para role="param">env:Receiver - ter:ActionNotSupported - ter:CnMapsToUserFailed </para>
+                <para role="text">The device does not support TLS client authentication, or TLS client authentication is not configured appropriately.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
@@ -2663,13 +2670,14 @@ Added certificate-based client authentication</revremark>
             <varlistentry>
               <term>request</term>
               <listitem>
-                <para role="param">This message is empty.</para>
+                <para role="text">This message is empty.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
               <term>response</term>
               <listitem>
-                <para role="text">cnMapsToUser - [xs:boolean] Whether cnMapsToUser is enabled.</para>
+                <para role="param">cnMapsToUser - [xs:boolean] </para>
+                <para role="text">Whether cnMapsToUser is enabled.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
@@ -2695,7 +2703,9 @@ Added certificate-based client authentication</revremark>
             <varlistentry>
               <term>request</term>
               <listitem>
-                <para role="param">CertPathValidationPolicyID - [tas:CertPathValidationPolicyID] The ID of the certification path validation policy to assign to the TLS server.</para>
+                <para role="param">CertPathValidationPolicyID - [tas:CertPathValidationPolicyID] </para>
+                <para role="text">The ID of the certification path validation policy to assign to
+                  the TLS server.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
@@ -2707,8 +2717,11 @@ Added certificate-based client authentication</revremark>
             <varlistentry>
               <term>faults</term>
               <listitem>
-                <para role="param">env:Sender - ter:InvalidArgVal - ter:CertPathValidationPolicyID No certification path validation policy is stored under the requested CertPathValidationPolicyID.</para>
-                <para role="param">env:Receiver - ter:Action - ter:MaximumNumberOfTLSCertPathValidationPoliciesReached The maximum number of certification path validation policies that may be assigned to the TLS server simultaneously is reached.</para>
+                <para role="param">env:Sender - ter:InvalidArgVal - ter:CertPathValidationPolicyID </para>
+                <para role="text">No certification path validation policy is stored under the
+                  requested CertPathValidationPolicyID.</para>
+                <para role="param">env:Receiver - ter:Action - ter:MaximumNumberOfTLSCertPathValidationPoliciesReached </para>
+                <para role="text">The maximum number of certification path validation policies that may be assigned to the TLS server simultaneously is reached.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
@@ -2727,7 +2740,8 @@ Added certificate-based client authentication</revremark>
             <varlistentry>
               <term>request</term>
               <listitem>
-                <para role="param">CertPathValidationPolicyID - [tas:CertPathValidationPolicyID] The ID of the certification path validation policy to remove from the TLS server.</para>
+                <para role="param">CertPathValidationPolicyID - [tas:CertPathValidationPolicyID] </para>
+                <para role="text">The ID of the certification path validation policy to remove from the TLS server.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
@@ -2739,7 +2753,8 @@ Added certificate-based client authentication</revremark>
             <varlistentry>
               <term>faults</term>
               <listitem>
-                <para role="param">env:Sender - ter:InvalidArgVal - ter:CertPathValidationPolicyID No certification path validation policy is stored under the requested CertPathValidationPolicyID.</para>
+                <para role="param">env:Sender - ter:InvalidArgVal - ter:CertPathValidationPolicyID </para>
+                <para role="text">No certification path validation policy is stored under the requested CertPathValidationPolicyID.</para>
               </listitem>
             </varlistentry>
             <varlistentry>


### PR DESCRIPTION
Split some erroneously concatenated parameter definitions and their annotation.