### PR TITLE
Remove duplicate pull point capability and mark it as deprecated.

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -7467,10 +7467,6 @@ http://www.onvif.org/ver10/tev/topicExpression/ConcreteSet
           <listitem><para>Indication if the device supports the WS Subscription policy according to Section <xref linkend="_Toc214944387" /></para></listitem>
         </varlistentry>
         <varlistentry>
-          <term>WSPullPointSupport</term>
-          <listitem><para>Indication if the device supports the WS Pull Point according to Section <xref linkend="_Toc214944387"/></para></listitem>
-        </varlistentry>
-        <varlistentry>
           <term>WSPausableSubscriptionManagerInterfaceSupport</term>
           <listitem><para>Indication if the device supports the WS Pausable Subscription Manager Interface according to Section <xref linkend="_Toc214944387"/></para></listitem>
         </varlistentry>
@@ -7480,7 +7476,7 @@ http://www.onvif.org/ver10/tev/topicExpression/ConcreteSet
         </varlistentry>
         <varlistentry>
           <term>MaxPullPoints</term>
-          <listitem><para>Maximum supported number of notification pull points</para></listitem>
+          <listitem><para>Maximum supported number of notification pull points according to Section <xref linkend="_Toc214944387"/></para></listitem>
         </varlistentry>
         <varlistentry>
           <term>PersistenNotificationStorage</term>

--- a/wsdl/ver10/events/wsdl/event.wsdl
+++ b/wsdl/ver10/events/wsdl/event.wsdl
@@ -82,7 +82,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:attribute>
 				<xs:attribute name="WSPullPointSupport" type="xs:boolean">
 					<xs:annotation>
-						<xs:documentation>Deprecated indication that WS Pull Point is supported. Superseeded by MaxPullPoints.</xs:documentation>
+						<xs:documentation>Deprecated indication that WS Pull Point is supported. Superseded by MaxPullPoints.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>

--- a/wsdl/ver10/events/wsdl/event.wsdl
+++ b/wsdl/ver10/events/wsdl/event.wsdl
@@ -45,11 +45,6 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:documentation>Indicates that the WS Subscription policy is supported.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
-				<xs:attribute name="WSPullPointSupport" type="xs:boolean">
-					<xs:annotation>
-						<xs:documentation>Indicates that the WS Pull Point is supported.</xs:documentation>
-					</xs:annotation>
-				</xs:attribute>
 				<xs:attribute name="WSPausableSubscriptionManagerInterfaceSupport" type="xs:boolean">
 					<xs:annotation>
 						<xs:documentation>Indicates that the WS Pausable Subscription Manager Interface is supported.</xs:documentation>
@@ -83,6 +78,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				<xs:attribute name="MetadataOverMQTT" type="xs:boolean">
 					<xs:annotation>
 						<xs:documentation>Indicates that metadata streaming over MQTT is supported</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="WSPullPointSupport" type="xs:boolean">
+					<xs:annotation>
+						<xs:documentation>Deprecated indication that WS Pull Point is supported. Superseeded by MaxPullPoints.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>


### PR DESCRIPTION
The boolean WSPullPointSupport has the same meaning as MaxPullPoint > 0. It looks like the DTT doesn't check the old capability as it was replae by MaxPullPoint many years ago.

This proposal suggests to remove it from the specification. For the schema it suggests to move the deprecated item to the end of the list and to mark it as deprecated anbd replaced by MaxPullPoint.