### PR TITLE
Enable future extensibility of ear shapes.

### DIFF
--- a/wsdl/ver20/analytics/humanface.xsd
+++ b/wsdl/ver20/analytics/humanface.xsd
@@ -164,7 +164,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		</xs:sequence>
 		<xs:anyAttribute processContents="lax"/>
 	</xs:complexType>	
-	<xs:simpleType name="Ear">
+	<xs:simpleType name="EarShape">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Round"/>	
 			<xs:enumeration value="Pointed"/>	
@@ -449,9 +449,9 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				<xs:documentation>Describe the eye of the face. </xs:documentation> 
 			</xs:annotation> 
 			</xs:element> 			
-			<xs:element name="Ear" type="fc:Ear" minOccurs="0"> 
+			<xs:element name="Ear" type="xs:string" minOccurs="0"> 
 			<xs:annotation> 
-				<xs:documentation>Describe the Ear of the face.</xs:documentation> 
+				<xs:documentation>Describe the Ear of the face. For definitions see fc:EarShape.</xs:documentation> 
 			</xs:annotation> 
 			</xs:element> 		
 			<xs:element name="Nose" type="fc:Nose" minOccurs="0"> 


### PR DESCRIPTION
All features of the HumanFace struct are extensible but the EarShape.

This PR intends keeping backward compatibility by not changing the shape type definitions. The type name has been changed from Ear to EarShape to more clearly reflect the content. Note that the type names have no impact on the instance documents and hence no impact on interoperability.