### PR TITLE
Add optional error information

### DIFF
--- a/doc/Media2.xml
+++ b/doc/Media2.xml
@@ -2083,6 +2083,9 @@
             <para>DefaultProfile [tt:ReferenceToken] – The default media profile to use for
               streaming if no specific profile is specified when initializing a session.</para>
           </listitem>
+          <listitem>
+            <para>Optional user readable error information (readonly).</para>
+          </listitem>
         </itemizedlist>
       </section>
       <section xml:id="section_wys_czg_ryb">

--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -355,6 +355,9 @@
           <para>AuthorizationServer :  JWTConfiguration token referring to an Authorization server
             that provides JWT token to authorize with the uplink server.</para>
         </listitem>
+        <listitem>
+          <para>Optional user readable error information (readonly).</para>
+        </listitem>
       </itemizedlist>
       <para>The device shall interpret the field RemoteAddress as key to a specific uplink
         configuration.</para>

--- a/wsdl/ver10/uplink/wsdl/uplink.wsdl
+++ b/wsdl/ver10/uplink/wsdl/uplink.wsdl
@@ -95,6 +95,9 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<xs:element name="AuthorizationServer" type="tt:ReferenceToken" minOccurs="0">
 						<xs:annotation><xs:documentation> JWTConfiguration token referring to an Authorization server that provides JWT token to authorize with the uplink server.</xs:documentation></xs:annotation>
 					</xs:element>
+					<xs:element name="Error" type="xs:string" minOccurs="0">
+						<xs:annotation><xs:documentation>Optional user readable error information (readonly).</xs:documentation></xs:annotation>
+					</xs:element>
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	 <!-- first ONVIF then Vendor -->
 				</xs:sequence>
 				<xs:anyAttribute processContents="lax"/>

--- a/wsdl/ver20/media/wsdl/media.wsdl
+++ b/wsdl/ver20/media/wsdl/media.wsdl
@@ -1255,6 +1255,9 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 							<xs:documentation>Indicates if the device is connected to the server. This parameter is read-only.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
+					<xs:element name="Error" type="xs:string" minOccurs="0">
+						<xs:annotation><xs:documentation>Optional user readable error information (readonly).</xs:documentation></xs:annotation>
+					</xs:element>
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
 				</xs:sequence>
 				<xs:anyAttribute processContents="lax"/>


### PR DESCRIPTION
Currently there is no way to signal to the user why some cloud functionality is not available because of e.g. DNS lookup failure, connection issue or rejected authentication.

This PR adds optional supplemental error information for WebRTC signaling server and uplink connection.