### PR TITLE
Proposal to add support for RFC 7714 SRTP with AES-GCM

### DIFF
--- a/doc/Streaming.xml
+++ b/doc/Streaming.xml
@@ -590,7 +590,7 @@
         </section>
         <section>
           <title>SRTP data transfer via UDP</title>
-          <para>This mode allows secure transmission of RTP packets via UDP unicast and multicast. See RFC 3711 for transmission and RFC 4567 for key exchange.</para>
+          <para>This mode allows secure transmission of RTP packets via UDP unicast and multicast. See RFC 3711 and RFC 7714 for transmission and RFC 4567 for key exchange. For RFC 3711, it is expected that the authentication tag is present. For RFC 7714, it is expected that the authentication tag is not present. It is expeced that the optional MKI is present in all cases.</para>
         </section>
         <section xml:id="_Ref213038219">
           <title>RTP/RTSP/HTTP/TCP</title>

--- a/wsdl/ver20/media/wsdl/media.wsdl
+++ b/wsdl/ver20/media/wsdl/media.wsdl
@@ -147,6 +147,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:documentation>Indicates support for live media streaming via RTSPS and SRTP.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
+				<xs:attribute name="SecureRTSPStreamingAlgorithms" type="tt:StringAttrList">
+					<xs:annotation>
+						<xs:documentation>If secure RTSP streaming is supported, this shall return the list of supported cryptographic algorithms as defined by tr2:SrtpSecurityAlgorithms.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:complexType>
 			<!--===============================-->
@@ -712,6 +717,14 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:restriction>
 			</xs:simpleType>
 			<!--===============================-->
+			<xs:simpleType name="SrtpSecurityAlgorithms">
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="AES_CM_128_HMAC_SHA1_80"/>
+					<xs:enumeration value="AEAD_AES_128_GCM"/>
+					<xs:enumeration value="AEAD_AES_256_GCM"/>
+				</xs:restriction>
+			</xs:simpleType>
+			<!--===============================-->
 			<xs:element name="GetVideoEncoderInstances">
 				<xs:complexType>
 					<xs:sequence>
@@ -773,6 +786,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:element name="Protocol" type="xs:string">
 							<xs:annotation>
 								<xs:documentation>Defines the network protocol for streaming as defined by tr2:TransportProtocol</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="SecurityProtocolAlgorithm" type="xs:string" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Defines the cryptographic algorithm to use as defined by tr2:SrtpSecurityAlgorithms</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="ProfileToken" type="tt:ReferenceToken">


### PR DESCRIPTION
Proposal for cryptographic algorithm negotiation to add support for RFC 7714 SRTP AES-GCM.

Reason:
EU governments will start forbidding SHA-1 starting 2025 December 31.
RFC 3711 defines an 80 bit SHA-1 authentication tag, which will be forbidden.
Using AES-CM (Counter Mode) without an authentication tag is insecure and forbidden by FIPS.

Compatibility analysis:
Devices that do not support the feature will not include the SecureRTSPStreamingAlgorithms in the StreamingCapabilities.
Clients that do not support the feature will not include the SecurityProtocolAlgorithm the GetStreamUri.
When either a client or device does not support the feature, AES-128-CM-SHA1_80 is implied. (As defined in RFC 3711).