### PR TITLE
Add support for segment encryption

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -2071,7 +2071,8 @@ secfrac = "." 1*6DIGIT</programlisting>
         <para>
           A device signaling support for recording to an external target with segment encryption shall support writing encrypted files according to NIST SP 800-38A — Recommendation for Block Cipher Modes of Operation: Methods and Techniques.
           The device shall lists which encryption algorithm it supports using the SupportedEncryptionAlgorithms capability.
-          When uploading the segment to the external object storage, the device shall include the following attributes in the metadata: <literal>CertThumb</literal>, <literal>Key</literal>, <literal>KID</literal>, <literal>IV</literal> and <literal>EncAlgo</literal>.
+          When uploading the segment to the external object storage, the device shall include the following attributes in the metadata: <literal>CertThumb1</literal>, <literal>CertThumb2</literal>,
+          <literal>Key1</literal>, <literal>Key2</literal>, <literal>KID</literal>, <literal>IV</literal> and <literal>EncAlgo</literal>.
           The listed metadata attributes are necessary in order to be able to decrypt the encoded segment.
           <literal>KeyRotationDurationFrequency</literal> indicates at which frequency the device shall generate a new key to encrypt a new segment. If not specified, key rotation is per segment.
         </para>
@@ -2256,10 +2257,10 @@ secfrac = "." 1*6DIGIT</programlisting>
             </row>
             <row>
               <entry>
-                <para><literal>CertThumb</literal></para>
+                <para><literal>CertThumb1</literal></para>
               </entry>
               <entry>
-                <para>Certificate thumbprint using SHA256</para>
+                <para>Primary certificate thumbprint using SHA256</para>
               </entry>
               <entry>
                 <para>Base64 string</para>
@@ -2267,10 +2268,32 @@ secfrac = "." 1*6DIGIT</programlisting>
             </row>
             <row>
               <entry>
-                <para><literal>Key</literal></para>
+                <para><literal>CertThumb2</literal></para>
               </entry>
               <entry>
-                <para>Symmetric key encrypted using public key of certificate defined in CertThumb</para>
+                <para>Secondary certificate thumbprint using SHA256</para>
+              </entry>
+              <entry>
+                <para>Base64 string</para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para><literal>Key1</literal></para>
+              </entry>
+              <entry>
+                <para>Symmetric key encrypted using public key of primary certificate defined in CertThumb1</para>
+              </entry>
+              <entry>
+                <para>Base64 string</para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para><literal>Key2</literal></para>
+              </entry>
+              <entry>
+                <para>Symmetric key encrypted using public key of secondary certificate defined in CertThumb2</para>
               </entry>
               <entry>
                 <para>Base64 string</para>

--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -190,6 +190,8 @@ Change Request 2061, 2063, 2065, 2109</revremark>
     <para role="reference">RFC 6381 — The 'Codecs' and 'Profiles' Parameters for "Bucket" Media Types &lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.ietf.org/rfc/rfc6381.txt" />&gt;</para>
     <para role="reference">ONVIF Core Specification &lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.onvif.org/specs/core/ONVIF-Core-Specification.pdf"></link>&gt;</para>
     <para role="reference">ONVIF Schedule Service Specification &lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.onvif.org/specs/srv/sched/ONVIF-Scheduler-Service-Spec.pdf"></link>&gt; </para>
+    <para role="reference">NIST SP 800-38A — Recommendation for Block Cipher Modes of Operation: Methods and Techniques &lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://csrc.nist.gov/pubs/sp/800/38/a/final"></link>&gt; </para>
+    <para role="reference">W3C "keyids" Initialization Data Format &lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.w3.org/TR/eme-initdata-keyids"></link>&gt; </para>
   </chapter>
   <chapter>
     <title>Terms and Definitions</title>
@@ -485,6 +487,12 @@ Change Request 2061, 2063, 2065, 2109</revremark>
             <term>Encryption</term>
             <listitem>
               <para>Optional encryption configuration.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>SegmentEncryption</term>
+            <listitem>
+              <para>Optional full segment encryption configuration.</para>
             </listitem>
           </varlistentry>
         </variablelist>
@@ -1593,6 +1601,15 @@ Change Request 2061, 2063, 2065, 2109</revremark>
             </para>
           </listitem>
         </varlistentry>
