### PR TITLE
Add stylesheet for literal when viewing files locally

### DIFF
--- a/doc/docbook.xsl
+++ b/doc/docbook.xsl
@@ -88,8 +88,7 @@ background-color: #d0d0d0;
 font-weight: bold;
 }
 literal {
-font-family: serif;
-font-weight: bold;
+font-family: monospace;
 }</xsl:variable>
     <xsl:template match="/">
         <html>

--- a/doc/docbook.xsl
+++ b/doc/docbook.xsl
@@ -86,6 +86,10 @@ padding: 1mm 3mm 1mm 3mm;
 .table>table>thead>tr>th {
 background-color: #d0d0d0;
 font-weight: bold;
+}
+literal {
+font-family: serif;
+font-weight: bold;
 }</xsl:variable>
     <xsl:template match="/">
         <html>


### PR DESCRIPTION
Add a stylesheet for literals so it is visibly different when viewing files locally
EX:
![image](https://github.com/onvif/specs/assets/39772820/d313f7b8-05fa-427d-b089-efb6457d7a8e)
