### PR TITLE
Support error notification in WebRTC

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -1788,7 +1788,7 @@
                     <para>fc: AccessoryDescription</para>
                   </entry>
                   <entry>
-                    <para>N/A</para>
+                    <para>fc:HatType*</para>
                   </entry>
                 </row>
                 <row>
@@ -1821,7 +1821,7 @@
                     <para>fc: AccessoryDescription</para>
                   </entry>
                   <entry>
-                    <para>N/A</para>
+                    <para>fc:HelmetType*</para>
                   </entry>
                 </row>
                 <row>
@@ -1907,6 +1907,7 @@
               </tbody>
             </tgroup>
           </table>
+          <para>Items denoted with asterisk as e.g. fc:HatType* apply to subtype.</para>
           <para>PoseAngle represents the estimated pose of the face, two elements are included in PoseAngle field. One is PoseAngles which includes three angles yaw, pitch, roll, the other one is the pose angle uncertainty, uncertainty describes the expected degree of uncertainty of each pose angle.</para>
           <para>Yaw angle: rotation about the vertical(y) axis.</para>
           <para>Pitch angle: rotation about the horizontal side-to-side(x) horizontal axis.</para>

--- a/doc/Media2.xml
+++ b/doc/Media2.xml
@@ -2142,7 +2142,14 @@
           <varlistentry>
             <term>faults</term>
             <listitem>
-              <para role="text">No command specific faults defined.</para>
+              <para role="param">env:Receiver - ter:Action - ter:MaxWebRTCConfiguration</para>
+              <para role="text">The maximum number of configurations supported by the device has been reached.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:InvalidConfig</para>
+              <para role="text">The configuration parameters are not possible to set.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoAuthorizationServer</para>
+              <para role="text">The authorization server token does not exist.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoProfile</para>
+              <para role="text">The profile token does not exist.</para>
             </listitem>
           </varlistentry>
           <varlistentry>

--- a/doc/Media2.xml
+++ b/doc/Media2.xml
@@ -9,7 +9,7 @@
       <orgname>ONVIF™</orgname>
       <uri>www.onvif.org</uri>
     </author>
-    <pubdate>Feb 2024 Draft for IPR Review</pubdate>
+    <pubdate>Feb 2024 Draft</pubdate>
     <mediaobject>
       <imageobject>
         <imagedata fileref="media/logo.png" contentwidth="60mm"/>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -1096,6 +1096,11 @@
       <para>OAuth 2.0 is a specification that describes how to issue access tokens. It is defined in RFC6749. OpenID Connect has been developed as an extension of OAuth 2.0.</para>
       <para>OAuth 2.0 includes the definition of a web API called "authorization endpoint". Requests to this API must include a parameter called <emphasis>response_type</emphasis> which can be either <emphasis>code</emphasis> or <emphasis>token</emphasis>. OpenID Connect extends the OAuth 2.0 specification, by adding the values <emphasis>id_token</emphasis> and <emphasis>none</emphasis> for <emphasis>response_type</emphasis> and allowing any combination of <emphasis>code</emphasis>, <emphasis>token</emphasis> and <emphasis>id_token</emphasis>.</para>
       <para>Any request for ID tokens must include <emphasis>openid</emphasis> in the <emphasis>scope</emphasis> request parameter.</para>
+      <para>For example OAuth 2.0 client registration, as specified by RFC6749 requires
+        configuration of ClientId, ClientSecret, an authentication method according to <xref
+          xmlns:xlink="http://www.w3.org/1999/xlink" linkend="table_smg_rzq_swb"/>plus server
+        dependent supplemental parameters before the client can use the OAuth2.0 and OpenID Connect
+        flow.</para>
       <section xml:id="section_acl_4zq_swb">
         <title>User authentication and authorization</title>
         <para>Users can retrieve JWTs from an OpenID Connect server by authenticating and authorizing access to resources by following the OAuth2 Authorization Code Flow.</para>
@@ -1108,7 +1113,7 @@
             </imageobject>
           </mediaobject>
         </figure>
-        <para>A device can be setup to use JWTs obtained with this flow to allow access to its internal web interface for externally authenticated users. In that case an authorization server configuration with type OAuthAuthorizationCode should be created.</para>
+        <para>A device can be setup to use JWTs obtained with this flow to allow access to its internal web interface for externally authenticated users. In that case an authorization server configuration with type OAuthAuthorizationCode or OIDC2AuthorizationCode should be created.</para>
         <para>Access to the camera can be granted to users bearing either an ID Token or an Access Token, as long as the claims specified in <xref linkend="_Ref395181339"/> are present.</para>
       </section>
       <section xml:id="section_bcl_4zq_swb">
@@ -1284,8 +1289,8 @@
                   <para>client_secret_jwt</para>
                 </entry>
                 <entry>
-                  <para>Use a HMAC signed JWT using client_secret as shared secret, see OpenID
-                    Connect Core</para>
+                  <para>Use a HMAC signed JWT using client_secret as shared secret during client
+                    registration, see OpenID Connect Core</para>
                 </entry>
               </row>
               <row>
@@ -1293,7 +1298,8 @@
                   <para>private_key_jwt</para>
                 </entry>
                 <entry>
-                  <para>Use PKI signed JWT using private key, see OpenID Connect Core</para>
+                  <para>Use PKI signed JWT using private key, see OpenID Connect Core, public key
+                    shared with authorization server during client registration</para>
                 </entry>
               </row>
               <row>
@@ -1301,7 +1307,9 @@
                   <para>tls_client_auth</para>
                 </entry>
                 <entry>
-                  <para>Use PKI certificate to authenticate, see RFC 8705</para>
+                  <para>Use PKI certificate to authenticate, public key shared with authorization
+                    server during client registration and X.509 certificate used to setup mTLS with
+                    authorization server, see RFC 8705</para>
                 </entry>
               </row>
               <row>
@@ -1309,7 +1317,9 @@
                   <para>self_signed_tls_client_auth</para>
                 </entry>
                 <entry>
-                  <para>Use self-signed certificate to authenticate, see RFC 8705</para>
+                  <para>Use self-signed certificate to authenticate, public key shared with
+                    authorization server during client registration and self signed certificate used
+                    to setup mTLS with authorization server,see RFC 8705</para>
                 </entry>
               </row>
             </tbody>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -4827,9 +4827,9 @@
       <para>All other configuration of the TLS server on a device is outside the scope of this specification revision and may be addressed by later revisions of this document.</para>
     </section>
   </chapter>
-  <appendix xml:id="_Ref460769599">
-    <title>JWT over SCTP example</title>
-    <para>The JWT will have the following content</para>
+  <appendix xml:id= "q5l_q5m_51c">
+    <title>JWT Content example</title>
+    <para>Here is an example of JWT components to be encoded into a JWT Token</para>
     <programlisting><![CDATA[{
     "typ":"JWT",
     "alg":"ES256",
@@ -4850,7 +4850,11 @@ RJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c</programlisting>
 piMjBpTENKdVltWWlPakUyTnpBME9ESTRNREFzSW1WNGNDSTZNVFkzTURVM01qZ3dNQ3dpWVhWa0lqb2lkR0Z5
 WjJWMExtRjFaR2xsYm1ObElpd2ljbTlzWlhNaU9pSnZiblpwWmpwUGNHVnlZWFJ2Y2lKOS5TZmxLeHdSSlNNZU
 tLRjJRVDRmd3BNZUpmMzZQT2s2eUpWX2FkUXNzdzVj</programlisting>
-    <para>At this point, the JWT can be used in the WS-Security header of the SOAP request:</para>
+  </appendix>
+  <appendix xml:id="_Ref460769599">
+    <title>JWT over SCTP example</title>
+    <para>JWT, whose content example is shown in <xref xmlns:xlink="http://www.w3.org/1999/xlink"
+        linkend="q5l_q5m_51c"/>, can be used in the WS-Security header of the SOAP request:</para>
     <programlisting><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
 <env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"
               xmlns:enc="http://www.w3.org/2003/05/soap-encoding"
@@ -4876,7 +4880,7 @@ pTTWVLS0YyUVQ0ZndwTWVKZjM2UE9rNnlKVl9hZFFzc3c1Yw==
   <env:Body>
 </env:Envelope>]]></programlisting>
   </appendix>
-  <appendix>
+  <appendix xml:id= "hq4_s5m_51c">
     <title>JWT over HTTPS example</title>
     <para>The following exchange between client and device over HTTPS demonstrates a device supporting MD5 and SHA-256 for digest authentication as well as JWT-based client authentication.</para>
     <para>Unauthenticated request from the client:</para>
@@ -4899,7 +4903,9 @@ nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"
 WWW-Authenticate: Digest algorithm=SHA-256, realm="Silvan_http_digest", qop="auth",
 nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"
 X-Frame-Options: SAMEORIGIN]]></programlisting>
