### PR TITLE
Minor cleanup of JSON metadata notion.

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -2441,9 +2441,9 @@
           </listitem>
         </itemizedlist></para>
 
-      <para>The following sections describe how topics and payload shall be
-      structured by an ONVIF metadata producer when published to an MQTT
-      broker.</para>
+      <para>The following section describe how topics shall be structured by an ONVIF metadata
+          producer when published to an MQTT broker. The payload shall be encoded as defined in
+          Annex E of the ONVIF Core Specification.</para>
     	</section>
       <section>
         <title>MQTT topic structure</title>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -9044,11 +9044,11 @@ http://www.onvif.org/ver10/tev/topicExpression/ConcreteSet
       <section>
         <title>XML to JSON conversion guidance</title>
         <para>Instead of creating a full fledged schema for XML to JSON conversion, <xref
-            linkend="xmlToJson"/> provides a set of generic rules that devices shall need to
-          implement to express ONVIF metadata in JSON format as defined by RFC 7159.</para>
+          linkend="xmlToJson"/> provides a set of generic rules to express ONVIF XML in JSON format
+        as defined by RFC 7159.</para>
 
         <table xml:id="xmlToJson">
-          <title>ONVIF Metadata XML to JSON conversion</title>
+          <title>ONVIF XML to JSON conversion</title>
 
           <tgroup cols="3">
             <thead>


### PR DESCRIPTION
Remove term metadata of JSON definition in core spec since this is a general mapping not only applicable to metadata.
Move requirements on JSON encoding from core spec back to analytics spec.