### PR TITLE
Remove requirement to signal maxInstances for for fixed rules and modules .

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -2992,7 +2992,7 @@ xmlns:acme="http://www.acme.com/schema"&gt;
         <section>
           <title>Example</title>
           <para>This examples explains the options for an analytics module called myModule in namespace nn with four simple parameters:</para>
-          <programlisting><![CDATA[<tt:AnalyticsModuleDescription Name="nn:myModule" fixed="true" maxInstances="1">
+          <programlisting><![CDATA[<tt:AnalyticsModuleDescription Name="nn:myModule" fixed="true">
   <tt:Parameters>
     <tt:SimpleItemDescription Name="Mode" Type="xs:string"/>
     <tt:SimpleItemDescription Name="Targets" Type="xs:string"/>
@@ -3088,7 +3088,8 @@ xmlns:acme="http://www.acme.com/schema"&gt;
         <para>The Create/Delete/Modify operations are atomic, meaning that either all modifications can be processed or the complete operation shall fail.</para>
         <section>
           <title>GetSupportedRules</title>
-          <para>A device signaling support for rules via the RuleSupport capability shall support this operation. It returns a list of rule descriptions according to the Rule Description Language described in Section <xref linkend="_Ref210635747" />. Additionally, it contains a list of URLs that provide the location of the schema files. These schema files describe the types and elements used in the rule descriptions. Rule descriptions that reference types or elements imported from any ONVIF defined schema files need not explicitly list those schema files. The device shall indicate its limit for maximum number of rules through the maxInstances attribute.</para>
+          <para>A device signaling support for rules via the RuleSupport capability shall support this operation. It returns a list of rule descriptions according to the Rule Description Language described in Section <xref linkend="_Ref210635747" />. Additionally, it contains a list of URLs that provide the location of the schema files. These schema files describe the types and elements used in the rule descriptions. Rule descriptions that reference types or elements imported from any ONVIF defined schema files need not explicitly list those schema files. </para>
+          <para>The device shall indicate its limit for maximum number of non-fixed rules through the maxInstances attribute.</para>
           <variablelist role="op">
             <varlistentry>
               <term>request</term>
@@ -3373,7 +3374,7 @@ xmlns:acme="http://www.acme.com/schema"&gt;
           <title>GetSupportedAnalyticsModules</title>
           <para>A device signaling support for analytics modules via the AnalyticsModuleSupport capability shall support retrieving a list of analytics modules for an analytics configuration. The description shall conform to the configuration description language as described in section <xref linkend="_Ref42033279" />.</para>
           <para>The optional AnalyticsModuleContentSchemaLocation parameter allows to list schema file locations that provide reference to types or elements which are not defined by ONVIF.</para>
-          <para>The device shall indicate its limit for maximum number of analytics modules through the maxInstances attribute.</para>
+          <para>The device shall indicate its limit for maximum number of analytics modules for non-fixed modules through the maxInstances attribute.</para>
           <variablelist role="op">
             <varlistentry>
               <term>request</term>


### PR DESCRIPTION
When adding the fixed attribute the requirement was not updated. Since the DTT requires presence for the maxInstances attribute a device has now to signal both.

Note that this change requires adaptation of DTT ANALYTICS-4-1-1.