### PR TITLE
Uplink Spec readability improvements

### DIFF
--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -211,7 +211,7 @@
           <figure xml:id="_Ref505091745">
             <title>Connection initiation from the device</title>
             <mediaobject>
-              <imageobject>identify 
+              <imageobject> 
                 <imagedata fileref="media/Uplink/image4.svg" contentwidth="128mm" />
               </imageobject>
             </mediaobject>

--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -358,7 +358,7 @@
         </listitem>
       </itemizedlist>
       <para>Field RemoteAddress shall be used as key to a specific uplink configuration.</para>
-      <para>Only one of CertificateID or AuthorizationServer shall be used for an uplink
+      <para>Only one of CertificateID or AuthorizationServerConfiguration shall be used for an uplink
         configuration.</para>
     </section>
     <section>

--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -356,9 +356,10 @@
             that provides JWT token to authorize with the uplink server.</para>
         </listitem>
       </itemizedlist>
-      <para>Field RemoteAddress shall be used as key to a specific uplink configuration.</para>
-      <para>Only one of CertificateID or AuthorizationServer shall be used for an uplink
+      <para>The device shall interpret the field RemoteAddress as key to a specific uplink
         configuration.</para>
+      <para>A device shall reject a configuration containing both CertificateID and
+        AuthorizationServer. </para>
     </section>
     <section>
       <title>GetUplinks</title>
@@ -407,6 +408,10 @@
           <listitem>
             <para role="param">env:Sender - ter:InvalidArgVal - ter:CertificateID</para>
             <para role="text"> No certificate is stored under the requested CertificateID.</para>
+            <para role="param">env:Sender - ter:InvalidArgVal -
+              ter:CertPathValidationPolicyID</para>
+            <para role="text"> No certificate validation policy is stored under the requested
+              CertPathValidationPolicyID.</para>
             <para role="param">env:Sender - ter:InvalidArgVal - ter:AuthorizationServerConfigurationToken</para>
             <para role="text"> No AuthorizationServerConfiguration exists for the specified token.</para>
             <para role="param">env:Sender - ter:InvalidArgs - ter:MissingAuthentication</para>

--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -357,7 +357,7 @@
         </listitem>
       </itemizedlist>
       <para>Field RemoteAddress shall be used as key to a specific uplink configuration.</para>
-      <para>Only one of CertificateID or AuthorizationServerConfiguration shall be used for an uplink
+      <para>Only one of CertificateID or AuthorizationServer shall be used for an uplink
         configuration.</para>
     </section>
     <section>

--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -254,8 +254,13 @@
     <section>
       <title>Connection Management</title>
       <para>A local service that is offered to a remote client for utilization is responsible for maintaining an operational communication channel. Since the connection needs to be established from the service to the remote client this connection is called uplink. The uplink shall be secured via TLS. </para>
-      <para>The service shall monitor whether the remote client is able to communicate via the uplink. It may use the HTTP/2 ping mechanism to check whether a link is still operational if no packets have been received for a longer period of time.</para>
-      <para>A local service shall close and reconnect the uplink whenever no packets have been received from the remote client for more than 30 seconds. Each camera shall use an individual ascending interval strategy to avoid that all cameras connect at the same time.</para>
+      <para>The local service shall monitor whether the remote client is able to communicate via the
+        uplink. It may use the HTTP/2 ping mechanism to check whether a link is still operational if
+        no packets have been received for a longer period of time.</para>
+      <para>The local service shall close and reconnect the uplink whenever no packets have been
+        received from the remote client for more than 30 seconds. Each camera shall use an
+        individual ascending interval strategy to avoid that all cameras connect at the same
+        time.</para>
       <para>The following example shows patterns chosen by two cameras A and B:</para>
       <itemizedlist>
         <listitem>
@@ -265,16 +270,23 @@
           <para>Camera B: 2s, 4s, 8s, 16s, 30s, 30s, 30s ...</para>
         </listitem>
       </itemizedlist>
-      <para>If the uplink list contains multiple entries the device shall try to establish all connections in parallel. </para>
-      <para>Note that this specification assumes that scenarios with multiple clients are designed such that they do not interfere with each other. The coordination between such multiple clients is outside of the scope of the specification.</para>
+      <para>If the multiple uplink configurations are included,  the device shall try to establish
+        all connections in parallel. </para>
+      <para>Note that this specification expects different clients may try to reach multiple local
+        services and it is assumed services and clients are designed such that they do not interfere
+        with each other. The coordination between such multiple clients and services is outside of
+        the scope of the specification.</para>
     </section>
     <section>
       <title>Authentication</title>
       <para>Note that for the following discussion the roles of client and server are swapped.</para>
