### PR TITLE
Support JWT authentication with the Uplink specification

### DIFF
--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -202,19 +202,22 @@
     <section>
       <title>Authentication</title>
       <para>Note that for the following discussion the roles of client and server are swapped.</para>
-      <para>The remote client shall authenticate itself using a valid server certificate. The service shall verify the validity of the remote certificate according to RFC 6125. </para>
-      <para>The service shall authenticate itself at the remote client using TLS client authentication according to RFC 5246 or subsequent specifications.</para>
-      <para>To uniquely identify local service on remote client, it is recommended to have a unique client certificate installed on each local service. For example, CN field or Serial number of installed certificate could be used to uniquely identify the local service.</para>
-      <para>The device shall assign any tunneled HTTP or RTSP request the UserLevel that is
-        configured for the configuration without the need of further authentication request headers. </para>
-    </section>
-    <section>
-      <title>HTTP/2 Frames</title>
-      <para>Once an http/2 connection has been established the communication parameters are negotiated as specified by RFC 7540 so that the uplink can be used to exchange frames between the remote client and the local service.</para>
-    </section>
-    <section>
-      <title>HTTP Transactions</title>
-      <para>The uplink shall be used in reverse direction for http requests and responses. The remote client shall send requests that are served in a standard http manner by the local service.</para>
+      <para>The remote client shall authenticate itself using a valid server certificate. The service shall verify the validity of the remote certificate according to RFC 6125.</para>
+      <section>
+        <title>mTLS authentication</title>
+        <para>When using mTLS authentication, the service shall authenticate itself at the remote client using TLS client authentication according to RFC 5246 or subsequent specifications.</para>
+        <para>To uniquely identify local service on remote client, it is recommended to have a unique client certificate installed on each local service. For example, CN field or Serial number of installed certificate could be used to uniquely identify the local service.</para>
+        <para>The device shall assign any tunneled HTTP or RTSP request the UserLevel that is configured for the configuration without the need of further authentication request headers. </para>
+        <para>To use this authentication mechanism, the <literal>CertificateID</literal> shall be set in the <literal>UplinkConfiguration</literal>.</para>
+      </section>
+      <section>
+        <title>JWT authentication</title>
+        <para>When using JWT authentication, the local service shall provide a JWT token when sending the upgrade request.</para>
+        <para>The remote client shall validate the JWT token provided following the JWT specification as defined in the Core specification.</para>
+        <para>The device shall assign any tunneled HTTP or RTSP request the UserLevel that is configured for the configuration without the need of further authentication request headers.</para>
+        <para>When a device indicates JsonWebToken is supported through its Capabilities, then it shall support JWT authentication in this specification.</para>
+        <para>To use this authentication mechanism, the <literal>AuthorizationServerConfigurationToken</literal> shall be set in the <literal>UplinkConfiguration</literal>.</para>
+      </section>
     </section>
     <section>
       <title>Media Streaming</title>
@@ -307,7 +310,30 @@
         <listitem>
           <para role="text">This message is empty</para>
         </listitem>
-        </varlistentry> 
+        </varlistentry>
+        <varlistentry>
+          <term>faults</term>
+          <listitem>
+            <para role="param">env:Sender - ter:InvalidArgVal - ter:CertificateID</para>
+            <para role="text"> No certificate is stored under the requested CertificateID.</para>
+          </listitem>
+          <listitem>
+            <para role="param">env:Sender - ter:InvalidArgVal - ter:AuthorizationServerConfigurationToken</para>
+            <para role="text"> No AuthorizationServerConfiguration exists for the specified token.</para>
+          </listitem>
+          <listitem>
+            <para role="param">env:Sender - ter:InvalidArgs - ter:MissingAuthentication</para>
+            <para role="text">CertificateID and AuthorizationServerConfigurationToken are both missing.</para>
+          </listitem>
+          <listitem>
+            <para role="param">env:Sender - ter:InvalidArgs - ter:AmbiguousAuthentication</para>
+            <para role="text">CertificateID and AuthorizationServerConfigurationToken are mutually exclusive.</para>
+          </listitem>
+          <listitem>
+            <para role="param">env:Sender - ter:InvalidArgs - ter:JsonWebTokenNotSupported</para>
+            <para role="text">Cannot set AuthorizationServerConfigurationToken when JsonWebToken is not supported.</para>
+          </listitem>
+        </varlistentry>
         <varlistentry>
           <term>access class</term>
           <listitem>

--- a/wsdl/ver10/uplink/wsdl/uplink.wsdl
+++ b/wsdl/ver10/uplink/wsdl/uplink.wsdl
@@ -56,7 +56,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<xs:element name="RemoteAddress" type="xs:anyURI">
 						<xs:annotation><xs:documentation>Uniform resource locator by which the remote client can be reached.</xs:documentation></xs:annotation>
 					</xs:element>
-					<xs:element name="CertificateID" type="xs:string">
+					<xs:element name="CertificateID" type="xs:string" minOccurs="0">
 						<xs:annotation><xs:documentation>ID of the certificate to be used for client authentication.</xs:documentation></xs:annotation>
 					</xs:element>
 					<xs:element name="UserLevel" type="xs:string">
@@ -69,6 +69,9 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:annotation>
 							<xs:documentation> CertPathValidationPolicyID used to validate the uplink server certificate. If CertPathValidationPolicyID is not configured, uplink server certificate shall not be validated. </xs:documentation>
 						</xs:annotation>
+					</xs:element>
+					<xs:element name="AuthorizationServerConfigurationToken" type="tt:ReferenceToken" minOccurs="0">
+						<xs:annotation><xs:documentation>The configuration to be used to obtain a JWT token to authorize with the uplink server.</xs:documentation></xs:annotation>
 					</xs:element>
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	 <!-- first ONVIF then Vendor -->
 				</xs:sequence>
@@ -96,7 +99,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<xs:sequence>
 						<xs:element name="Configuration" type="tup:Configuration">
 							<xs:annotation>
-								<xs:documentation>SConfiguration to be added or modified.</xs:documentation>
+								<xs:documentation>Configuration to be added or modified.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 					</xs:sequence>

--- a/wsdl/ver10/uplink/wsdl/uplink.wsdl
+++ b/wsdl/ver10/uplink/wsdl/uplink.wsdl
@@ -70,7 +70,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 							<xs:documentation> CertPathValidationPolicyID used to validate the uplink server certificate. If CertPathValidationPolicyID is not configured, uplink server certificate shall not be validated. </xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="AuthorizationServerConfigurationToken" type="tt:ReferenceToken" minOccurs="0">
+					<xs:element name="AuthorizationServer" type="tt:ReferenceToken" minOccurs="0">
 						<xs:annotation><xs:documentation>The configuration to be used to obtain a JWT token to authorize with the uplink server.</xs:documentation></xs:annotation>
 					</xs:element>
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	 <!-- first ONVIF then Vendor -->


### PR DESCRIPTION
This proposals changes the uplink specification to be able to use a JWT token to authorize a device with the uplink server. This builds on top changes from #293.

If CertificateID is set, mTLS will be used.
If AuthorizationServerConfigurationToken is set, JWT authentication will be used.