### PR TITLE
Remove redundant array definition for various types

### DIFF
--- a/yaml/ver10/cloudintegration/yaml/cloudintegration.yaml
+++ b/yaml/ver10/cloudintegration/yaml/cloudintegration.yaml
@@ -14,35 +14,22 @@ components:
   schemas:
     Base64DERencodedASN1Value:
       description: This schema is the equivalent of tas:Base64DERencodedASN1Value in the Security Service specification.
-      type: object
-      properties:
-        Value:
-          type: string
-          format: byte
-      required:
-        - Value
+      type: string
 
     EndpointReferenceType:
       description: This schema is the equivalent of wsa:EndpointReferenceType in the WA-Addressing 1.0 specification.
-      type: object
-      properties:
-        Address:
-          type: string
-          format: uri
-      required:
-        - Address
+      type: string
+      format: uri
 
     DeviceConfiguration:
       type: object
       properties:
         ShareToken:
           description: The share token, to prove permission to share the device.
-          item:
-            $ref: '#/components/schemas/Base64DERencodedASN1Value'
+          $ref: '#/components/schemas/Base64DERencodedASN1Value'
         EndpointReferences:
           description: The endpoint to be notified to inform that the operation was completed. It may be more then one if the requesting cloud has redundant URIs to receive the notification.
-          items:
-            $ref: '#/components/schemas/EndpointReferenceType'
+          $ref: '#/components/schemas/EndpointReferenceType'
       required:
         - ShareToken
         - EndpointReferences
@@ -52,12 +39,10 @@ components:
       properties:
         ShareToken:
           description: The share token, to know what device the public key is associated to.
-          item:
-            $ref: '#/components/schemas/Base64DERencodedASN1Value'
+          $ref: '#/components/schemas/Base64DERencodedASN1Value'
         DevicePublicKey:
           description: The public key of the device.
-          item:
-            $ref: '#/components/schemas/Base64DERencodedASN1Value'
+          $ref: '#/components/schemas/Base64DERencodedASN1Value'
       required:
         - ShareToken
         - DevicePublicKey
@@ -110,16 +95,13 @@ components:
       type: object
       properties:
         CamerasConfiguration:
-          items:
-            $ref: '#/components/schemas/DeviceConfiguration'
+          $ref: '#/components/schemas/DeviceConfiguration'
           description: For each camera requested to be shared, it is necessary to pass both the shared token and the endpoint reference.
         JWTConfiguration:
-          items:
-            $ref: '#/components/schemas/JWTConfiguration'
+          $ref: '#/components/schemas/JWTConfiguration'
           description: Configuration of JWT authentication.
         UplinkConfiguration:
-          items:
-            $ref: '#/components/schemas/UplinkConfiguration'
+          $ref: '#/components/schemas/UplinkConfiguration'
           description: Configuration of the uplink service.
       required:
         - CamerasConfiguration
@@ -130,8 +112,7 @@ components:
       type: object
       properties:
         DevicesInformation:
-          items:
-            $ref: '#/components/schemas/DeviceInformation'
+          $ref: '#/components/schemas/DeviceInformation'
           description: For each shared device, the share token and the public key will be provided.
       required:
         - DevicesInformation


### PR DESCRIPTION
I've updated the OpenAPI document to remove some redundant array definition.

New model:
```json
{
  "CamerasConfiguration": {
    "ShareToken": "string",
    "EndpointReferences": "string"
  },
  "JWTConfiguration": {
    "Audiences": [
      "string"
    ],
    "TrustedIssuers": [
      "string"
    ],
    "JWTCertificate": [
      "string"
    ],
    "JWTTrustAnchor": [
      "string"
    ]
  },
  "UplinkConfiguration": {
    "RemoteAddress": "string",
    "UserLevel": "Administrator",
    "UplinkTrustAnchor": [
      "string"
    ]
  }
}
```

Old model:
```json
{
  "CamerasConfiguration": [
    {
      "ShareToken": [
        {
          "Value": "string"
        }
      ],
      "EndpointReferences": [
        {
          "Address": "string"
        }
      ]
    }
  ],
  "JWTConfiguration": [
    {
      "Audiences": [
        "string"
      ],
      "TrustedIssuers": [
        "string"
      ],
      "JWTCertificate": [
        {
          "Value": "string"
        }
      ],
      "JWTTrustAnchor": [
        {
          "Value": "string"
        }
      ]
    }
  ],
  "UplinkConfiguration": [
    {
      "RemoteAddress": "string",
      "UserLevel": "Administrator",
      "UplinkTrustAnchor": [
        {
          "Value": "string"
        }
      ]
    }
  ]
}
```