-      <para>The remote client shall authenticate itself using a valid server certificate. The service shall verify the validity of the remote certificate according to RFC 6125.</para>
+      <para>The remote client shall authenticate itself using a valid server certificate. The local
+        service shall verify the validity of the remote certificate according to RFC 6125.</para>
       <section>
         <title>mTLS authentication</title>
-        <para>When using mTLS authentication, the service shall authenticate itself at the remote client using TLS client authentication according to RFC 5246 or subsequent specifications.</para>
+        <para>When using mTLS authentication, the local service shall authenticate itself at the
+          remote client using TLS client authentication according to RFC 5246 or subsequent
+          specifications.</para>
         <para>To uniquely identify a local service on remote client, it is recommended to have a unique client certificate installed on each local service. For example, CN field or Serial number of installed certificate could be used to uniquely identify the local service.</para>
         <para>The device shall assign any tunneled HTTP or RTSP request the UserLevel that is configured for the configuration without the need of further authentication request headers. </para>
         <para>If the <literal>CertificateID</literal> is present in the <literal>UplinkConfiguration</literal> the device shall use this authentication mechanism.</para>
@@ -294,8 +306,8 @@
         <title>Introduction</title>
         <para>The ONVIF Media Service Specification and the ONVIF Streaming Specification define
           various mechanism for streaming Video, Audio and Metadata. This specification defines how
-          to apply streaming over http. Usage of other communication mechanism like UDP unicast and
-          multicast are outside of the scope of this specification.</para>
+          to apply streaming over http/2. Usage of other communication mechanism like UDP unicast
+          and multicast are outside of the scope of this specification.</para>
       </section>
       <section>
         <title>RTSP over HTTP</title>
@@ -310,8 +322,8 @@
       </section>
       <section>
         <title>RTSP over WebSockets</title>
-        <para>A device signaling support for websockets over RTSP via its capabilities shall support
-          RFC 8441 on the uplink.</para>
+        <para>A device signaling support for websockets over RTSP via its capability <emphasis
+            role="bold">RTSPWebSocketUri</emphasis> shall support RFC 8441 on the uplink.</para>
       </section>
     </section>
   </chapter>
@@ -321,22 +333,33 @@
       <title>Configuration parameters</title>
       <itemizedlist>
         <listitem>
-          <para>RemoteAddress Uniform resource locator by which the remote client can be reached.</para>
+          <para><emphasis role="bold">RemoteAddress</emphasis> Uniform resource locator by which the
+            remote client can be reached.</para>
         </listitem>
         <listitem>
-          <para>CertificateID	ID of the certificate to be used for client authentication.</para>
+          <para><emphasis role="bold">CertificateID</emphasis> ID of the certificate to be used for
+            client authentication.</para>
         </listitem>
         <listitem>
-          <para>UserLevel	Authorization level that will be assigned to the uplink connection</para>
+          <para><emphasis role="bold">UserLevel</emphasis> Authorization level that will be assigned
+            to the uplink connection</para>
         </listitem>
         <listitem>
-          <para>Status	Current connection status</para>
+          <para><emphasis role="bold">Status</emphasis> Current connection status</para>
         </listitem>
          <listitem>
-          <para>CertPathValidationPolicyID  ID of Certificate Validation policy to validate the remote uplink server certficate. If not configured, server certificate shall not be validated. </para>
+          <para><emphasis role="bold">CertPathValidationPolicyID</emphasis> ID of Certificate
+            Validation policy to validate the remote uplink server certficate. If not configured,
+            server certificate shall not be validated. </para>
+        </listitem>
+        <listitem>
+          <para><emphasis role="bold">AuthorizationServerConfiguration</emphasis> The configuration
+            to be used to obtain a JWT token to authorize with the uplink server.</para>
         </listitem>
       </itemizedlist>
-      <para>Field RemoteAddress is used as key of the list of uplink configurations.</para>
+      <para>Field RemoteAddress shall be used as key to a specific uplink configuration.</para>
+      <para>Only one of CertificateID or AuthorizationServer shall be used for an uplink
+        configuration.</para>
     </section>
     <section>
       <title>GetUplinks</title>

--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -270,7 +270,7 @@
           <para>Camera B: 2s, 4s, 8s, 16s, 30s, 30s, 30s ...</para>
         </listitem>
       </itemizedlist>
-      <para>If the multiple uplink configurations are included,  the device shall try to establish
+      <para>If multiple uplink configurations are included, the device shall try to establish
         all connections in parallel. </para>
       <para>Note that this specification expects different clients may try to reach multiple local
         services and it is assumed services and clients are designed such that they do not interfere

