### PR TITLE
Extend LPR event to include Speed and Direction of the detected object

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -7174,7 +7174,7 @@ xmlns:acme="http://www.acme.com/schema"&gt;
       <tt:ElementItemDescription Name="VehicleInfo" Type="tt:VehicleInfo"/>
       <tt:ElementItemDescription Name="VehicleImage" Type="xs:base64Binary"/>
       <tt:SimpleItemDescription Name="Speed" Type="xs:float"/>
-      <tt:SimpleItemDescription Name="Direction" Type="tt:GeoOrientation"/>
+      <tt:ElementItemDescription Name="Direction" Type="tt:GeoOrientation"/>
     </tt:Data>
     <tt:ParentTopic>
       tns1:RuleEngine/Recognition/LicensePlate

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -6994,6 +6994,11 @@ xmlns:acme="http://www.acme.com/schema"&gt;
               </entry>
             </row>
             <row>
+              <entry>ObjectID</entry>
+              <entry>ID of the recognized object of type tt:ObjectId</entry>
+              <entry>Optional</entry>
+            </row>
+            <row>
               <entry>
                 <para>BoundingBox</para>
               </entry>
@@ -7072,6 +7077,7 @@ xmlns:acme="http://www.acme.com/schema"&gt;
     </tt:Source>
     <tt:Data>
       <tt:SimpleItemDescription Name="Likelihood" Type="xs:float"/>
+      <tt:ElementItemDescription Name="ObjectId" Type="tt:ObjectId"/>
       <tt:SimpleItemDescription Name="Label" Type="xs:string "/>
       <tt:SimpleItemDescription Name="ImageUri" Type="xs:anyURI"/>
       <tt:SimpleItemDescription Name="EnrollmentID" Type="xs:string"/>
@@ -7142,30 +7148,33 @@ xmlns:acme="http://www.acme.com/schema"&gt;
   <tt:Parameters>
     <tt:SimpleItemDescription Name="IncludeImage" Type=”xs:string"/>
     <tt:SimpleItemDescription Name="PlateLocation" Type="xs:string"/>
-    <tt:ElementItemDescription Name=”Region” Type=”tt:Polygon”/>
-    <tt:ElementItemDescription Name=”SnapLine” Type=”tt:Polyline”/>
-	<tt: SimpleItemDescription Name=”Country” Type=”xs:string”/>
-	<tt: SimpleItemDescription Name=”Sensitivity” Type=”xs:float”/>
-	<tt: SimpleItemDescription Name=”Threshold” Type=”xs:float”/>
-	<tt: SimpleItemDescription Name=”PlateMinWidth” Type=”xs:float”/>
-	<tt: SimpleItemDescription Name=”PlateMaxWidth” Type=”xs:float”/>
-	<tt: SimpleItemDescription Name=”EventInterval” Type=”xs:int”/>
+    <tt:ElementItemDescription Name="Region" Type="tt:Polygon"/>
+    <tt:ElementItemDescription Name="SnapLine" Type="tt:Polyline"/>
+    <tt:SimpleItemDescription Name="Country" Type="xs:string"/>
+    <tt:SimpleItemDescription Name="Sensitivity" Type="xs:float"/>
+    <tt:SimpleItemDescription Name="Threshold” Type=”xs:float"/>
+    <tt:SimpleItemDescription Name="PlateMinWidth" Type="xs:float"/>
+    <tt:SimpleItemDescription Name="PlateMaxWidth" Type="xs:float"/>
+    <tt:SimpleItemDescription Name="EventInterval" Type="xs:int"/>
   </tt:Parameters>
   <tt:Messages>
     <tt:Source>
-      <tt:SimpleItemDescription Name=”VideoSource” Type=”tt:ReferenceToken”/>
-      <tt:SimpleItemDescription Name=”Rule” Type=”xs:string”/>
+      <tt:SimpleItemDescription Name="VideoSource" Type="tt:ReferenceToken"/>
+      <tt:SimpleItemDescription Name="Rule” Type="xs:string"/>
     </tt:Source>
     <tt:Data>
