### PR TITLE
Add RTCP & i-Frame requests requirements to WebRTC spec

### DIFF
--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -77,6 +77,9 @@
     <para>IETF RFC 8866 - SDP: Session Description Protocol</para>
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
         xlink:href="http://tools.ietf.org/html/rfc8866"/>&gt;</para>
+    <para>IETF RFC 8834 - Media Transport and Use of RTP in WebRTC</para>
+    <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="http://tools.ietf.org/html/rfc8834"/>&gt;</para>
     <para>IETF RFC 8839 - Session Description Protocol (SDP) Offer/Answer Procedures for
       Interactive Connectivity Establishment (ICE)</para>
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -106,6 +109,12 @@
     <para>IETF RFC 7065 - Traversal Using Relays around NAT (TURN) Uniform Resource Identifiers</para>
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="https://datatracker.ietf.org/doc/html/rfc7065"/>&gt;</para>
+    <para>IETF RFC 4585 - Extended RTP Profile for Real-Time Transport Control Protocol (RTCP)-Based Feedback</para>
+    <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="https://datatracker.ietf.org/doc/html/rfc4585"/>&gt;</para>
+    <para>IETF RFC 5104 - Codec Control Messages in the RTP Audio-Visual Profile with Feedback (AVPF) Profile</para>
+    <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="https://datatracker.ietf.org/doc/html/rfc5104"/>&gt;</para>
     <para>JSON-RPC 2.0</para>
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="https://www.jsonrpc.org/specification"/>&gt;</para>
@@ -331,7 +340,7 @@
           </tgroup>
         </table>
       </para>
-      <para>The following sections specify the parameters of the indivdual commands.</para>
+      <para>The following sections specify the parameters of the individual commands.</para>
       <section xml:id="section_register">
         <title>register</title>
         <para> A signaling server shall expect this command to be sent once before any other command
@@ -629,6 +638,14 @@ Server -> Device: { "method": "trickle", "params": {"session": "s1", "candidate"
        switch only between profiles with the same video source and same video codec. Once there
        is enough available bandwidth, devices should aim to switch back to the initially selected
        profile.</para>
+    </section>
+    <section xml:id="section_xyt_v12_v5b">
+      <title>Feedback mechanisms</title>
+      <para>Devices shall be able to exchange RTCP feedback with their peer as defined in RFC 8834.
+        In particular, devices shall handle FIR messages, as defined in RFC 5104, and PLI messages,
+        as defined in RFC 4585, and attempt to provide a synchronization point according to the
+        semantics of these requests.</para>
+      <para></para>
     </section>
     <section xml:id="section_vyt_v12_v5b">
       <title>Video</title>


### PR DESCRIPTION
This change adds a bit of text to solidify the requirement for device to handle the FIR & PLI messages, which request a new synchronisation point to the stream. In theory, WebRTC already requires that media producers implement those, so it is not really new, but we make it much clearer.

Those messages also do not absolutely force the production of an i-frame, as the device can use bandwidth requirements and other factors to decide if it should produce one, as specified in the linked RFCs