### PR TITLE
Add reference to IANA for elliptic curve definitions.

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -151,6 +151,8 @@
     <title>Normative References</title>
     <para>Basic Security Profile Version 1.1 Committee Specification 01, OASIS Standard, 22 October 2004</para>
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://docs.oasis-open.org/ws-brsp/BasicSecurityProfile/v1.1/cs01/BasicSecurityProfile-v1.1-cs01.pdf">https://docs.oasis-open.org/ws-brsp/BasicSecurityProfile/v1.1/cs01/BasicSecurityProfile-v1.1-cs01.pdf</link>&gt;</para>
+    <para>IANA TLS Supported Groups, Elliptic curve groups</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8"/>&gt;</para>
     <para>IEEE 802.1X, Port-Based Network Access Control</para>
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://standards.ieee.org/getieee802/download/802.1X-2004.pdf">http://standards.ieee.org/getieee802/download/802.1X-2004.pdf</link>&gt;</para>
     <para>ONVIF Core Specification</para>
@@ -1622,7 +1624,7 @@
                 <term>request</term>
                 <listitem>
                   <para role="param">EllipticCurve - [xs:string]</para>
-                  <para role="text"> The name of the elliptic curve to be used for genereting the ECC keypair.</para>
+                  <para role="text"> The name of the elliptic curve to be used for genereting the ECC keypair. For definitions see [IANA TLS Supported Groups].</para>
                   <para role="param">Alias - optional [xs:string] </para>
                   <para role="text">The client-defined alias of the key.</para>
                 </listitem>


### PR DESCRIPTION
Elliptic curve name definition was unclear. Suggest to use the provided reference.