-      <SimpleItemDescription name="Likelihood" Type="xs:float"/>
+      <tt:SimpleItemDescription name="Likelihood" Type="xs:float"/>
+      <tt:ElementItemDescription Name="ObjectId" Type="tt:ObjectId"/>
       <tt:SimpleItemDescription Name="Label" Type="xs:string"/>
-      <tt:SimpleItemDescription Name=”ImageURI” Type=”xs:anyURI”/>
-      <tt:SimpleItemDescription Name=”VehicleImageURI” Type=”xs:anyURI”/>
-      <tt:ElementItemDescription Name=”BoundingBox” Type=”tt:Rectangle”/>
-      <tt:ElementItemDescription Name=”Image” Type=”xs:base64Binary/>
-      <tt:ElementItemDescription Name=”LicensePlateInfo” Type=”tt:LicensePlateInfo”/>
-      <tt:ElementItemDescription Name=”VehicleInfo” Type=”tt:VehicleInfo”/>
-      <tt:ElementItemDescription Name=”VehicleImage” Type=”xs:base64Binary/>
+      <tt:SimpleItemDescription Name="ImageURI" Type="xs:anyURI"/>
+      <tt:SimpleItemDescription Name="VehicleImageURI" Type="xs:anyURI"/>
+      <tt:ElementItemDescription Name="BoundingBox" Type="tt:Rectangle"/>
+      <tt:ElementItemDescription Name="Image" Type="xs:base64Binary"/>
+      <tt:ElementItemDescription Name="LicensePlateInfo" Type="tt:LicensePlateInfo"/>
+      <tt:ElementItemDescription Name="VehicleInfo" Type="tt:VehicleInfo"/>
+      <tt:ElementItemDescription Name="VehicleImage" Type="xs:base64Binary"/>
+      <tt:SimpleItemDescription Name="Speed" Type="xs:float"/>
+      <tt:SimpleItemDescription Name="Direction" Type="tt:GeoOrientation"/>
     </tt:Data>
     <tt:ParentTopic>
       tns1:RuleEngine/Recognition/LicensePlate
@@ -7352,6 +7361,16 @@ xmlns:acme="http://www.acme.com/schema"&gt;
               <entry>
                 <para>Optional</para>
               </entry>
+            </row>
+            <row>
+              <entry>Speed</entry>
+              <entry>Speed value of the recognized object in meters per second.</entry>
+              <entry>Optional</entry>
+            </row>
+            <row>
+              <entry>Direction</entry>
+              <entry>Direction of the object as a GeoOrientation type.</entry>
+              <entry>Optional</entry>
             </row>
           </tbody>
         </tgroup>

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -6999,6 +6999,11 @@ xmlns:acme="http://www.acme.com/schema"&gt;
               <entry>Optional</entry>
             </row>
             <row>
+              <entry>ParentObjectID</entry>
+              <entry>Parent Object ID of the recognized object of type tt:ObjectId</entry>
+              <entry>Optional</entry>
+            </row>
+            <row>
               <entry>
                 <para>BoundingBox</para>
               </entry>
@@ -7078,6 +7083,7 @@ xmlns:acme="http://www.acme.com/schema"&gt;
     <tt:Data>
       <tt:SimpleItemDescription Name="Likelihood" Type="xs:float"/>
       <tt:ElementItemDescription Name="ObjectId" Type="tt:ObjectId"/>
+      <tt:ElementItemDescription Name="ParentObjectId" Type="tt:ObjectId"/>
       <tt:SimpleItemDescription Name="Label" Type="xs:string "/>
       <tt:SimpleItemDescription Name="ImageUri" Type="xs:anyURI"/>
       <tt:SimpleItemDescription Name="EnrollmentID" Type="xs:string"/>
