### PR TITLE
Update the command GetSnapshotUri description, delete outdated parameters

### DIFF
--- a/wsdl/ver20/media/wsdl/media.wsdl
+++ b/wsdl/ver20/media/wsdl/media.wsdl
@@ -1742,9 +1742,7 @@ the PTZ position shall be repeated within the metadata stream.</wsdl:documentati
 		</wsdl:operation>
 		<wsdl:operation name="GetSnapshotUri">
 			<wsdl:documentation>A client uses the GetSnapshotUri command to obtain a JPEG snapshot from the
-device. The returned URI shall remain valid indefinitely even if the profile is changed. The
-ValidUntilConnect, ValidUntilReboot and Timeout Parameter shall be set accordingly
-(ValidUntilConnect=false, ValidUntilReboot=false, timeout=PT0S). The URI can be used for
+device. The returned URI shall remain valid indefinitely even if the profile is changed. The URI can be used for
 acquiring a JPEG image through a HTTP GET operation. The image encoding will always be
 JPEG regardless of the encoding setting in the media profile. The Jpeg settings
 (like resolution or quality) may be taken from the profile if suitable. The provided


### PR DESCRIPTION
Hi! I think next params: ValidUntilConnect, ValidUntilReboot and Timeout Parameter are outdated. They are used for the Media1 service.