### PR TITLE
Minor clarification for the SetWebRTCConfigurations

### DIFF
--- a/doc/Media2.xml
+++ b/doc/Media2.xml
@@ -2136,7 +2136,7 @@
               <para role="param">Configuration - optional, unbounded
                 [tr2:WebRTCConfiguration]</para>
               <para role="text">This message contains the WebRTC configurations to use for the
-                device. If empty, WebRTC is disabled,</para>
+                device. If empty, existing WebRTC configurations are deleted.</para>
             </listitem>
           </varlistentry>
           <varlistentry>

--- a/wsdl/ver20/media/wsdl/media.wsdl
+++ b/wsdl/ver20/media/wsdl/media.wsdl
@@ -1287,7 +1287,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<xs:sequence>
 						<xs:element name="WebRTCConfiguration" type="tr2:WebRTCConfiguration" minOccurs="0" maxOccurs="unbounded">
 							<xs:annotation>
-								<xs:documentation>Video Source Configuration Token that specifies an existing video source configuration that the options shall be compatible with.</xs:documentation>
+								<xs:documentation>This message contains the WebRTC configurations to use for the device. If empty, existing WebRTC configurations are deleted.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 					</xs:sequence>


### PR DESCRIPTION
Since we don't have delete webrtconfigurations, it would be better to clarify the behavior of setwebrtcconfigurations.
If a configuration is not passed, we could delete that configuration.  Mainly useful when multiple webrtcconfigurations are supported by device.
