### PR TITLE
Discovery scope parameters extended with MacAddress and SerialNumber

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -2680,6 +2680,28 @@ X-Frame-Options: SAMEORIGIN]]></programlisting>
                       <para>The searchable name of the device. A device shall include at least one name entry into its scope list.</para>
                     </entry>
                   </row>
+                  <row>
+                    <entry>
+                      <para>MacAddress</para>
+                    </entry>
+                    <entry>
+                      <para>Any character string.</para>
+                    </entry>
+                    <entry>
+                      <para>MacAddress of the network interface.</para>
+                    </entry>
+                  </row>
+                  <row>
+                    <entry>
+                      <para>SerialNumber</para>
+                    </entry>
+                    <entry>
+                      <para>Any character string (alphanumeric).</para>
+                    </entry>
+                    <entry>
+                      <para>Unique serial number of the device.</para>
+                    </entry>
+                  </row>
                 </tbody>
               </tgroup>
             </table>


### PR DESCRIPTION
Based on Zagreb F2F discussion, added MacAddress and SerialNumber to the scope parameters  (issue number #350)

Please review.