### PR TITLE
WebRTC: Use Authorization header as standard authentication

### DIFF
--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -295,8 +295,11 @@
       <para>In case a connection is dropped the device shall reconnect automatically. Each client
         should use an individual ascending interval strategy to avoid that all clients reconnect at
         the same time.</para>
-      <para>Both a client and a device must provide their JWT access token using the Authorization header
+      <para>Both a client and a device shall provide their JWT access token using the Authorization header
         or via query parameter on the WebSocket URI as defined by [RFC6750] Section 2.3.</para>
+      <para>Once the WebSocket is open, both device and client shall immediately send a register command
+        as specified in section <xref linkend="section_register"/> when they receive the HTTP 101 switching
+        protocol.</para>
     </section>
     <section xml:id="section_ayt_v12_v5b">
       <title>Communication Protocol</title>

--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -97,6 +97,9 @@
     <para>IETF RFC 6749 - The OAuth 2.0 Authorization Framework</para>
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="http://tools.ietf.org/html/rfc6749"/>&gt;</para>
+    <para>IETF RFC 6750 - The OAuth 2.0 Authorization Framework: Bearer Token Usage</para>
+    <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="http://tools.ietf.org/html/rfc6750"/>&gt;</para>
     <para>IETF RFC 7064 - URI Scheme for the Session Traversal Utilities for NAT (STUN) Protocol</para>
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="https://datatracker.ietf.org/doc/html/rfc7064"/>&gt;</para>
@@ -292,9 +295,8 @@
       <para>In case a connection is dropped the device shall reconnect automatically. Each client
         should use an individual ascending interval strategy to avoid that all clients reconnect at
         the same time.</para>
-      <para>Both device and client shall immediately send a register command as specified in section
-          <xref linkend="section_register"/> when they receive the HTTP 101 switching
-        protocol.</para>
+      <para>Both a client and a device must provide their JWT access token using the Authorization header
+        or via query parameter on the WebSocket URI as defined by [RFC6750] Section 2.3.</para>
     </section>
     <section xml:id="section_ayt_v12_v5b">
       <title>Communication Protocol</title>


### PR DESCRIPTION
Currently, the signaling protocol specifies initial authentication as a mandatory register message when opening the websocket. This forces a signaling server to accept unauthenticated websockets and leave them open for some time to receive the actual authentication information which open us to some DoS/resource exhaustion attacks.

Since we have a precedent in the Uplink specification of authenticating a WebSocket connection via the header or query parameter (to accomodate browser websockets, which can't provide headers). This ensures we use a common way of authenticating these kind of cloud connections in both specs, and allow us to validate that the request is legitimate before accepting any websocket session.