--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -322,8 +322,8 @@
       </section>
       <section>
         <title>RTSP over WebSockets</title>
-        <para>A device signaling support for websockets over RTSP via its capability <emphasis
-            role="bold">RTSPWebSocketUri</emphasis> shall support RFC 8441 on the uplink.</para>
+        <para>A device signaling support for websockets over RTSP via its capability
+          RTSPWebSocketUri shall support RFC 8441 on the uplink.</para>
       </section>
     </section>
   </chapter>
@@ -333,28 +333,27 @@
       <title>Configuration parameters</title>
       <itemizedlist>
         <listitem>
-          <para><emphasis role="bold">RemoteAddress</emphasis> Uniform resource locator by which the
-            remote client can be reached.</para>
+          <para>RemoteAddress : Uniform resource locator by which the remote client can be
+            reached.</para>
         </listitem>
         <listitem>
-          <para><emphasis role="bold">CertificateID</emphasis> ID of the certificate to be used for
-            client authentication.</para>
+          <para>CertificateID : ID of the certificate to be used for client authentication.</para>
         </listitem>
         <listitem>
-          <para><emphasis role="bold">UserLevel</emphasis> Authorization level that will be assigned
-            to the uplink connection</para>
+          <para>UserLevel : Authorization level that will be assigned to the uplink
+            connection</para>
         </listitem>
         <listitem>
-          <para><emphasis role="bold">Status</emphasis> Current connection status</para>
+          <para>Status :  Current connection status</para>
         </listitem>
          <listitem>
-          <para><emphasis role="bold">CertPathValidationPolicyID</emphasis> ID of Certificate
-            Validation policy to validate the remote uplink server certficate. If not configured,
-            server certificate shall not be validated. </para>
+          <para>CertPathValidationPolicyID : ID of Certificate Validation policy to validate the
+            remote uplink server certficate. If not configured, server certificate shall not be
+            validated. </para>
         </listitem>
         <listitem>
-          <para><emphasis role="bold">AuthorizationServerConfiguration</emphasis> The configuration
-            to be used to obtain a JWT token to authorize with the uplink server.</para>
+          <para>AuthorizationServer :  JWTConfiguration token referring to an Authorization server
+            that provides JWT token to authorize with the uplink server.</para>
         </listitem>
       </itemizedlist>
       <para>Field RemoteAddress shall be used as key to a specific uplink configuration.</para>

--- a/wsdl/ver10/uplink/wsdl/uplink.wsdl
+++ b/wsdl/ver10/uplink/wsdl/uplink.wsdl
@@ -92,8 +92,8 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 							<xs:documentation> CertPathValidationPolicyID used to validate the uplink server certificate. If CertPathValidationPolicyID is not configured, uplink server certificate shall not be validated. </xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="AuthorizationServerConfiguration" type="tt:ReferenceToken" minOccurs="0">
-						<xs:annotation><xs:documentation>The configuration to be used to obtain a JWT token to authorize with the uplink server.</xs:documentation></xs:annotation>
+					<xs:element name="AuthorizationServer" type="tt:ReferenceToken" minOccurs="0">
+						<xs:annotation><xs:documentation> JWTConfiguration token referring to an Authorization server that provides JWT token to authorize with the uplink server.</xs:documentation></xs:annotation>
 					</xs:element>
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	 <!-- first ONVIF then Vendor -->
 				</xs:sequence>

--- a/wsdl/ver10/uplink/wsdl/uplink.wsdl
+++ b/wsdl/ver10/uplink/wsdl/uplink.wsdl
@@ -92,7 +92,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 							<xs:documentation> CertPathValidationPolicyID used to validate the uplink server certificate. If CertPathValidationPolicyID is not configured, uplink server certificate shall not be validated. </xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="AuthorizationServer" type="tt:ReferenceToken" minOccurs="0">
+					<xs:element name="AuthorizationServerConfiguration" type="tt:ReferenceToken" minOccurs="0">
 						<xs:annotation><xs:documentation>The configuration to be used to obtain a JWT token to authorize with the uplink server.</xs:documentation></xs:annotation>
 					</xs:element>
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	 <!-- first ONVIF then Vendor -->


### PR DESCRIPTION
Summary of the PR changes

- Referred to service as "local service" to keep the context
- Improved text related to out of scope
- identified capability clearly when talking about websockets over RTSP
- Included missing "AuthorizationServerConfiguration" from the spec though such field is included in the wsdl
  - Renamed "AuthorizationServer" to "AuthorizationServerConfiguration"
- Fixed XML DocBook validation error in uplink.wsdl