+        <varlistentry>
+          <term>SupportedEncryptionAlgorithms</term>
+          <listitem>
+            <para>
+              Supported encryption algorithms for segment encryption.
+              See tt:EncryptionAlgorithm for a list of definitions.
+            </para>
+          </listitem>
+        </varlistentry>
       </variablelist>
     </section>
     <section>
@@ -2011,41 +2028,57 @@ secfrac = "." 1*6DIGIT</programlisting>
     </section>
     <section xml:id="_refCloudRecordingEncryption">
       <title>Encryption</title>
-      <para>
-        A device signaling support for recording to an external target with encryption shall support writing encrypted files according to ISO/IEC 23001-7 (common encryption in ISO base media file format files).
-        Each <literal>Encryption</literal> entry configured for a recording covers a distinct set of tracks for which to apply the encryption, identified by the <literal>Track</literal> element.
-        If an encryption entry contains no <literal>Track</literal> elements, it covers all tracks of the recording.
-        If an encryption entry contains one or more <literal>Track</literal> elements, it covers the tracks indicated by the track tokens contained in these elements.
-        The device shall encrypt the covered tracks with the scheme given by the <literal>Mode</literal> configured for the encryption entry:
-      </para>
-      <para>
-        <variablelist>
-          <varlistentry>
-            <term>CENC</term>
-            <listitem>
-              <para>
-                AES-CTR mode full sample and video NAL Subsample encryption, defined in ISO/IEC 23001-7.
-              </para>
-            </listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>CBCS</term>
-            <listitem>
-              <para>
-                AES-CBC mode partial video NAL pattern encryption, defined in ISO/IEC 23001-7.
-              </para>
-            </listitem>
-          </varlistentry>
-        </variablelist>
-      </para>
-      <para>
-        The device shall create an individual initialization vector for each segment.
-        The device shall encrypt with the <literal>Key</literal> configured for the encryption entry as the encryption key.
-        The device shall interpret the <literal>KID</literal> configured for the encryption entry as a 16-byte hexadecimal value and use this value as the key identifier.
-      </para>
-      <para>
-        If an encryption entry is reconfigured for an active recording, the device shall continue to use the old configuration for any open segments and shall start to use the new configuration for new segments.
-      </para>
+      <section xml:id="_refSampleEncryption">
+        <title>Sample Encryption</title>
+        <para>
+          A device signaling support for recording to an external target with sample encryption shall support writing encrypted files according to ISO/IEC 23001-7 (common encryption in ISO base media file format files).
+          Each <literal>Encryption</literal> entry configured for a recording covers a distinct set of tracks for which to apply the encryption, identified by the <literal>Track</literal> element.
+          If an encryption entry contains no <literal>Track</literal> elements, it covers all tracks of the recording.
+          If an encryption entry contains one or more <literal>Track</literal> elements, it covers the tracks indicated by the track tokens contained in these elements.
+          The device shall encrypt the covered tracks with the scheme given by the <literal>Mode</literal> configured for the encryption entry:
+        </para>
+        <para>
+          <variablelist>
+            <varlistentry>
+              <term>CENC</term>
+              <listitem>
+                <para>
+                  AES-CTR mode full sample and video NAL Subsample encryption, defined in ISO/IEC 23001-7.
+                </para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>CBCS</term>
+              <listitem>
+                <para>
+                  AES-CBC mode partial video NAL pattern encryption, defined in ISO/IEC 23001-7.
+                </para>
+              </listitem>
+            </varlistentry>
+          </variablelist>
+        </para>
+        <para>
+          The device shall create an individual initialization vector for each segment.
+          The device shall encrypt with the <literal>Key</literal> configured for the encryption entry as the encryption key.
+          The device shall interpret the <literal>KID</literal> configured for the encryption entry as a 16-byte hexadecimal value and use this value as the key identifier.
+        </para>
+        <para>
+          If an encryption entry is reconfigured for an active recording, the device shall continue to use the old configuration for any open segments and shall start to use the new configuration for new segments.
+        </para>
+      </section>
+      <section xml:id="_refSegmentEncryption">
+        <title>Segment Encryption</title>
+        <para>
+          A device signaling support for recording to an external target with segment encryption shall support writing encrypted files according to NIST SP 800-38A — Recommendation for Block Cipher Modes of Operation: Methods and Techniques.
+          The device shall lists which encryption algorithm it supports using the SupportedEncryptionAlgorithms capability.
+          When uploading the segment to the external object storage, the device shall include the following attributes in the metadata: <literal>CertThumb</literal>, <literal>Key</literal>, <literal>KID</literal>, <literal>IV</literal> and <literal>EncAlgo</literal>.
+          The listed metadata attributes are necessary in order to be able to decrypt the encoded segment.
+          <literal>KeyRotationDurationFrequency</literal> indicates at which frequency the device shall generate a new key to encrypt a new segment. If not specified, key rotation is per segment.
+        </para>
+        <para>
+          If an encryption entry is reconfigured for an active recording, the device shall continue to use the old configuration for any open segments and shall start to use the new configuration for new segments.
+        </para>
+      </section>
     </section>
     <section xml:id="_refCloudRecordingObjectAttributes">
       <title>Object attributes</title>
