### PR TITLE
Extend ObjectStorageS3 configuration to include Token

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -6202,10 +6202,12 @@ onvif://www.onvif.org/name/ARV-453
                 <para>
                   The device shall use the contents of <literal>UserName</literal> as the access key ID for authenticating requests.
                 </para>
-                <para> The device shall use the contents of <literal>Password</literal> as the
+                <para> 
+                  The device shall use the contents of <literal>Password</literal> as the
                   secret access key for authenticating requests. </para>
-                <para>If  required by S3 service provider, the device shall use the contents of
-                    <literal>Token</literal> as the STS token for authorizing requests .</para>
+                <para>
+                  If required by S3 service provider, the device shall use the contents of <literal>Token</literal> as the STS token for authorizing requests.
+                </para>
                 <para>
                   The device shall use the contents of <literal>Region</literal> as the region for authenticating requests.
                   If <literal>Region</literal> is not configured, the device shall use <literal>us-east-1</literal> as the region.

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -6202,9 +6202,10 @@ onvif://www.onvif.org/name/ARV-453
                 <para>
                   The device shall use the contents of <literal>UserName</literal> as the access key ID for authenticating requests.
                 </para>
-                <para>
-                  The device shall use the contents of <literal>Password</literal> as the secret access key for authenticating requests.
-                </para>
+                <para> The device shall use the contents of <literal>Password</literal> as the
+                  secret access key for authenticating requests. </para>
+                <para>If  required by S3 service provider, the device shall use the contents of
+                    <literal>Token</literal> as the STS token for authorizing requests .</para>
                 <para>
                   The device shall use the contents of <literal>Region</literal> as the region for authenticating requests.
                   If <literal>Region</literal> is not configured, the device shall use <literal>us-east-1</literal> as the region.

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -2097,6 +2097,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 							<xs:documentation> optional password</xs:documentation> 
 						</xs:annotation>
 					</xs:element>
+					<xs:element name="Token" type="xs:string" minOccurs="0">
+						<xs:annotation>	
+							<xs:documentation> optional access token</xs:documentation> 
+						</xs:annotation>
+					</xs:element>					
 					<xs:element name="Extension" minOccurs="0">
 						<xs:complexType>
 							<xs:sequence>

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -2098,8 +2098,8 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="Token" type="xs:string" minOccurs="0">
-						<xs:annotation>	
-							<xs:documentation> optional access token</xs:documentation> 
+						<xs:annotation>
+							<xs:documentation> optional access token</xs:documentation>
 						</xs:annotation>
 					</xs:element>					
 					<xs:element name="Extension" minOccurs="0">


### PR DESCRIPTION
Ref: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl

- tt:UserCredential element used to access ObjectStorageS3 has only two fields, UserName and Password. This is not enough to access an S3 Bucket through an AWS STS (Security Token Service). For this the client needs to provide
  - Access key ID (username)
  - Secret access key (password)
  - Session token

We thus propose that we add an additional field for the session token for ObjectStorageS3 storage configuration type.