### PR TITLE
Authorization Server Type OIDC2AuthorizationCode added

### DIFF
--- a/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
+++ b/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
@@ -887,6 +887,11 @@
 							<xs:documentation>OAuth2 client credentials grant flow per RFC 6749</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
+					<xs:enumeration value="OIDC2AuthorizationCode">
+						<xs:annotation>
+							<xs:documentation>OpenID Connect authorization code flow per Open ID Connect Core</xs:documentation>
+						</xs:annotation>
+					</xs:enumeration>
 				</xs:restriction>
 			</xs:simpleType>
 			<!--===============================-->


### PR DESCRIPTION
Authrorization Server Type **OIDC2AuthorizationCode** was defined in the specification, but in the wsdl it was not included.