@@ -2219,6 +2252,61 @@ secfrac = "." 1*6DIGIT</programlisting>
               </entry>
               <entry>
                 <para>Integer</para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para><literal>CertThumb</literal></para>
+              </entry>
+              <entry>
+                <para>Certificate thumbprint using SHA256</para>
+              </entry>
+              <entry>
+                <para>Base64 string</para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para><literal>Key</literal></para>
+              </entry>
+              <entry>
+                <para>Symmetric key encrypted using public key of certificate defined in CertThumb</para>
+              </entry>
+              <entry>
+                <para>Base64 string</para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para><literal>KID</literal></para>
+              </entry>
+              <entry>
+                <para>Key ID for the encrypted segment. See [W3C "keyids"]</para>
+              </entry>
+              <entry>
+                <para>Base64 String</para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para><literal>IV</literal></para>
+              </entry>
+              <entry>
+                <para>Initialization vector</para>
+              </entry>
+              <entry>
+                <para>Base64 string</para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para><literal>EncAlgo</literal></para>
+              </entry>
+              <entry>
+                <para>See tt:EncryptionAlgorithm</para>
+              </entry>
+              <entry>
+                <para>String</para>
               </entry>
             </row>
           </tbody>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -4941,6 +4941,55 @@ CSeq: 2
 User-Agent: ./onvifClient
 Accept: application/sdp]]></programlisting>
   </appendix>
+  <appendix>
+    <title>Asymmetric Encryption</title>
+    <section>
+      <title>RSA</title>
+      <para>
+        Asymmetric encryption of data using RSA keys shall use the RSA OAEP encryption scheme as defined in RFC 8017 Section 7.1 with the SHA-256 hash unless otherwise specified.
+      </para>
+    </section>
+    <section>
+      <title>ECC</title>
+      <para>
+        Asymmetric encryption of data using ECC keys shall use the ECIES encryption scheme as defined in IEEE 1363-2000 unless otherwise specified. The ECIES scheme shall use the following algorithms:
+      </para>
+      <itemizedlist>
+        <listitem>
+          <para>The ECDH key agreement scheme using a new ephemeral key for the each encryption operation;</para>
+        </listitem>
+        <listitem>
+          <para>The key agreement material shall be derived using the SHA-256 hash algorithm;</para>
+        </listitem>
+        <listitem>
+          <para>
+            The encryption shall use AEAD-AES-256-GCM as defined in RFC 5116 Section 5.2 with a tag length of 16 bytes.
+            The nonce shall be set to zero, as the encryption key is never reused.
+          </para>
+        </listitem>
+      </itemizedlist>
+      <para>
+        The resulting ciphertext shall be encoded in the following way:
+      </para>
+      <itemizedlist>
+        <listitem>
+          <para>One byte set to the value <literal>0x01</literal> as a the format's version</para>
+        </listitem>
+        <listitem>
+          <para>The ECDH ephemeral key point X</para>
+        </listitem>
+        <listitem>
+          <para>The ECDH ephemeral key point Y</para>
+        </listitem>
+        <listitem>
+          <para>The AES-GCM encryption tag</para>
+        </listitem>
+        <listitem>
+          <para>The ciphertext</para>
+        </listitem>
+      </itemizedlist>
+    </section>
+  </appendix>
   <appendix role="revhistory">
     <title>Revision History</title>
     <para/>

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -7736,16 +7736,16 @@ and sample rate. </xs:documentation>
 	<!--===============================-->
 	<xs:complexType name="SegmentEncryption">
 		<xs:sequence>
