### PR TITLE
Minor correction in webrtc configuration

### DIFF
--- a/wsdl/ver20/media/wsdl/media.wsdl
+++ b/wsdl/ver20/media/wsdl/media.wsdl
@@ -1245,14 +1245,14 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 							<xs:documentation>The default media profile to use for streaming if no specific profile is specified when initializing a session.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Enabled " type="xs:boolean">
+					<xs:element name="Enabled" type="xs:boolean">
 						<xs:annotation>
 							<xs:documentation> Enables/disables the configuration.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Connected " type="xs:boolean" minOccurs="0">
+					<xs:element name="Connected" type="xs:boolean" minOccurs="0">
 						<xs:annotation>
-							<xs:documentation> Enables/disables the configuration.</xs:documentation>
+							<xs:documentation>Indicates if the device is connected to the server. This parameter is read-only.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->


### PR DESCRIPTION
Description for the **connected** parameter in the webrtc configuration corrected and removed extra space in Enabled and Connected parameter.
