### PR TITLE
Proposal: Storage Configuration - Renewal of cloud storage credentials

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -6232,10 +6232,12 @@ onvif://www.onvif.org/name/ARV-453
       <section>
         <title>Configuration Renewal</title>
         <para>
-          The configuration allows for a renewal endpoint to be set. If the device supports this feature, it shall automatically renew the credentials when they are about to expire.
+          The configuration allows for a renewal endpoint to be set. If the device supports this feature, it shall automatically renew the credentials 
+          when they are about to expire.
         </para>
         <para>
-          The device shall do a GET request to the configured <literal>RenewalEndpoint</literal> with a JWT token retrieved from the configured <literal>AuthorizationServer</literal>. The endpoint shall respond with a JSON payload with the following structure:
+          The device shall do a GET request to the configured <literal>RenewalEndpoint</literal> with a JWT token retrieved from the configured 
+          <literal>AuthorizationServer</literal>. The endpoint shall respond with a JSON payload with the following structure:
           <programlisting><![CDATA[Content-Type: application/vnd.onvif.storageconfiguration.renewal+json
 
 {
@@ -6249,7 +6251,14 @@ onvif://www.onvif.org/name/ARV-453
     },
     "expiresAt": "<ISO 8601 date-time>"
 }]]></programlisting>
-          The device shall ensure to renew the configuration before the expiration provided by the <literal>expiresAt</literal> field. If the renewal endpoint fails to provide a valid response, the device shall continue to use the existing configuration and retry the renewal later using an exponential backoff strategy.
+          When the device receive a configuration with the <literal>ConfigurationRenewal</literal> set, it shall immediately contact
+          the renewal endpoint to get up-to-date credentials. The device may use the credentials provided by the configuration in the
+          meantime to avoid service disruption.
+        </para>
+        <para>
+          The device shall ensure to renew the configuration before the expiration provided by the <literal>expiresAt</literal> field.
+          If the renewal endpoint fails to provide a valid response, the device shall continue to use the existing configuration and retry
+          later using an exponential backoff strategy.
         </para>
       </section>
       <section>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -6230,6 +6230,29 @@ onvif://www.onvif.org/name/ARV-453
         </para>
       </section>
       <section>
+        <title>Configuration Renewal</title>
+        <para>
+          The configuration allows for a renewal endpoint to be set. If the device supports this feature, it shall automatically renew the credentials when they are about to expire.
+        </para>
+        <para>
+          The device shall do a GET request to the configured <literal>RenewalEndpoint</literal> with a JWT token retrieved from the configured <literal>AuthorizationServer</literal>. The endpoint shall respond with a JSON payload with the following structure:
+          <programlisting><![CDATA[Content-Type: application/vnd.onvif.storageconfiguration.renewal+json
+
+{
+    "type": "string",
+    "region": "string" | null,
+    "localPath": "string" | null,
+    "storageUri": "string" | null,
+    "user": {
+        "username": "string" | null,
+        "password": "string" | null
+    },
+    "expiresAt": "<ISO 8601 date-time>"
+}]]></programlisting>
+          The device shall ensure to renew the configuration before the expiration provided by the <literal>expiresAt</literal> field. If the renewal endpoint fails to provide a valid response, the device shall continue to use the existing configuration and retry the renewal later using an exponential backoff strategy.
+        </para>
+      </section>
+      <section>
         <title>GetStorageConfigurations</title>
         <para>This operation lists all existing storage configurations. A device indicating storage configuration capability shall support the listing of existing storage configurations through the GetStorageConfigurations command.</para>
         <variablelist role="op">

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -2182,6 +2182,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 										<xs:documentation>CertPathValidationPolicyID used to validate the renewal endpoint server certificate. If CertPathValidationPolicyID is not configured, the certificate shall not be validated.</xs:documentation>
 									</xs:annotation>
 								</xs:element>
+								<xs:element name="Error" type="xs:string" minOccurs="0">
+									<xs:annotation>
+										<xs:documentation>Optional user readable error information (readonly).</xs:documentation>
+									</xs:annotation>
+								</xs:element>
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -336,6 +336,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:documentation>Indicates maximum number of storage configurations supported.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
+				<xs:attribute name="StorageConfigurationRenewal" type="xs:boolean">
+					<xs:annotation>
+						<xs:documentation>Indicates support for renewal of storage configuration.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:attribute name="GeoLocationEntries" type="xs:int">
 					<xs:annotation>
 						<xs:documentation>If present signals support for geo location. The value signals the supported number of entries.</xs:documentation>
@@ -2158,6 +2163,27 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:annotation>
 							<xs:documentation>User credential for the storage server</xs:documentation>
 						</xs:annotation>
+					</xs:element>
+					<xs:element name="ConfigurationRenewal" minOccurs="0">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="RenewalEndpoint" type="xs:anyURI">
+									<xs:annotation>
+										<xs:documentation>Remote URL to be queried by the device to renew the storage configuration.</xs:documentation>
+									</xs:annotation>
+								</xs:element>
+								<xs:element name="AuthorizationServer" type="tt:ReferenceToken">
+									<xs:annotation>
+										<xs:documentation>JWTConfiguration token referring to an Authorization server that provides JWT token to authorize with the the renewal endpoint.</xs:documentation>
+									</xs:annotation>
+								</xs:element>
+								<xs:element name="CertPathValidationPolicyID" type="xs:string" minOccurs="0">
+									<xs:annotation>
+										<xs:documentation>CertPathValidationPolicyID used to validate the renewal endpoint server certificate. If CertPathValidationPolicyID is not configured, the certificate shall not be validated.</xs:documentation>
+									</xs:annotation>
+								</xs:element>
+							</xs:sequence>
+						</xs:complexType>
 					</xs:element>
 					<xs:element name="Extension" minOccurs="0">
 						<xs:complexType>


### PR DESCRIPTION
With the current specification, a cloud provider must continuously renew the credentials assigned to a device using the SetStorageConfiguration API. This means that a cloud provider must keep track of all devices and attempt to refresh this configuration, generally over Uplink, regularly to ensure that there is no loss of recording.

Instead of a manual procedure by the cloud provider, we propose that the device manage the lifecycle of its credentials on its own, by accepting an endpoint to a simple API that provides credentials to the device on-demand. This will allow the device to refresh credentials much faster in case of outages, where the device comes back online after a while and wants to resume recording as quickly as possible.