+			<xs:element name="CertificateID" type="xs:token" minOccurs="2" maxOccurs="2">
+				<xs:annotation>
+					<xs:documentation>
+						ID of the certificates to use for the asymmetric encryption of the encryption keys
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<!--When <literal>KeyRotationDuration</literal> is set then the device shall generate a new <literal>KID/Key</literal> pair at the specified time interval as defined by <literal>KeyRotationDuration</literal>, but still use the current key until the segment is finished.-->
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
 		</xs:sequence>
-		<xs:attribute name="CertificateID" type="xs:token" use="required">
-			<xs:annotation>
-				<xs:documentation>
-					
-				</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
 		<xs:attribute name="EncryptionAlgorithm" type="xs:string" use="required">
 			<xs:annotation>
 				<xs:documentation>

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -7678,6 +7678,24 @@ and sample rate. </xs:documentation>
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:simpleType name="EncryptionAlgorithm">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AES-128-CBC">
+				<xs:annotation>
+					<xs:documentation>
+						AES 128 bit key using chain-block cypher mode [NIST SP 800-38A]
+					</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AES-256-CTR">
+				<xs:annotation>
+					<xs:documentation>
+						AES 256 bit key using counter mode [NIST SP 800-38A]
+					</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
 	<!--===============================-->
 	<xs:complexType name="RecordingEncryption">
 		<xs:sequence>
@@ -7711,6 +7729,36 @@ and sample rate. </xs:documentation>
 					Mode of encryption.
 					See tt:EncryptionMode for a list of definitions and capability trc:SupportedEncryptionModes for the supported encryption modes.
 				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:anyAttribute processContents="lax"/>
+	</xs:complexType>
+	<!--===============================-->
+	<xs:complexType name="SegmentEncryption">
+		<xs:sequence>
+			<!--When <literal>KeyRotationDuration</literal> is set then the device shall generate a new <literal>KID/Key</literal> pair at the specified time interval as defined by <literal>KeyRotationDuration</literal>, but still use the current key until the segment is finished.-->
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
+		</xs:sequence>
+		<xs:attribute name="CertificateID" type="xs:token" use="required">
+			<xs:annotation>
+				<xs:documentation>
+					
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="EncryptionAlgorithm" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>
+					See tt:EncryptionAlgorithm list for possible values. (AES-128)
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="KeyRotationDuration" type="xs:duration" use="optional">
+			<xs:annotation>
+				<xs:documentation>
+				Frequency at which the device shall generate a new key to encrypt a new segment.
+				If not specified, key rotation is per segment.
+				KeyRotationDuration must be a positive duration value.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:anyAttribute processContents="lax"/>
@@ -7754,10 +7802,17 @@ and sample rate. </xs:documentation>
 			<xs:element name="Encryption" type="tt:RecordingEncryption" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>
-						Optional encryption configuration.
+						Optional frame encryption configuration [Common encryption ISO/IEC 23001-7:2016]. This is mutually exclusive with tt:SegmentEncryption.
 						See capability trc:EncryptionEntryLimit for the number of supported entries.
 						By specifying multiple encryption entries per recording, different tracks can be encrypted with different configurations.
 						Each track shall only be contained in one encryption configuration.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="SegmentEncryption" type="tt:SegmentEncryption" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Optional full segment encryption configuration.
 					</xs:documentation>
 				</xs:annotation>
 			</xs:element>


### PR DESCRIPTION
We have tested using the current cloud recording specification to upload encrypted segments and playing them back through an HLS playlist on various devices. We have discovered that frame encryption is not well supported on Apple devices (iPhone, iPad & macbooks) without FairPlay.

For security reasons, some customers are not comfortable with frame encryption since metadata is in clear and for CBCS only 10% of the segment is encrypted.

This proposal adds a different mechanism for encrypting whole segments. It simplifies the whole process, adds compatibility with Apple devices and covers customer concerns about security. This proposal is compatible with both HLS and MPEG-DASH.