### PR TITLE
Add hash of segment for validatity purposes

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -2221,6 +2221,17 @@ secfrac = "." 1*6DIGIT</programlisting>
                 <para>Integer</para>
               </entry>
             </row>
+            <row>
+              <entry>
+                <para><literal>SHA256</literal></para>
+              </entry>
+              <entry>
+                <para>Hash of the uploaded segment.</para>
+              </entry>
+              <entry>
+                <para>Hexadecimal string</para>
+              </entry>
+            </row>
           </tbody>
         </tgroup>
       </table>


### PR DESCRIPTION
This will be used to validate the integrity of the file in case there was corruption during transit or after storage. This can also help when replicating the data into different storages to ensure the integrity of the copied data, for example when using content addressable storage use cases where the hash of the file can also be its identifier. 
	
The intent is not to validate the authenticity of the file, as anyone that can modify the file can also update the hash in the metadata. For this use case, media signing is probably a better solution.