### PR TITLE
Add upload speed limit for cloud recording

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -2009,6 +2009,14 @@ secfrac = "." 1*6DIGIT</programlisting>
         </mediaobject>
       </figure>
     </section>
+    <section xml:id="_refCloudRecordingUpload">
+      <title>Uploading to an Object Storage</title>
+      <para>
+        A device signaling support for recording to an external target shall limit the upload speed so that a segment takes at least half as long as its duration to upload.
+        If the upload fails on the first try, the device shall retry uploading to the external target as fast as possible, to prevent loss of recording.
+        For example, if a segment has a duration of 1 minute, then the device shall limit the upload speed so that it completes the upload after 30 seconds.
+      </para>
+    </section>
     <section xml:id="_refCloudRecordingEncryption">
       <title>Encryption</title>
       <para>


### PR DESCRIPTION
This PR introduces a new upload limit for cloud recording, to help prevent network spikes when a device uploads a segment to the object storage. Without this type of limit, having numerous devices uploading their segments at the same time can greatly degrade the network quality of a customer.