-    <para>Authenticated request from the client, by using JWT-based client authentication</para>
+    <para>Authenticated request from the client, by using JWT-based client authentication whose JWT
+      content looks like the example is shown in <xref xmlns:xlink="http://www.w3.org/1999/xlink"
+        linkend="q5l_q5m_51c"/></para>
     <programlisting><![CDATA[POST /onvif/device_service HTTP/1.1
 Host: 10.XX.XX.XX
 Authorization: Bearer ZXlKMGVYQWlPaUpLVjFRaUxDSmhiR2NpT2lKRlV6STFOaUo5LmV5SnBjM01pT2lK
@@ -4925,8 +4931,8 @@ WWW-Authenticate: Digest algorithm=SHA-256, realm="Silvan_http_digest", qop="aut
 nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"
 X-Frame-Options: SAMEORIGIN]]></programlisting>
   </appendix>
-  <appendix role="revhistory">
-    <title>JWT over RTSPS</title>
+  <appendix xml:id= "b14_55m_51c">
+    <title>JWT over RTSPS example</title>
     <para>The following exchange between client and device over RTSPS demonstrates a device supporting MD5 and SHA-256 for digest authentication as well as JWT-based client authentication.</para>
     <para>Unauthenticated request from the client:</para>
     <programlisting><![CDATA[DESCRIBE rtsp://10.XX.XX.XX/stream RTSP/1.0
@@ -4941,7 +4947,9 @@ WWW-Authenticate: Digest algorithm=MD5, realm="Silvan_rtsp_digest", qop="auth",
 nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"
 WWW-Authenticate: Digest algorithm=SHA-256, realm="Silvan_rtsp_digest", qop="auth",
 nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"]]></programlisting>
-    <para>Authenticated request from the client, by using JWT-based client authentication</para>
+    <para>Authenticated request from the client, by using JWT-based client authentication whose JWT
+      content looks like the example is shown in <xref xmlns:xlink="http://www.w3.org/1999/xlink"
+        linkend="q5l_q5m_51c"/></para>
     <programlisting><![CDATA[DESCRIBE rtsp://10.XX.XX.XX/stream RTSP/1.0
 Authorization: Bearer ZXlKMGVYQWlPaUpLVjFRaUxDSmhiR2NpT2lKRlV6STFOaUo5LmV5SnBjM01pT2lK
 elpYSjJaWEl1Y0dGMGFDNWpiMjBpTENKdVltWWlPakUyTnpBME9ESTRNREFzSW1WNGNDSTZNVFkzTURVM01qZ3

--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -270,8 +270,8 @@
           <para>Camera B: 2s, 4s, 8s, 16s, 30s, 30s, 30s ...</para>
         </listitem>
       </itemizedlist>
-      <para>If multiple uplink configurations are included, the device shall try to establish
-        all connections in parallel. </para>
+      <para>If multiple uplink configurations are included, the device shall try to establish 
+        all connections from the list and maintain those connections in parallel.</para>
       <para>Note that this specification expects different clients may try to reach multiple local
         services and it is assumed services and clients are designed such that they do not interfere
         with each other. The coordination between such multiple clients and services is outside of

--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -9,7 +9,7 @@
       <orgname>ONVIF™</orgname>
       <uri>www.onvif.org</uri>
     </author>
-    <pubdate>Feb 2024 Draft for IPR Review - see sections 5.1.1.2 and 5.3.2</pubdate>
+    <pubdate>Feb 2024 Draft</pubdate>
     <mediaobject>
       <imageobject>
         <imagedata fileref="media/logo.png" contentwidth="60mm" />

--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -211,7 +211,7 @@
           <figure xml:id="_Ref505091745">
             <title>Connection initiation from the device</title>
             <mediaobject>
-              <imageobject>identify 
+              <imageobject> 
                 <imagedata fileref="media/Uplink/image4.svg" contentwidth="128mm" />
               </imageobject>
             </mediaobject>
@@ -254,8 +254,13 @@
     <section>
       <title>Connection Management</title>
       <para>A local service that is offered to a remote client for utilization is responsible for maintaining an operational communication channel. Since the connection needs to be established from the service to the remote client this connection is called uplink. The uplink shall be secured via TLS. </para>
-      <para>The service shall monitor whether the remote client is able to communicate via the uplink. It may use the HTTP/2 ping mechanism to check whether a link is still operational if no packets have been received for a longer period of time.</para>
-      <para>A local service shall close and reconnect the uplink whenever no packets have been received from the remote client for more than 30 seconds. Each camera shall use an individual ascending interval strategy to avoid that all cameras connect at the same time.</para>
+      <para>The local service shall monitor whether the remote client is able to communicate via the
+        uplink. It may use the HTTP/2 ping mechanism to check whether a link is still operational if
+        no packets have been received for a longer period of time.</para>
+      <para>The local service shall close and reconnect the uplink whenever no packets have been
+        received from the remote client for more than 30 seconds. Each camera shall use an
+        individual ascending interval strategy to avoid that all cameras connect at the same
+        time.</para>
       <para>The following example shows patterns chosen by two cameras A and B:</para>
       <itemizedlist>
         <listitem>
@@ -265,16 +270,23 @@
           <para>Camera B: 2s, 4s, 8s, 16s, 30s, 30s, 30s ...</para>
         </listitem>
       </itemizedlist>
-      <para>If the uplink list contains multiple entries the device shall try to establish all connections in parallel. </para>
-      <para>Note that this specification assumes that scenarios with multiple clients are designed such that they do not interfere with each other. The coordination between such multiple clients is outside of the scope of the specification.</para>
+      <para>If multiple uplink configurations are included, the device shall try to establish
+        all connections in parallel. </para>
+      <para>Note that this specification expects different clients may try to reach multiple local
+        services and it is assumed services and clients are designed such that they do not interfere
+        with each other. The coordination between such multiple clients and services is outside of
+        the scope of the specification.</para>
     </section>
     <section>
       <title>Authentication</title>
       <para>Note that for the following discussion the roles of client and server are swapped.</para>
-      <para>The remote client shall authenticate itself using a valid server certificate. The service shall verify the validity of the remote certificate according to RFC 6125.</para>
+      <para>The remote client shall authenticate itself using a valid server certificate. The local
+        service shall verify the validity of the remote certificate according to RFC 6125.</para>
       <section>
         <title>mTLS authentication</title>
-        <para>When using mTLS authentication, the service shall authenticate itself at the remote client using TLS client authentication according to RFC 5246 or subsequent specifications.</para>
+        <para>When using mTLS authentication, the local service shall authenticate itself at the
+          remote client using TLS client authentication according to RFC 5246 or subsequent
+          specifications.</para>
         <para>To uniquely identify a local service on remote client, it is recommended to have a unique client certificate installed on each local service. For example, CN field or Serial number of installed certificate could be used to uniquely identify the local service.</para>
         <para>The device shall assign any tunneled HTTP or RTSP request the UserLevel that is configured for the configuration without the need of further authentication request headers. </para>
         <para>If the <literal>CertificateID</literal> is present in the <literal>UplinkConfiguration</literal> the device shall use this authentication mechanism.</para>
@@ -294,8 +306,8 @@
         <title>Introduction</title>
         <para>The ONVIF Media Service Specification and the ONVIF Streaming Specification define
           various mechanism for streaming Video, Audio and Metadata. This specification defines how
-          to apply streaming over http. Usage of other communication mechanism like UDP unicast and
-          multicast are outside of the scope of this specification.</para>
+          to apply streaming over http/2. Usage of other communication mechanism like UDP unicast
+          and multicast are outside of the scope of this specification.</para>
       </section>
       <section>
         <title>RTSP over HTTP</title>
@@ -310,8 +322,8 @@
       </section>
       <section>
         <title>RTSP over WebSockets</title>
-        <para>A device signaling support for websockets over RTSP via its capabilities shall support
-          RFC 8441 on the uplink.</para>
+        <para>A device signaling support for websockets over RTSP via its capability
+          RTSPWebSocketUri shall support RFC 8441 on the uplink.</para>
       </section>
     </section>
   </chapter>
@@ -321,22 +333,33 @@
       <title>Configuration parameters</title>
       <itemizedlist>
         <listitem>
-          <para>RemoteAddress Uniform resource locator by which the remote client can be reached.</para>
+          <para>RemoteAddress : Uniform resource locator by which the remote client can be
+            reached.</para>
         </listitem>
         <listitem>
-          <para>CertificateID	ID of the certificate to be used for client authentication.</para>
+          <para>CertificateID : ID of the certificate to be used for client authentication.</para>
         </listitem>
         <listitem>
-          <para>UserLevel	Authorization level that will be assigned to the uplink connection</para>
+          <para>UserLevel : Authorization level that will be assigned to the uplink
+            connection</para>
         </listitem>
         <listitem>
-          <para>Status	Current connection status</para>
+          <para>Status :  Current connection status</para>
         </listitem>
          <listitem>
-          <para>CertPathValidationPolicyID  ID of Certificate Validation policy to validate the remote uplink server certficate. If not configured, server certificate shall not be validated. </para>
+          <para>CertPathValidationPolicyID : ID of Certificate Validation policy to validate the
+            remote uplink server certficate. If not configured, server certificate shall not be
+            validated. </para>
+        </listitem>
+        <listitem>
+          <para>AuthorizationServer :  JWTConfiguration token referring to an Authorization server
+            that provides JWT token to authorize with the uplink server.</para>
         </listitem>
       </itemizedlist>
-      <para>Field RemoteAddress is used as key of the list of uplink configurations.</para>
+      <para>The device shall interpret the field RemoteAddress as key to a specific uplink
+        configuration.</para>
+      <para>A device shall reject a configuration containing both CertificateID and
+        AuthorizationServer. </para>
     </section>
     <section>
       <title>GetUplinks</title>
@@ -385,6 +408,10 @@
           <listitem>
             <para role="param">env:Sender - ter:InvalidArgVal - ter:CertificateID</para>
             <para role="text"> No certificate is stored under the requested CertificateID.</para>
+            <para role="param">env:Sender - ter:InvalidArgVal -
+              ter:CertPathValidationPolicyID</para>
+            <para role="text"> No certificate validation policy is stored under the requested
+              CertPathValidationPolicyID.</para>
             <para role="param">env:Sender - ter:InvalidArgVal - ter:AuthorizationServerConfigurationToken</para>
             <para role="text"> No AuthorizationServerConfiguration exists for the specified token.</para>
             <para role="param">env:Sender - ter:InvalidArgs - ter:MissingAuthentication</para>

--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -9,7 +9,7 @@
       <orgname>ONVIF™</orgname>
       <uri>www.onvif.org</uri>
     </author>
-    <pubdate>Feb 2024 Draft for IPR Review</pubdate>
+    <pubdate>Feb 20204 Draft</pubdate>
     <mediaobject>
       <imageobject>
         <imagedata fileref="media/logo.png" contentwidth="60mm"/>

--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -521,9 +521,18 @@
     <title>WebRTC Usage</title>
     <para>This chapter describes ONVIF specific usage of WebRTC regarding how to send data between
       the client and device on the peer-to-peer connection.</para>
-    <para>Devices may define profiles for different streaming scenarios that can be choosen by the
-      client based on the available bandwidth or other limiting factors. For example, a specific
-      profile for mobile clients, another one for high quality streaming, etc.</para>
+    <section xml:id="section_uyt_v12_v5b">
+      <title>Bandwidth management</title>
+      <para>Devices may define profiles for different streaming scenarios that can be chosen by the
+       client based on the available bandwidth or other limiting factors. For example, a specific
+       profile for mobile clients, another one for high quality streaming, etc.</para>
+      <para>Devices should estimate available uplink bandwidth and reduce stream
+       bitrate as needed to avoid packet loss. It may be achieved by switching the currently
+       streamed profile into a profile with a lower bitrate encoding. Devices are allowed to
+       switch only between profiles with the same video source and same video codec. Once there
+       is enough available bandwidth, devices should aim to switch back to the initially selected
+       profile.</para>
+    </section>
     <section xml:id="section_vyt_v12_v5b">
       <title>Video</title>
       <para>When using WebRTC with a web browser only certain codecs will work. Because of this

--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -264,7 +264,7 @@
       <emphasis role="italic">client</emphasis> and a <emphasis role="italic">device</emphasis> 
       with the intention of establishing a WebRTC peer-to-peer connection between the
       client and a device. The messages are always sent via the <emphasis>signaling
-      server</emphasis> called <emphasis>server</emphasis> from now on. Once a peer-to-peer
+        server</emphasis> called <emphasis>server</emphasis> from now on. Once a peer-to-peer
       connection has been established the connection with the server can be dropped without
       affecting the peer-to-peer connection.</para>
     <figure xml:id="_Ref493258797">
@@ -278,7 +278,7 @@
     <section>
       <title>WebSocket Connection Management</title>
       <para>Both a client and a device need to connect to the server by setting up a WebSocket
-        connection according to [RFC 6455]. The WebSocket subprotocol shall be set to
+        connection according to [RFC 6455]. The WebSocket sub protocol shall be set to
         'webrtc.onvif.org'.</para>
       <para>A device shall connect to a signaling server as soon as the configuration contains a valid URI. </para>
       <para>In case a connection is dropped the device shall reconnect automatically. Each client
@@ -290,7 +290,7 @@
     </section>
     <section xml:id="section_ayt_v12_v5b">
       <title>Communication Protocol</title>
-      <para>The communication protocols shall use JSON-RPC version 2 over a WebSocket connection.
+      <para>The communication protocols shall use JSON-RPC version 2 over a WebSocket connection .
         Parameters shall be passed through an Object by-name [JSON-RPC section 4.2]. The table below provides the encodings to
         be used.</para>
       <para>
@@ -360,166 +360,242 @@
           </varlistentry>
       </variablelist>
       </section>
-      <section xml:id="section_init">
-        <title>connect</title>
-        <para>An ONVIF compliant signaling server and device shall support this command to establish a
-          streaming session between two peers.</para>
-        <variablelist role="op">
-          <varlistentry>
-            <term>request</term>
-            <listitem>
+    <section xml:id="section_init">
+      <title>connect</title>
+      <para>An ONVIF compliant signaling server and device shall support this command to establish a
+        streaming session between two peers. </para>
+      <variablelist role="op">
+        <varlistentry>
+          <term>request</term>
+          <listitem>
               <para role="param">peer optional [string]</para>
-              <para role="text">The ID of the peer to connect to.</para>
-              <para role="param">authorization [JWT]</para>
-              <para role="text">Access token that authorizes the device or client.</para>
-              <para role="param">session optional [string]</para>
-              <para role="text">The ID assigned by the signaling server to the session.</para>
-              <para role="param">profile optional [string]</para>
+            <para role="text">The ID of the peer to connect to.</para>
+            <para role="param">authorization [JWT]</para>
+            <para role="text">Access token that authorizes the device or client.</para>
+            <para role="param">session optional [string]</para>
+            <para role="text">The ID assigned by the signaling server to the session.</para>
+            <para role="param">profile optional [string]</para>
               <para role="text">Optional token of the media streaming profile to use.</para>
-              <para role="param">iceServers optional unbounded [RTCIceServer]</para>
-              <para role="text">List of STUN and TURN servers to be used.</para>
-            </listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>response</term>
-            <listitem>
-              <para role="param">session optional [string]</para>
-              <para role="text">The ID assigned by the signaling server to the session.</para>
-              <para role="param">iceServers optional unbounded [RTCIceServer]</para>
-              <para role="text">List of STUN and TURN servers to be used.</para>
-            </listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>faults</term>
-            <listitem>
-              <para role="param">401 Authorization failed</para>
-              <para role="text">The JWT token cannot be verified, does not include the required claims or has expired.</para>
+            <para role="param">iceServers optional unbounded [RTCIceServer]</para>
+            <para role="text">List of STUN and TURN servers to be used. </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>response</term>
+          <listitem>
+            <para role="param">session optional [string]</para>
+            <para role="text">The ID assigned by the signaling server to the session. </para>
+            <para role="param">iceServers optional unbounded [RTCIceServer]</para>
+            <para role="text">List of STUN and TURN servers to be used. </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>faults</term>
+          <listitem>
+            <para role="param">401 Authorization failed</para>
+            <para role="text">The JWT token cannot be verified, does not include the required claims or has expired.</para>
               <para role="param">403 Forbidden</para>
               <para role="text">The client is not authorized to connect to the provided peer.</para>
-              <para role="param">480 Temporary unavailable.</para>
-              <para role="text">The target device is currently unavailable.</para>
-            </listitem>
-          </varlistentry>
-        </variablelist>
-        <para>An ONVIF compliant signaling server shall provide the session ID and a list of STUN and TURN servers in
+            <para role="param">480 Temporary unavailable.</para>
+            <para role="text">The target device is currently unavailable.</para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+      <para>An ONVIF compliant signaling server shall provide the session ID and a list of STUN and TURN servers in
           both request and response such that both device and client can use them.
-          A compliant client and device shall support password based authentication of TURN server.
-          The urls parameter of the iceServers shall always be encoded as array of strings. The
-          optional shortcut defined by W3C WebRTC specification of passing a single string shall not
-          be used.</para>
-        <para>An ONVIF compliant device shall issue an invite method immediately after responding to
-          this method.</para>
-      </section>
-      <section xml:id="section_invite">
-        <title>invite</title>
-        <para>An ONVIF compliant signaling server shall support this command to establish a streaming
-          session between two peers. It shall forward this command to the client and correspondingly
-          route the response back to the device.</para>
-        <para>The dynamics and the format of the SDP records are defined in RFC 8829.</para>
-        <variablelist role="op">
-          <varlistentry>
-            <term>request</term>
-            <listitem>
-              <para role="param">session [string]</para>
-              <para role="text">The ID assigned by the signaling server to the session.</para>
-              <para role="param">offer [SDP]</para>
-              <para role="text">The SDP offer provided by the device.</para>
-            </listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>response</term>
-            <listitem>
-              <para role="param">answer [SDP]</para>
-              <para role="text">The SDP answer provided by the client. </para>
-            </listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>faults</term>
-            <listitem>
-              <para role="param">400 Bad Request</para>
-              <para role="text">Invalid session ID or SDP payload.</para>
-              <para role="param">408 Request Timeout</para>
-              <para role="text">The peer did not react.</para>
-              <para role="param">410 Gone</para>
-              <para role="text">The peer is no more available.</para>
-            </listitem>
-          </varlistentry>
-        </variablelist>
-      </section>
-      <section xml:id="section_trickle">
-        <title>trickle</title>
-        <para>An ONVIF compliant signaling server, device and client shall support this command to
-          signal new ICE candidates for the trickleICE procedure as defined in RFC 8840.</para>
-        <para>A signaling server shall relay this command unaltered to the peer.</para>
-        <variablelist role="op">
-          <varlistentry>
-            <term>request</term>
-            <listitem>
-              <para role="param">session [string]</para>
-              <para role="text">The ID assigned by the signaling server to the session.</para>
-              <para role="param">candidate [IceCandidate]</para>
-              <para role="text">The ICE Candidate SDP update for the peer. </para>
-            </listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>response</term>
-            <listitem>
-              <para role="text">&lt;none&gt;</para>
-            </listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>faults</term>
-            <listitem>
-              <para role="text">&lt;none&gt;</para>
-            </listitem>
-          </varlistentry>
-        </variablelist>
-        <para>Both client and device produce ICE candidates and send them to each other, via the
+        A compliant client and device shall support password based authentication of TURN server.
+        The urls parameter of the iceServers shall always be encoded as array of strings. The
+        optional shortcut defined by W3C WebRTC specification of passing a single string shall not
+        be used. </para>
+      <para>An ONVIF compliant device shall issue an invite method immediately after responding to
+        this method.</para>
+    </section>
+    <section xml:id="section_invite">
+      <title>invite</title>
+      <para>An ONVIF compliant signaling server shall support this command to establish a streaming
+        session between two peers. It shall forward this command to the client and correspondingly
+        route the response back to the device.</para>
+      <para>The dynamics and the format of the SDP records are defined in RFC 8829.</para>
+      <variablelist role="op">
+        <varlistentry>
+          <term>request</term>
+          <listitem>
+            <para role="param">session [string]</para>
+            <para role="text">The ID assigned by the signaling server to the session. </para>
+            <para role="param">offer [SDP]</para>
+            <para role="text">The SDP offer provided by the device. </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>response</term>
+          <listitem>
+            <para role="param">answer [SDP]</para>
+            <para role="text">The SDP answer provided by the client. </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>faults</term>
+          <listitem>
+            <para role="param">400 Bad Request</para>
+            <para role="text">Invalid session ID or SDP payload.</para>
+            <para role="param">408 Request Timeout</para>
+            <para role="text">The peer did not react.</para>
+            <para role="param">410 Gone</para>
+            <para role="text">The peer is no more available.</para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </section>
+    <section xml:id="section_trickle">
+      <title>trickle</title>
+      <para>An ONVIF compliant signaling server, device and client shall support this command to
+        signal new ICE candidates for the trickleICE procedure as defined in RFC 8840.</para>
+      <para>A signaling server shall relay this command unaltered to the peer.</para>
+      <variablelist role="op">
+        <varlistentry>
+          <term>request</term>
+          <listitem>
+            <para role="param">session [string]</para>
+            <para role="text">The ID assigned by the signaling server to the session. </para>
+            <para role="param">candidate [IceCandidate]</para>
+            <para role="text">The ICE Candidate SDP update for the peer. </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>response</term>
+          <listitem>
+            <para role="text">&lt;none&gt;</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>faults</term>
+          <listitem>
+            <para role="text">&lt;none&gt;</para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+      <para>Both client and device produce ICE candidates and send them to each other, via the
           server. Once all ICE candidates have been sent by a peer, it shall send a last trickle 
           notification with an empty ICE candidate content to indicate that all candidates have
           been sent according to RFC 8838.</para>
-        <para><emphasis role="bold">NOTE</emphasis>: Note that ICE candidates can arrive <emphasis
-          role="bold">before</emphasis> the SDP offer and the implementing client needs to handle
-          this.</para>
-        <para>If everything works as it should, a peer-to-peer WebRTC session can be set up between
-          client and device. After the session has been established the client can terminate the
-          WebSocket session to the signaling server and the peer-to-peer connection will not be
+      <para><emphasis role="bold">NOTE</emphasis>: Note that ICE candidates can arrive <emphasis
+        role="bold">before</emphasis> the SDP offer and the implementing client needs to handle
+        this.</para>
+      <para>If everything works as it should, a peer-to-peer WebRTC session can be set up between
+        client and device. After the session has been established the client can terminate the
+        WebSocket session to the signaling server and the peer-to-peer connection will not be
           affected.</para>
-      </section>
-      <section>
-        <title>Example Flow (informative)</title>
-        <para>The following example shows the flow using JSON-RPC 2.0. Note that for improved
+    </section>
+    <section xml:id="section_error_notification">
+      <title>error</title>
+      <para>An ONVIF compliant signaling server, device and client shall support sending or receiving notifications signaling that an error has occurred.</para>
+      <para>This message is a [JSON-RPC] "Request notification" and shall include [JSON-RPC] "Error object" in its <literal>params</literal> field.</para>
+      <variablelist role="op">
+        <varlistentry>
+          <term>request</term>
+          <listitem>
+            <para role="param">code [int]</para>
+            <para role="text">A number that indicates the error type that occurred.</para>
+            <para role="param">message [string]</para>
+            <para role="text">A string providing a short description of the error. The message should be limited to a concise single sentence.</para>
+            <para role="param">session [string]</para>
+            <para role="text">The ID assigned by the signaling server to the session. </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>response</term>
+          <listitem>
+            <para role="text">&lt;none&gt;</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>faults</term>
+          <listitem>
+            <para role="text">&lt;none&gt;</para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+      <para>The following table defines possible error codes:</para>
+      <table>
+        <title>WebRTC signaling errors</title>
+        <tgroup cols="3">
+          <colspec colname="c1" colwidth="49*" />
+          <colspec colname="c2" colwidth="13*" />
+          <colspec colname="c3" colwidth="37*" />
+          <thead>
+            <row>
+              <entry>
+                <para>Signaling Error</para>
+              </entry>
+              <entry>
+                <para>Error Code</para>
+              </entry>
+              <entry>
+                <para>Reason</para>
+              </entry>
+            </row>
+          </thead>
+          <tbody valign="top">
+            <row>
+              <entry>
+                <para>Malformed candidate</para>
+              </entry>
+              <entry>
+                <para>1001</para>
+              </entry>
+              <entry>
+                <para>The trickle ICE candidate received is malformed.</para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>Peer disconnected</para>
+              </entry>
+              <entry>
+                <para>1002</para>
+              </entry>
+              <entry>
+                <para>A peer in the session has closed its websocket connection with the Signaling Server.</para>
+              </entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </section>
+    <section>
+      <title>Example Flow (informative)</title>
+      <para>The following example shows the flow using JSON-RPC 2.0. Note that for improved
           readability the mandatory JSON version string is not shown.</para>
-        <programlisting><![CDATA[
-  Client -> Server: { "method": "register", "params": {"authorization": "JWT..."}, "id":1}
-  Server -> Client: { "result": { "id": "client-a1" }, "id": 1}
-  Device -> Server: { "method": "register", "params": {"authorization": "JWT..."}, "id":1}
-  Server -> Device: { "result": { "id": "device-b1" }, "id": 1}
+      <programlisting><![CDATA[
+Client -> Server: { "method": "register", "params": {"authorization": "JWT..."}, "id":1}
+Server -> Client: { "result": { "id": "client-a1" }, "id": 1}
+Device -> Server: { "method": "register", "params": {"authorization": "JWT..."}, "id":1}
+Server -> Device: { "result": { "id": "device-b1" }, "id": 1}
 
-  Client -> Server: { "method": "connect", 
-                "params": {"authorization": "JWT...", "DeviceID": "device-b1"}, "id":2}
-  Server -> Device: { "method": "connect", 
+Client -> Server: { "method": "connect", 
+              "params": {"authorization": "JWT...", "DeviceID": "device-b1"}, "id":2}
+Server -> Device: { "method": "connect", 
                 "params": {"session": "s1", "iceServers": [{"urls": ["stun:1.2.3.4"]}], "id":2}
   Device -> Server: { "result": {}, "id": 2}
-  Server -> Client: { "result": {"session": "s1", 
-                                "iceServers": [{"urls": ["stun:1.2.3.4"]}]}, "id": 2}
+Server -> Client: { "result": {"session": "s1", 
+                               "iceServers": [{"urls": ["stun:1.2.3.4"]}]}, "id": 2}
 
   Device -> Server: { "method": "invite", "params": {"session": "s1", "offer": "SDP..."}, "id":3}
-  Server -> Client: { "method": "invite", "params": {"session": "s1", "offer": "SDP..."}, "id":3}
-  Client -> Server: { "result": {"answer": "SDP..."}, "id": 3}
+Server -> Client: { "method": "invite", "params": {"session": "s1", "offer": "SDP..."}, "id":3}
+Client -> Server: { "result": {"answer": "SDP..."}, "id": 3}
   Server -> Device: { "result": {"answer": "SDP..."}, "id": 3}
 
-  Device -> Server: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
-  Server -> Client: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
-
-  Client -> Server: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
-  Server -> Device: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
+Device -> Server: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
+Server -> Client: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
 
 Client -> Server: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
 Server -> Device: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
-  ...
-  ]]></programlisting>
-      </section>
+
+Client -> Server: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
+Server -> Device: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
+...
+]]></programlisting>
+    </section>
     </section>
   </chapter>
   <chapter xml:id="chapter_uyt_v12_v5b">
@@ -529,8 +605,8 @@ Server -> Device: { "method": "trickle", "params": {"session": "s1", "candidate"
     <section xml:id="section_uyt_v12_v5b">
       <title>Bandwidth management</title>
       <para>Devices may define profiles for different streaming scenarios that can be chosen by the
-       client based on the available bandwidth or other limiting factors. For example, a specific
-       profile for mobile clients, another one for high quality streaming, etc.</para>
+      client based on the available bandwidth or other limiting factors. For example, a specific
+      profile for mobile clients, another one for high quality streaming, etc.</para>
       <para>Devices should estimate available uplink bandwidth and reduce stream
        bitrate as needed to avoid packet loss. It may be achieved by switching the currently
        streamed profile into a profile with a lower bitrate encoding. Devices are allowed to

--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -538,13 +538,13 @@
           <tbody valign="top">
             <row>
               <entry>
-                <para>Malformed candidate</para>
+                <para>Insufficient resources</para>
               </entry>
               <entry>
                 <para>1001</para>
               </entry>
               <entry>
-                <para>The trickle ICE candidate received is malformed.</para>
+                <para>The peer does not have sufficient resources.</para>
               </entry>
             </row>
             <row>
@@ -556,6 +556,17 @@
               </entry>
               <entry>
                 <para>A peer in the session has closed its websocket connection with the Signaling Server.</para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>Malformed candidate</para>
+              </entry>
+              <entry>
+                <para>1003</para>
+              </entry>
+              <entry>
+                <para>The trickle ICE candidate received is malformed.</para>
               </entry>
             </row>
           </tbody>

--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -136,16 +136,17 @@
             <row>
               <entry align="left">
                 <para>
-                  <emphasis role="bold">Peer-ID</emphasis>
+                  <emphasis role="bold">Peer ID</emphasis>
                 </para>
               </entry>
-              <entry>A peer's assigned ID provided by the signaling server. Matches to GUID for
-                persistent peers like devices.</entry>
+              <entry>
+                <para>A peer's assigned ID provided by the signaling server.</para>
+              </entry>
             </row>
             <row>
               <entry align="left">
                 <para>
-                  <emphasis role="bold">Session-ID</emphasis>
+                  <emphasis role="bold">Session ID</emphasis>
                 </para>
               </entry>
               <entry align="left">
@@ -177,14 +178,6 @@
               </entry>
               <entry valign="middle">
                 <para>Network Address Translation</para>
-              </entry>
-            </row>
-            <row>
-              <entry valign="middle">
-                <para>P2P</para>
-              </entry>
-              <entry valign="middle">
-                <para>Peer-to-peer</para>
               </entry>
             </row>
             <row>
@@ -226,11 +219,11 @@
   </chapter>
   <chapter xml:id="chapter_yxt_v12_v5b">
     <title>Overview</title>
-    <para>The WebRTC standard includes APIs for communicating with an ICE Server, but the signaling
+    <para>The WebRTC standard includes APIs for communicating with an ICE Agent, but the signaling
       component is not part of it. Signaling is needed in order for two peers to share how they
       should connect.</para>
     <para>Signaling can be implemented in many different ways, and the WebRTC standard doesn't
-      prefer any specific solution.</para>
+      recommend any specific solution.</para>
     <para>This specification contains documentation and examples of the signaling protocol used in
       ONVIF to set up a WebRTC peer-to-peer connection. The setup involves three participants:
         <emphasis role="italic">client</emphasis>, <emphasis role="italic">device</emphasis> and
@@ -246,7 +239,7 @@
     </figure>
     <para>In this figure,<itemizedlist>
         <listitem>
-          <para>The <emphasis role="italic">client</emphasis> represents a real user who initiates
+          <para>The <emphasis role="italic">client</emphasis> represents a user who initiates
             the WebRTC session.</para>
         </listitem>
         <listitem>
@@ -268,13 +261,12 @@
   <chapter xml:id="chapter_zxt_v12_v5b">
     <title>Signaling Protocol</title>
     <para>The <emphasis role="italic">Signaling Protocol</emphasis> defines the messages between a
-        <emphasis role="italic">client</emphasis> and a <emphasis role="italic">device</emphasis> in
-      a WebRTC system with the intention of esatblishing a peer-to-peer connection between the
+      <emphasis role="italic">client</emphasis> and a <emphasis role="italic">device</emphasis> 
+      with the intention of establishing a WebRTC peer-to-peer connection between the
       client and a device. The messages are always sent via the <emphasis>signaling
-        server</emphasis> called <emphasis>server</emphasis> from now on. Once a peer-to-peer
+      server</emphasis> called <emphasis>server</emphasis> from now on. Once a peer-to-peer
       connection has been established the connection with the server can be dropped without
-      affecting the peer-to-peer connection. It's however recommended to keep the server connection
-      open to be able receive error messages from the server.</para>
+      affecting the peer-to-peer connection.</para>
     <figure xml:id="_Ref493258797">
       <title>Signaling flow sequence diagram</title>
       <mediaobject>
@@ -286,7 +278,7 @@
     <section>
       <title>WebSocket Connection Management</title>
       <para>Both a client and a device need to connect to the server by setting up a WebSocket
-        connection according to [RFC 6455]. The WebSocket sub protocol shall be set to
+        connection according to [RFC 6455]. The WebSocket subprotocol shall be set to
         'webrtc.onvif.org'.</para>
       <para>A device shall connect to a signaling server as soon as the configuration contains a valid URI. </para>
       <para>In case a connection is dropped the device shall reconnect automatically. Each client
@@ -298,8 +290,8 @@
     </section>
     <section xml:id="section_ayt_v12_v5b">
       <title>Communication Protocol</title>
-      <para>The communication protocols shall use JSON-RPC version 2 over a WebSocket connection .
-        Parameters and responses shall be passed by name. The table below provides the encodings to
+      <para>The communication protocols shall use JSON-RPC version 2 over a WebSocket connection.
+        Parameters shall be passed through an Object by-name [JSON-RPC section 4.2]. The table below provides the encodings to
         be used.</para>
       <para>
         <table frame="all">
@@ -316,7 +308,7 @@
             <tbody>
               <row>
                 <entry><para>JWT</para></entry>
-                <entry><para>Base64 encoded according to RFC 7519</para></entry>
+                <entry><para>Encoded according to RFC 7519</para></entry>
               </row>
               <row>
                 <entry><para>SDP</para></entry>
@@ -329,10 +321,6 @@
               <row>
                 <entry><para>RTCIceServer</para></entry>
                 <entry><para>Connection parameters for a STUN or TURN server as defined by W3C WebRTC</para></entry>
-              </row>
-              <row>
-                <entry><para>URL</para></entry>
-                <entry><para>STUN or TURN server url encoded according to RFC 7064 or RFC 7065</para></entry>
               </row>
             </tbody>
           </tgroup>
@@ -349,7 +337,7 @@
           <term>request</term>
           <listitem>
             <para role="param">authorization [JWT]</para>
-            <para role="text">Access token that authorizes the device or client..</para>
+            <para role="text">Access token that authorizes the device or client.</para>
             <para role="param">id optional [string]</para>
             <para role="text">The unique ID of the device or client.</para>
             <para role="param">name optional [string]</para>
@@ -372,170 +360,168 @@
           </varlistentry>
       </variablelist>
       </section>
-    </section>
-    <section xml:id="section_init">
-      <title>connect</title>
-      <para>An ONVIF compliant signaling server and device shall support this command to establish a
-        streaming session between two peers. </para>
-      <variablelist role="op">
-        <varlistentry>
-          <term>request</term>
-          <listitem>
-            <para role="param">peer [string]</para>
-            <para role="text">The ID of the peer to connect to.</para>
-            <para role="param">authorization [JWT]</para>
-            <para role="text">Access token that authorizes the device or client.</para>
-            <para role="param">session optional [string]</para>
-            <para role="text">The ID assigned by the signaling server to the session.</para>
-            <para role="param">profile optional [string]</para>
-            <para role="text">Optional token of the media streaming profile to connect to.</para>
-            <para role="param">iceServers optional unbounded [RTCIceServer]</para>
-            <para role="text">List of STUN and TURN servers to be used. </para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term>response</term>
-          <listitem>
-            <para role="param">session optional [string]</para>
-            <para role="text">The ID assigned by the signaling server to the session. </para>
-            <para role="param">iceServers optional unbounded [RTCIceServer]</para>
-            <para role="text">List of STUN and TURN servers to be used. </para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term>faults</term>
-          <listitem>
-            <para role="param">401 Authorization failed</para>
-            <para role="text">The JWT token cannot be verified, does not include the required claims or has expired.</para>
-            <para role="param">408 Request Timeout</para>
-            <para role="text">The peer did not react.</para>
-            <para role="param">480 Temporary unavailable.</para>
-            <para role="text">The target device is currently unavailable.</para>
-          </listitem>
-        </varlistentry>
-      </variablelist>
-      <para>An ONVIF compliant signaling server shall provide the session ID and a list of STUN and TURN servers in
-        both request and response such that both device and client use the same set of ICE servers.
-        A compliant client and device shall support password based authentication of TURN server.
-        The urls parameter of the iceServers shall always be encoded as array of strings. The
-        optional shortcut defined by W3C WebRTC specification of passing a single string shall not
-        be used. </para>
-      <para>An ONVIF compliant device shall issue an invite method immediately after responding to
-        this method.</para>
-    </section>
-    <section xml:id="section_invite">
-      <title>invite</title>
-      <para>An ONVIF compliant signaling server shall support this command to establish a streaming
-        session between two peers. It shall forward this command to the client and correspondingly
-        route the response back to the device.</para>
-      <para>The dynamics and the format of the SDP records are defined in RFC 8829.</para>
-      <variablelist role="op">
-        <varlistentry>
-          <term>request</term>
-          <listitem>
-            <para role="param">session [string]</para>
-            <para role="text">The ID assigned by the signaling server to the session. </para>
-            <para role="param">offer [SDP]</para>
-            <para role="text">The SDP offer provided by the device. </para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term>response</term>
-          <listitem>
-            <para role="param">answer [SDP]</para>
-            <para role="text">The SDP answer provided by the client. </para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term>faults</term>
-          <listitem>
-            <para role="param">400 Bad Request</para>
-            <para role="text">Invalid session ID or SDP payload.</para>
-            <para role="param">408 Request Timeout</para>
-            <para role="text">The peer did not react.</para>
-            <para role="param">410 Gone</para>
-            <para role="text">The peer is no more available.</para>
-          </listitem>
-        </varlistentry>
-      </variablelist>
-    </section>
-    <section xml:id="section_trickle">
-      <title>trickle</title>
-      <para>An ONVIF compliant signaling server, device and client shall support this command to
-        signal new ICE candidates for the trickleICE procedure as defined in RFC 8840.</para>
-      <para>A signaling server shall relay this command unaltered to the peer.</para>
-      <variablelist role="op">
-        <varlistentry>
-          <term>request</term>
-          <listitem>
-            <para role="param">session [string]</para>
-            <para role="text">The ID assigned by the signaling server to the session. </para>
-            <para role="param">candidate [IceCandidate]</para>
-            <para role="text">The ICE Candidate SDP update for the peer. </para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term>response</term>
-          <listitem>
-            <para role="text">&lt;none&gt;</para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term>faults</term>
-          <listitem>
-            <para role="text">&lt;none&gt;</para>
-          </listitem>
-        </varlistentry>
-      </variablelist>
-      <para>Both client and device produce ICE candidates and send them to each other, via the
-        server, in any order.</para>
-      <para><emphasis role="bold">NOTE</emphasis>: Note that ICE candidates can arrive <emphasis
-        role="bold">before</emphasis> the SDP offer and the implementing client needs to handle
-        this.</para>
-      <para>If everything works as it should, a peer-to-peer WebRTC session can be set up between
-        client and device. After the session has been established the client can terminate the
-        WebSocket session to the signaling server and the peer-to-peer connection will not be
-        affected. However, it's recommended to keep the WebSocket session to the server open to be
-        able to receive event messages from the signaling server.</para>
-    </section>
-    <section>
-      <title>Example Flow (informative)</title>
-      <para>The following example shows the flow using JSON-RPC 2.0. Note that for improved
-        readability the madnatory JSON version string is not shown.</para>
-      <programlisting><![CDATA[
-Client -> Server: { "method": "register", "params": {"authorization": "JWT..."}, "id":1}
-Server -> Client: { "result": { "id": "client-a1" }, "id": 1}
-Device -> Server: { "method": "register", "params": {"authorization": "JWT..."}, "id":1}
-Server -> Device: { "result": { "id": "device-b1" }, "id": 1}
+      <section xml:id="section_init">
+        <title>connect</title>
+        <para>An ONVIF compliant signaling server and device shall support this command to establish a
+          streaming session between two peers.</para>
+        <variablelist role="op">
+          <varlistentry>
+            <term>request</term>
+            <listitem>
+              <para role="param">peer optional [string]</para>
+              <para role="text">The ID of the peer to connect to.</para>
+              <para role="param">authorization [JWT]</para>
+              <para role="text">Access token that authorizes the device or client.</para>
+              <para role="param">session optional [string]</para>
+              <para role="text">The ID assigned by the signaling server to the session.</para>
+              <para role="param">profile optional [string]</para>
+              <para role="text">Optional token of the media streaming profile to use.</para>
+              <para role="param">iceServers optional unbounded [RTCIceServer]</para>
+              <para role="text">List of STUN and TURN servers to be used.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>response</term>
+            <listitem>
+              <para role="param">session optional [string]</para>
+              <para role="text">The ID assigned by the signaling server to the session.</para>
+              <para role="param">iceServers optional unbounded [RTCIceServer]</para>
+              <para role="text">List of STUN and TURN servers to be used.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>faults</term>
+            <listitem>
+              <para role="param">401 Authorization failed</para>
+              <para role="text">The JWT token cannot be verified, does not include the required claims or has expired.</para>
+              <para role="param">403 Forbidden</para>
+              <para role="text">The client is not authorized to connect to the provided peer.</para>
+              <para role="param">480 Temporary unavailable.</para>
+              <para role="text">The target device is currently unavailable.</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+        <para>An ONVIF compliant signaling server shall provide the session ID and a list of STUN and TURN servers in
+          both request and response such that both device and client can use them.
+          A compliant client and device shall support password based authentication of TURN server.
+          The urls parameter of the iceServers shall always be encoded as array of strings. The
+          optional shortcut defined by W3C WebRTC specification of passing a single string shall not
+          be used.</para>
+        <para>An ONVIF compliant device shall issue an invite method immediately after responding to
+          this method.</para>
+      </section>
+      <section xml:id="section_invite">
+        <title>invite</title>
+        <para>An ONVIF compliant signaling server shall support this command to establish a streaming
+          session between two peers. It shall forward this command to the client and correspondingly
+          route the response back to the device.</para>
+        <para>The dynamics and the format of the SDP records are defined in RFC 8829.</para>
+        <variablelist role="op">
+          <varlistentry>
+            <term>request</term>
+            <listitem>
+              <para role="param">session [string]</para>
+              <para role="text">The ID assigned by the signaling server to the session.</para>
+              <para role="param">offer [SDP]</para>
+              <para role="text">The SDP offer provided by the device.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>response</term>
+            <listitem>
+              <para role="param">answer [SDP]</para>
+              <para role="text">The SDP answer provided by the client. </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>faults</term>
+            <listitem>
+              <para role="param">400 Bad Request</para>
+              <para role="text">Invalid session ID or SDP payload.</para>
+              <para role="param">408 Request Timeout</para>
+              <para role="text">The peer did not react.</para>
+              <para role="param">410 Gone</para>
+              <para role="text">The peer is no more available.</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+      </section>
+      <section xml:id="section_trickle">
+        <title>trickle</title>
+        <para>An ONVIF compliant signaling server, device and client shall support this command to
+          signal new ICE candidates for the trickleICE procedure as defined in RFC 8840.</para>
+        <para>A signaling server shall relay this command unaltered to the peer.</para>
+        <variablelist role="op">
+          <varlistentry>
+            <term>request</term>
+            <listitem>
+              <para role="param">session [string]</para>
+              <para role="text">The ID assigned by the signaling server to the session.</para>
+              <para role="param">candidate [IceCandidate]</para>
+              <para role="text">The ICE Candidate SDP update for the peer.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>response</term>
+            <listitem>
+              <para role="text">&lt;none&gt;</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>faults</term>
+            <listitem>
+              <para role="text">&lt;none&gt;</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+        <para>Both client and device produce ICE candidates and send them to each other, via the
+          server, in any order.</para>
+        <para><emphasis role="bold">NOTE</emphasis>: Note that ICE candidates can arrive <emphasis
+          role="bold">before</emphasis> the SDP offer and the implementing client needs to handle
+          this.</para>
+        <para>If everything works as it should, a peer-to-peer WebRTC session can be set up between
+          client and device. After the session has been established the client can terminate the
+          WebSocket session to the signaling server and the peer-to-peer connection will not be
+          affected.</para>
+      </section>
+      <section>
+        <title>Example Flow (informative)</title>
+        <para>The following example shows the flow using JSON-RPC 2.0. Note that for improved
+          readability the mandatory JSON version string is not shown.</para>
+        <programlisting><![CDATA[
+  Client -> Server: { "method": "register", "params": {"authorization": "JWT..."}, "id":1}
+  Server -> Client: { "result": { "id": "client-a1" }, "id": 1}
+  Device -> Server: { "method": "register", "params": {"authorization": "JWT..."}, "id":1}
+  Server -> Device: { "result": { "id": "device-b1" }, "id": 1}
 
-Client -> Server: { "method": "connect", 
-              "params": {"authorization": "JWT...", "DeviceID": "device-b1"}, "id":2}
-Server -> Device: { "method": "connect", 
-              "params": {"session": "s1", "iceServers": [{"urls": ["stun:1.2.3.4"]}], "id":1}
-Device -> Server: { "result": {}, "id": 1}
-Server -> Client: { "result": {"session": "s1", 
-                               "iceServers": [{"urls": ["stun:1.2.3.4"]}]}, "id": 2}
+  Client -> Server: { "method": "connect", 
+                "params": {"authorization": "JWT...", "DeviceID": "device-b1"}, "id":2}
+  Server -> Device: { "method": "connect", 
+                "params": {"session": "s1", "iceServers": [{"urls": ["stun:1.2.3.4"]}], "id":2}
+  Device -> Server: { "result": {}, "id": 2}
+  Server -> Client: { "result": {"session": "s1", 
+                                "iceServers": [{"urls": ["stun:1.2.3.4"]}]}, "id": 2}
 
-Device -> Server: { "method": "invite", "params": {"session": "s1", "offer": "SDP..."}, "id":2}
-Server -> Client: { "method": "invite", "params": {"session": "s1", "offer": "SDP..."}, "id":3}
-Client -> Server: { "result": {"answer": "SDP..."}, "id": 3}
-Server -> Device: { "result": {"answer": "SDP..."}, "id": 2}
+  Device -> Server: { "method": "invite", "params": {"session": "s1", "offer": "SDP..."}, "id":3}
+  Server -> Client: { "method": "invite", "params": {"session": "s1", "offer": "SDP..."}, "id":3}
+  Client -> Server: { "result": {"answer": "SDP..."}, "id": 3}
+  Server -> Device: { "result": {"answer": "SDP..."}, "id": 3}
 
-Device -> Server: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
-Server -> Client: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
+  Device -> Server: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
+  Server -> Client: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
 
-Client -> Server: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
-Server -> Device: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
-...
-]]></programlisting>
-      <para><emphasis>Remaining sections unaltered.</emphasis></para>
+  Client -> Server: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
+  Server -> Device: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
+  ...
+  ]]></programlisting>
+      </section>
     </section>
   </chapter>
   <chapter xml:id="chapter_uyt_v12_v5b">
     <title>WebRTC Usage</title>
     <para>This chapter describes ONVIF specific usage of WebRTC regarding how to send data between
       the client and device on the peer-to-peer connection.</para>
-    <para>Devices MAY define profiles for different streaming scenarios that can be choosen by the
+    <para>Devices may define profiles for different streaming scenarios that can be choosen by the
       client based on the available bandwidth or other limiting factors. For example, a specific
       profile for mobile clients, another one for high quality streaming, etc.</para>
     <section xml:id="section_vyt_v12_v5b">
@@ -553,98 +539,6 @@ Server -> Device: { "method": "trickle", "params": {"session": "s1", "candidate"
         loops.</para>
     </section>
   </chapter>
-  <appendix xml:id="chapter_cwp_r2k_v5b">
-    <title>Authentication with OpenID</title>
-    <para>This informative section describe how clients and devices may autheticate using JWT 
-      tokens obtained via OpenID Connect to access the signaling server.</para>
-    <section xml:id="section_msq_qhn_rwb">
-      <title>User login and access</title>
-      <para>A user logs in and gets an access token using OAuth2 and OpenID Connect. This is
-        described in the [ONVIF Security Service Specification].</para>
-    </section>
-    <section xml:id="section_dwp_r2k_v5b">
-      <title>Device access</title>
-      <para>In order for a device to connect to a signaling server an Authorization Server
-        Configuration must have been set up during device onboarding. See the [ONVIF Security
-        Service] regarding Authorization Server Configurations. This configuration tells the device
-        how to get an access token that can be used to connect to the signaling server. Typically a
-        configuration is created that allows the device to use OAuth2 Client Credentials Grant flow
-        using <code>private_key_jwt</code> as client authentication method as described in [OpenID
-        Connect Core]. In case <code>private_key_jwt</code> is used, the JWT contains these
-        claims:</para>
-      <table>
-        <title>JWT claims when using <code>private_key_jwt</code> (informative)</title>
-        <tgroup cols="2">
-          <colspec colname="c1" colnum="1" colwidth="20*"/>
-          <colspec colname="c2" colnum="2" colwidth="80*"/>
-          <thead>
-            <row>
-              <entry>
-                <para>Claim</para>
-              </entry>
-              <entry>
-                <para>Description</para>
-              </entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry>
-                <para>iss</para>
-              </entry>
-              <entry>
-                <para>client_id, an id that uniqely identifies the device, e.g.
-                  orgId/deviceId</para>
-              </entry>
-            </row>
-            <row>
-              <entry>
-                <para>sub</para>
-              </entry>
-              <entry>
-                <para>client_id, an id that uniqely identifies the device, e.g.
-                  orgId/deviceId</para>
-              </entry>
-            </row>
-            <row>
-              <entry>
-                <para>aud</para>
-              </entry>
-              <entry>
-                <para>Authorization server URI</para>
-              </entry>
-            </row>
-            <row>
-              <entry>
-                <para>jti</para>
-              </entry>
-              <entry>
-                <para>Random nonce</para>
-              </entry>
-            </row>
-            <row>
-              <entry>
-                <para>exp</para>
-              </entry>
-              <entry>
-                <para>Expiration time</para>
-              </entry>
-            </row>
-            <row>
-              <entry>
-                <para>iat (optional)</para>
-              </entry>
-              <entry>
-                <para>Issuance time</para>
-              </entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
-      <para>NOTE: This is one way for a device to authenticate. Other setups are possible depending
-        on the specific Authorization Server and Signaling Server configurations.</para>
-    </section>
-  </appendix>
   <appendix role="revhistory">
     <title>Revision History</title>
     <para/>

--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -9,7 +9,7 @@
       <orgname>ONVIF™</orgname>
       <uri>www.onvif.org</uri>
     </author>
-    <pubdate>Feb 20204 Draft</pubdate>
+    <pubdate>Feb 2024 Draft</pubdate>
     <mediaobject>
       <imageobject>
         <imagedata fileref="media/logo.png" contentwidth="60mm"/>

--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -458,7 +458,7 @@
               <para role="param">session [string]</para>
               <para role="text">The ID assigned by the signaling server to the session.</para>
               <para role="param">candidate [IceCandidate]</para>
-              <para role="text">The ICE Candidate SDP update for the peer.</para>
+              <para role="text">The ICE Candidate SDP update for the peer. </para>
             </listitem>
           </varlistentry>
           <varlistentry>
@@ -475,7 +475,9 @@
           </varlistentry>
         </variablelist>
         <para>Both client and device produce ICE candidates and send them to each other, via the
-          server, in any order.</para>
+          server. Once all ICE candidates have been sent by a peer, it shall send a last trickle 
+          notification with an empty ICE candidate content to indicate that all candidates have
+          been sent according to RFC 8838.</para>
         <para><emphasis role="bold">NOTE</emphasis>: Note that ICE candidates can arrive <emphasis
           role="bold">before</emphasis> the SDP offer and the implementing client needs to handle
           this.</para>
@@ -512,6 +514,9 @@
 
   Client -> Server: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
   Server -> Device: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
+
+Client -> Server: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
+Server -> Device: { "method": "trickle", "params": {"session": "s1", "candidate": {...}}}
   ...
   ]]></programlisting>
       </section>

--- a/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
+++ b/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
@@ -891,15 +891,18 @@
 			</xs:simpleType>
 			<!--===============================-->
 			<xs:simpleType name="ClientAuthenticationMethod">
+				<xs:annotation>
+					<xs:documentation>Client Authentication methods listed are referenced from <a href="https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml#token-endpoint-auth-method"> IANA OAuth Token Endpoint Authentication Methods</a>.</xs:documentation>
+				</xs:annotation>
 				<xs:restriction base="xs:string">
 					<xs:enumeration value="client_secret_basic">
 						<xs:annotation>
-							<xs:documentation>Use HTTP Authorization header to specify client_secret per RFC 6749</xs:documentation>
+							<xs:documentation>Use HTTP Authorization header to specify client_secret as per RFC 6749</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 					<xs:enumeration value="client_secret_post">
 						<xs:annotation>
-							<xs:documentation>Use HTTP POST body to specify client_secret per RFC 6749</xs:documentation>
+							<xs:documentation>Use HTTP POST body to specify client_secret as per RFC 6749</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 					<xs:enumeration value="client_secret_jwt">
@@ -909,17 +912,17 @@
 					</xs:enumeration>
 					<xs:enumeration value="private_key_jwt">
 						<xs:annotation>
-							<xs:documentation>Use PKI signed JWT using private key per OpenID Connect Core</xs:documentation>
+							<xs:documentation>Use PKI signed JWT using private key as per OpenID Connect Core</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 					<xs:enumeration value="tls_client_auth">
 						<xs:annotation>
-							<xs:documentation>Use PKI certificate to authenticate per RFC 8705</xs:documentation>
+							<xs:documentation>Use PKI certificate to authenticate as per RFC 8705</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 					<xs:enumeration value="self_signed_tls_client_auth">
 						<xs:annotation>
-							<xs:documentation>Use self-signed certificate to authenticate per RFC 8705</xs:documentation>
+							<xs:documentation>Use self-signed certificate to authenticate as per RFC 8705</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 				</xs:restriction>

--- a/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
+++ b/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
@@ -887,6 +887,11 @@
 							<xs:documentation>OAuth2 client credentials grant flow per RFC 6749</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
+					<xs:enumeration value="OIDC2AuthorizationCode">
+						<xs:annotation>
+							<xs:documentation>OpenID Connect authorization code flow per Open ID Connect Core</xs:documentation>
+						</xs:annotation>
+					</xs:enumeration>
 				</xs:restriction>
 			</xs:simpleType>
 			<!--===============================-->

--- a/wsdl/ver10/schema/metadatastream.xsd
+++ b/wsdl/ver10/schema/metadatastream.xsd
@@ -79,7 +79,6 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:enumeration value="ISBN-10"/>
 			<xs:enumeration value="ITF-14"/>
 			<xs:enumeration value="EAN-2"/>
-			<xs:enumeration value="EAN-2"/>
 			<xs:enumeration value="EAN-8"/>
 			<xs:enumeration value="EAN-13"/>
 			<xs:enumeration value="EAN-14"/>

--- a/wsdl/ver10/uplink/wsdl/uplink.wsdl
+++ b/wsdl/ver10/uplink/wsdl/uplink.wsdl
@@ -93,7 +93,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="AuthorizationServer" type="tt:ReferenceToken" minOccurs="0">
-						<xs:annotation><xs:documentation>The configuration to be used to obtain a JWT token to authorize with the uplink server.</xs:documentation></xs:annotation>
+						<xs:annotation><xs:documentation> JWTConfiguration token referring to an Authorization server that provides JWT token to authorize with the uplink server.</xs:documentation></xs:annotation>
 					</xs:element>
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	 <!-- first ONVIF then Vendor -->
 				</xs:sequence>

--- a/wsdl/ver20/analytics/humanbody.xsd
+++ b/wsdl/ver20/analytics/humanbody.xsd
@@ -76,6 +76,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="LongSleeve"/>
 			<xs:enumeration value="ShortSleeve"/>
+			<xs:enumeration value="Sleeveless"/>
 			<xs:enumeration value="Other"/>
 		</xs:restriction>
 	</xs:simpleType>
@@ -92,9 +93,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Tailor"/>
 			<xs:enumeration value="Jacket"/>
+			<xs:enumeration value="Shirt"/>
 			<xs:enumeration value="Sweater"/>
 			<xs:enumeration value="Overcoat"/>
 			<xs:enumeration value="Dress"/>
+			<xs:enumeration value="Vest"/> 	
 			<xs:enumeration value="Other"/>
 		</xs:restriction>
 	</xs:simpleType>
@@ -167,6 +170,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	</xs:complexType>
 	<xs:simpleType name="ShoesCategory">
 		<xs:restriction base="xs:string">
+			<xs:enumeration value="Boots"/>
 			<xs:enumeration value="LeatherShoes"/>
 			<xs:enumeration value="Sneakers"/>
 			<xs:enumeration value="Sandal"/>

--- a/wsdl/ver20/analytics/humanface.xsd
+++ b/wsdl/ver20/analytics/humanface.xsd
@@ -274,6 +274,21 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:enumeration value="Other"/>				
 		</xs:restriction>
 	</xs:simpleType>	
+
+	<xs:simpleType name="HatType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Cap"/>
+		</xs:restriction>
+	</xs:simpleType>	
+	
+	<xs:simpleType name="HelmetType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ConstructionCap"/>
+			<xs:enumeration value="CycleCap"/>
+			<xs:enumeration value="RidingHat"/>
+		</xs:restriction>
+	</xs:simpleType>	
+	
 	<xs:complexType name="PoseAngle">
 		<xs:sequence>
 			<xs:element name="PoseAngles" type="tt:GeoOrientation" minOccurs="0">
@@ -301,6 +316,12 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:annotation> 
 				<xs:documentation>Describe the Color of the accessory.</xs:documentation> 
 			</xs:annotation> 
+			</xs:element> 
+			<xs:element name="Subtype" type="xs:string" minOccurs="0">
+				<xs:annotation> 
+					<xs:documentation>Optional subtype of the accessory. For definitions refer enumerations starting with 
+						the accessory name followed by 'Type' like fc:HatType or fc:HelmetType.</xs:documentation> 
+				</xs:annotation> 
 			</xs:element> 
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- reserved for ONVIF -->
 		</xs:sequence>

--- a/wsdl/ver20/media/wsdl/media.wsdl
+++ b/wsdl/ver20/media/wsdl/media.wsdl
@@ -1245,14 +1245,14 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 							<xs:documentation>The default media profile to use for streaming if no specific profile is specified when initializing a session.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Enabled " type="xs:boolean">
+					<xs:element name="Enabled" type="xs:boolean">
 						<xs:annotation>
 							<xs:documentation> Enables/disables the configuration.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Connected " type="xs:boolean" minOccurs="0">
+					<xs:element name="Connected" type="xs:boolean" minOccurs="0">
 						<xs:annotation>
-							<xs:documentation> Enables/disables the configuration.</xs:documentation>
+							<xs:documentation>Indicates if the device is connected to the server. This parameter is read-only.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->


### PR DESCRIPTION
In the current WebRTC specification, there is no way for a peer to inform the other peer that an error has occurred outside of the response to some requests. 

Examples:
- If a peer has disconnected in the middle of the handshake from the signaling server, the other peer will have to wait for an indefinite period of time before closing its session. With this proposal, the signaling server will be able to notify the connected peer that its counterpart has disconnected and the session can be closed. 

- If a client sends a connect to a device that does not have sufficient resources to start a new session, the device will now be able to send an error 1001 to inform the client that it cannot continue with this session.