### PR TITLE
Add object attribute UUID.

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -738,7 +738,7 @@
       <tt:Translate x="-1.0" y="-1.0"/>
       <tt:Scale x="0.003125" y="0.00416667"/>
     </tt:Transformation>
-    <tt:Object ObjectId="12">
+    <tt:Object ObjectId="12" UUID='032e91c6-39f1-4504-9970-3a2c41408d4a'>
       <tt:Appearance>
         <tt:Shape>
           <tt:BoundingBox left="20.0" top="180.0" right="100.0" bottom="30.0"/>

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -640,31 +640,6 @@
         <para>When the receiver of a scene description receives an empty frame, the receiver should assume that all subsequent frames are empty as well until the next non-empty frame is received. When the last received frame is non-empty, the receiver should assume that a description of the next processed frame will be transmitted.</para>
         <section xml:id="_Ref208712481">
           <title>Objects</title>
-          <para>Objects are identified via their ObjectId. Features relating to one particular
-            object are collected in an object node with the corresponding ObjectId as an attribute.
-            Associations of objects, such as Object Renaming, Object Splits, Object Merges and
-            Object Deletions are expressed in a separate ObjectTree node. An ObjectId is implicitly
-            created with the first appearance of the ObjectId within an object node<footnote
-              xml:id="__FN3__">
-              <para>Please note that the schema is included here for <emphasis>information only.
-                </emphasis>[ONVIF Schema] contains the normative schema definition.</para>
-            </footnote>.</para>
-          <programlisting><![CDATA[<xs:complexType name="ObjectId">
-  <xs:attribute name="ObjectId" type="xs:integer"/>
-</xs:complexType>
-<xs:complexType name="Object">
-  <xs:complexContent>
-    <xs:extension base="ObjectId">
-      <xs:sequence>
-        <xs:element name="Appearance" type="Appearance" minOccurs="0"/>
-        <xs:element name="Behaviour" type="Behaviour" minOccurs="0"/>
-        ...
-      </xs:sequence>
-      <xs:attribute name="Parent" type="xs:integer">
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-]]></programlisting>
           <para>The object node has two placeholders for appearance and behaviour information. The appearance node starts with an optional transformation node which can be used to change from a frame-centric coordinate system to an object-centric coordinate system. Next, the Shape of an object can be specified. If an object is detected in a frame, the shape information should be present in the appearance description. The analytics algorithm may add object nodes for currently not visible objects, if it is able to infer information for this object otherwise. In such cases, the shape description may be omitted.</para>
           <para>Object features such as shape (see <xref linkend="_Ref208821074" />), color (see <xref linkend="_Toc214944464" />) and object class (see <xref linkend="_Ref485906999" />) can be added to the appearance node. </para>
           <para>This specification defines two standard behaviours for objects: Removed or Idle.
@@ -749,6 +724,13 @@
     </tt:Object>
   </tt:Frame>
 ]]></programlisting>
+        </section>
+        <section>
+          <title>Object Identifier</title>
+          <para>Objects are enumerated via their integer ObjectId. ObjectIds are implicitly created
+          by an analytics module with the first appearance of the object. A unique identifier can be
+          assigned to objects via the UUID attribute for linking object information from multiple
+          analytics module streams.</para>
           <para>Objects can be related, for example, a LicensePlate object can be related to Vehicle Object to which it belongs, in this case LicensePlate object which is child has the Vehicle's ObjectId as Parent.</para>
           <para>Example:</para>
           <programlisting><![CDATA[  <tt:Frame UtcTime="2019-06-10T12:24:57.321">

--- a/wsdl/ver10/schema/metadatastream.xsd
+++ b/wsdl/ver10/schema/metadatastream.xsd
@@ -319,6 +319,9 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	</xs:complexType>
 	<xs:complexType name="ObjectId">
 		<xs:attribute name="ObjectId" type="xs:integer"/>
+		<xs:attribute name="UUID" type="xs:string">
+			<xs:annotation><xs:documentation>Optional unique identifier.</xs:documentation></xs:annotation>
+		</xs:attribute>
 	</xs:complexType>
 	<xs:complexType name="Behaviour">
 		<xs:sequence>


### PR DESCRIPTION
Slightly reorganized section on Objects. 
* Gathered ID related information into an own section, 
* Removed object schema as its complex structure is hard to understand,
* Added UUID to example