### PR TITLE
Add support for B-Frame configuration.

### DIFF
--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -1066,6 +1066,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:documentation>Group of Video frames length. Determines typically the interval in which the I-Frames will be coded. An entry of 1 indicates I-Frames are continuously generated. An entry of 2 indicates that every 2nd image is an I-Frame, and 3 only every 3rd frame, etc. The frames in between are coded as P or B Frames.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
+				<xs:attribute name="AnchorFrameDistance" type="xs:int">
+					<xs:annotation>
+						<xs:documentation>Distance between anchor frames of type I-Frame and P-Frame. '1' indicates no B-Frames, '2' indicates that every 2nd frame is encoded as B-Frame, '3' indicates a structure like IBBPBBP..., etc.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:attribute name="Profile" type="xs:string">
 					<xs:annotation>
 						<xs:documentation>The encoder profile as defined in tt:VideoEncodingProfiles.</xs:documentation>
@@ -1151,6 +1156,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:attribute name="GovLengthRange" type="tt:IntList">
 			<xs:annotation>
 				<xs:documentation>Exactly two values, which define the Lower and Upper bounds for the supported group of Video frames length. These values typically correspond to the I-Frame distance.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="MaxAnchorFrameDistance" type="xs:int">
+			<xs:annotation>
+				<xs:documentation>Signals support for B-Frames. Upper bound for the supported anchor frame distance (must be larger than one).</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="FrameRatesSupported" type="tt:FloatList">


### PR DESCRIPTION
Add an attribute to the encoder configuration and signal availability and range via the encoder options.

The naming convention and definition are taken from https://en.wikipedia.org/wiki/Group_of_pictures