@@ -7165,6 +7171,7 @@ xmlns:acme="http://www.acme.com/schema"&gt;
     <tt:Data>
       <tt:SimpleItemDescription name="Likelihood" Type="xs:float"/>
       <tt:ElementItemDescription Name="ObjectId" Type="tt:ObjectId"/>
+      <tt:ElementItemDescription Name="ParentObjectId" Type="tt:ObjectId"/>
       <tt:SimpleItemDescription Name="Label" Type="xs:string"/>
       <tt:SimpleItemDescription Name="ImageURI" Type="xs:anyURI"/>
       <tt:SimpleItemDescription Name="VehicleImageURI" Type="xs:anyURI"/>
@@ -7369,7 +7376,8 @@ xmlns:acme="http://www.acme.com/schema"&gt;
             </row>
             <row>
               <entry>Direction</entry>
-              <entry>Direction of the object as a GeoOrientation type.</entry>
+              <entry>Direction of the vehicle having License Plate with respect to camera view, of
+                type tt:VehicleDirection.</entry>
               <entry>Optional</entry>
             </row>
           </tbody>

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -7376,8 +7376,7 @@ xmlns:acme="http://www.acme.com/schema"&gt;
             </row>
             <row>
               <entry>Direction</entry>
-              <entry>Direction of the vehicle having License Plate with respect to camera view, of
-                type tt:VehicleDirection.</entry>
+              <entry>Vehicle Moving Direction of type tt:ObjectMovement.</entry>
               <entry>Optional</entry>
             </row>
           </tbody>

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -7181,7 +7181,7 @@ xmlns:acme="http://www.acme.com/schema"&gt;
       <tt:ElementItemDescription Name="VehicleInfo" Type="tt:VehicleInfo"/>
       <tt:ElementItemDescription Name="VehicleImage" Type="xs:base64Binary"/>
       <tt:SimpleItemDescription Name="Speed" Type="xs:float"/>
-      <tt:SimpleItemDescription Name="Direction" Type="tt:VehicleDirection"/>
+      <tt:SimpleItemDescription Name="Direction" Type="tt:ObjectMovement"/>
     </tt:Data>
     <tt:ParentTopic>
       tns1:RuleEngine/Recognition/LicensePlate

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -7181,7 +7181,7 @@ xmlns:acme="http://www.acme.com/schema"&gt;
       <tt:ElementItemDescription Name="VehicleInfo" Type="tt:VehicleInfo"/>
       <tt:ElementItemDescription Name="VehicleImage" Type="xs:base64Binary"/>
       <tt:SimpleItemDescription Name="Speed" Type="xs:float"/>
-      <tt:SimpleItemDescription Name="Direction" Type="tt:ObjectMovement"/>
+      <tt:SimpleItemDescription Name="Direction" Type="tt:Direction"/>
     </tt:Data>
     <tt:ParentTopic>
       tns1:RuleEngine/Recognition/LicensePlate
@@ -7376,7 +7376,7 @@ xmlns:acme="http://www.acme.com/schema"&gt;
             </row>
             <row>
               <entry>Direction</entry>
-              <entry>Vehicle Moving Direction of type tt:ObjectMovement.</entry>
+              <entry>Vehicle Moving Direction of type tt:Direction.</entry>
               <entry>Optional</entry>
             </row>
           </tbody>

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -7181,7 +7181,7 @@ xmlns:acme="http://www.acme.com/schema"&gt;
       <tt:ElementItemDescription Name="VehicleInfo" Type="tt:VehicleInfo"/>
       <tt:ElementItemDescription Name="VehicleImage" Type="xs:base64Binary"/>
       <tt:SimpleItemDescription Name="Speed" Type="xs:float"/>
-      <tt:ElementItemDescription Name="Direction" Type="tt:GeoOrientation"/>
+      <tt:SimpleItemDescription Name="Direction" Type="tt:VehicleDirection"/>
     </tt:Data>
     <tt:ParentTopic>
       tns1:RuleEngine/Recognition/LicensePlate

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -6730,8 +6730,8 @@ If set to 0.0, infinity will be used.</xs:documentation>
 	</xs:simpleType>
 	<xs:simpleType name="ObjectMovement">
 		<xs:restriction base="xs:string">
