### PR TITLE
Update section 6 for better guidance on signature algorithm selection.

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -4764,7 +4764,13 @@
         <para>Faults and their types shall not disclose sensitive information to an attacker that he could not obtain otherwise.</para>
       </listitem>
       <listitem>
-        <para>For interoperability reasons, sha1WithRSAEncryption as specified in RFC 3279 is mandated as default signature algorithm. However, since the security of the SHA-1 algorithm is under question, this specification mandates that a signature algorithm based on SHA-256, particularly sha256WithRSAEncryption as specified in RFC 4055, be supported in addition.</para>
+        <para>Secure up to date signaturem algorithm should be implemented by devices and clients.
+          Devices signal the supported algorithm via their capabilities and clients should select
+          the algorithm with highest security strength supported by both parties. As common baseline
+          this specification requires device side support for SHA-2, particularly
+          sha256WithRSAEncryption as specified in RFC 4055. Note that for backward compatibility of
+          some usages this specification currently mandates device side support for
+          sha1WithRSAEncryption as specified in RFC 3279. </para>
       </listitem>
       <listitem>
         <para>Operations with arguments that need protection against eavesdropping or manipulation shall only be executed over sufficiently protected communication channels. </para>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -4764,7 +4764,7 @@
         <para>Faults and their types shall not disclose sensitive information to an attacker that he could not obtain otherwise.</para>
       </listitem>
       <listitem>
-        <para>Secure up to date signaturem algorithm should be implemented by devices and clients.
+        <para>Secure up to date signature algorithm should be implemented by devices and clients.
           Devices signal the supported algorithm via their capabilities and clients should select
           the algorithm with highest security strength supported by both parties. As common baseline
           this specification requires device side support for SHA-2, particularly


### PR DESCRIPTION
The current specification defines in informative section 6 that sha1 is the default algorithm although it clearly defines which algorithm are required in section 5.7.6.

Intention of this PR is putting focus on selecting best digest and keeping sha2 as common denominator as well as sha1 as backward compatibility requirement. So for the time being no change on requirement level but clearly indicating that things may change in the future. See e.g. section 5.2. of [NIST SP800-107](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-107r1.pdf).