### PR TITLE
Introduce hardware type in ServiceCapabilities

### DIFF
--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -371,6 +371,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:documentation>List of supported Addons by the device.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
+				<xs:attribute name="HardwareType" type="xs:string">
+					<xs:annotation>
+						<xs:documentation>Indicates what type of device this is. See tt:HardwareTypes for available options.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:complexType>
 			<!--===============================-->
@@ -389,6 +394,41 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<xs:enumeration value="Leveling">
 						<xs:annotation>	
 							<xs:documentation>Automatic adjustment of the deviation from the horizon also called pitch and roll.</xs:documentation>
+						</xs:annotation>
+					</xs:enumeration>
+				</xs:restriction>
+			</xs:simpleType>
+			<!--===============================-->
+			<xs:simpleType name="HardwareTypes">
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="Camera">
+						<xs:annotation>
+							<xs:documentation>Single sensor camera. Ex. bullet, PTZ or fisheye camera.</xs:documentation>
+						</xs:annotation>
+					</xs:enumeration>
+					<xs:enumeration value="Multi-sensor">
+						<xs:annotation>
+							<xs:documentation>Multiple sensors device.</xs:documentation>
+						</xs:annotation>
+					</xs:enumeration>
+					<xs:enumeration value="Encoder">
+						<xs:annotation>
+							<xs:documentation>Analog encoder. Can have 1 or more encoders.</xs:documentation>
+						</xs:annotation>
+					</xs:enumeration>
+					<xs:enumeration value="Intercom">
+						<xs:annotation>
+							<xs:documentation>Intercom device, which has both a microphone and a speaker.</xs:documentation>
+						</xs:annotation>
+					</xs:enumeration>
+					<xs:enumeration value="AccessControl">
+						<xs:annotation>
+							<xs:documentation>Access control device.</xs:documentation>
+						</xs:annotation>
+					</xs:enumeration>
+					<xs:enumeration value="NetworkSpeaker">
+						<xs:annotation>
+							<xs:documentation>A network speaker which is not an intercom.</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 				</xs:restriction>


### PR DESCRIPTION
Fixes #425 

Adds an optional attribute in GetServiceCapabilities in the DeviceManagement specification to indicate what type of hardware the client is interacting with.