-			<xs:enumeration value="Approaching"/>
-			<xs:enumeration value="Departing"/>
+			<xs:enumeration value="TowardsSensor"/>
+			<xs:enumeration value="AwayFromSensor"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<!--    Analytics Configuration    -->

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -6728,9 +6728,9 @@ If set to 0.0, infinity will be used.</xs:documentation>
 			<xs:enumeration value="Any"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="VehicleDirection">
+	<xs:simpleType name="ObjectMovement">
 		<xs:restriction base="xs:string">
-			<xs:enumeration value="Arriving"/>
+			<xs:enumeration value="Approaching"/>
 			<xs:enumeration value="Departing"/>
 		</xs:restriction>
 	</xs:simpleType>

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -6728,6 +6728,12 @@ If set to 0.0, infinity will be used.</xs:documentation>
 			<xs:enumeration value="Any"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:simpleType name="VehicleDirection">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Arriving"/>
+			<xs:enumeration value="Departing"/>
+		</xs:restriction>
+	</xs:simpleType>
 	<!--    Analytics Configuration    -->
 	<!--===============================-->
 	<xs:complexType name="AnalyticsEngineConfiguration">

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -6721,19 +6721,22 @@ If set to 0.0, infinity will be used.</xs:documentation>
 	</xs:complexType>
 	<xs:element name="Polyline" type="tt:Polyline"/>
 	<!--===============================-->
+	
 	<xs:simpleType name="Direction">
+		<xs:union memberTypes="tt:ExtendedDirection"/>
+	</xs:simpleType>
+	
+	<xs:simpleType name="ExtendedDirection">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Left"/>
 			<xs:enumeration value="Right"/>
 			<xs:enumeration value="Any"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="ObjectMovement">
-		<xs:restriction base="xs:string">
+			<!-- Add new values -->
 			<xs:enumeration value="TowardsSensor"/>
 			<xs:enumeration value="AwayFromSensor"/>
 		</xs:restriction>
 	</xs:simpleType>
+	
 	<!--    Analytics Configuration    -->
 	<!--===============================-->
 	<xs:complexType name="AnalyticsEngineConfiguration">

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -6727,13 +6727,21 @@ If set to 0.0, infinity will be used.</xs:documentation>
 	</xs:simpleType>
 	
 	<xs:simpleType name="ExtendedDirection">
+		<xs:annotation>
+			<xs:documentation>Entering represents object coming into the polygon boundary.</xs:documentation>
+			<xs:documentation>Exiting represents object going out of the polygon boundary.</xs:documentation>
+			<xs:documentation>Approaching represents distance of object to camera sensor decreasing over time.</xs:documentation>
+			<xs:documentation>Departing represents distance of object to camera sensor increasing over time.</xs:documentation>		
+		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Left"/>
 			<xs:enumeration value="Right"/>
 			<xs:enumeration value="Any"/>
 			<!-- Add new values -->
-			<xs:enumeration value="TowardsSensor"/>
-			<xs:enumeration value="AwayFromSensor"/>
+			<xs:enumeration value="Entering"/>
+			<xs:enumeration value="Exiting"/>
+			<xs:enumeration value="Approaching"/>
+			<xs:enumeration value="Departing"/>
 		</xs:restriction>
 	</xs:simpleType>
 	


### PR DESCRIPTION
1. Extend the License plate recognition event to include additional data of the recognized license plate
    - Speed in unit of m/sec
    - Direction expressed as tt:ObjectMovement
    -  tt:ObjectMovement enum defined
2. Extend the generic recognition event output parameters to include 
    - Object ID
      - This was available for classification event but missing from recognition events.
        - Only the source structure for the recognition event is referenced from https://www.onvif.org/specs/srv/analytics/ONVIF-Analytics-Service-Spec.pdf Annex A.1.1.
 3. Fixed XML validation error for incorrect " " symbol.