### PR TITLE
Relax requirement for certificate duplicates.

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -1402,8 +1402,6 @@
       <section>
         <title>Uniqueness of Objects in the Keystore</title>
         <para>A device shall allow multiple copies of the same passphrase to be present in the keystore under different IDs simultaneously.</para>
-        <para>A device shall allow multiple copies of the same certificate to be present in the
-          keystore under different IDs, respectively.</para>
         <para>A device shall allow multiple copies of the same certificate revocation list to be present in the keystore under different IDs, respectively.</para>
         <para>A device shall allow multiple copies of the same certification path validation policy to be present in the keystore under different IDs, respectively.</para>
         <para>A device shall allow multiple copies of the same IEEE 802.1X configuration to be present in the keystore under different IDs simultaneously.</para>
@@ -2131,6 +2129,8 @@
                   <para role="text"> The specified signature algorithm is not supported by the device.</para>
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:InvalidKeyStatus</para>
                   <para role="text"> The key pair has an inappropriate status.</para>
+                  <para role="param">ter:Sender - ter:InvalidArgVal - ter:Duplicate</para>
+                  <para role="text"> The certificate already exists.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>


### PR DESCRIPTION
Current specification has unnecessary requirement to allow storing multiple copies of the same certificate. As there is no benefit of having the exact same certificate multiple times in the cert store, the current specification inhibits device implementation to protect against malicious clients installing by accident the same certificate multiple times.

For backward compatibility reasons this change does not forbid supporting storing the exact same certificate multiple times.

Note that this change should have no implication on storing variations of e.g. same subject and issuer but differing not-before or not-after dates.