### PR TITLE
Cloud Recording Near Live Command

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -1480,8 +1480,10 @@ Change Request 2061, 2063, 2065, 2109</revremark>
         When the temporary override is active, the device should attempt to close its currently recording segment and then
         shall record further segments with the new duration provided in this command. The override shall be active for the
         duration specified in the command, once the command expires the device shall resume recording with the original segment
-        duration on its next segment. If a new override request is sent before the previous override has expired, the
-        new override shall replace the previous override and the new expiration shall apply.
+        duration on its next segment.
+
+        When a new override request is sent before the previous override has expired, the new override shall replace the 
+        previous override and the new expiration shall apply.
       </para>
       <para>
         The active override value, if any exists, shall be shown in the corresponding <literal>RecordingConfiguration</literal>.

--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -1487,7 +1487,8 @@ Change Request 2061, 2063, 2065, 2109</revremark>
         previous override and the new expiration shall apply.
       </para>
       <para>
-        The active override value, if any exists, shall be shown in the corresponding <literal>RecordingConfiguration</literal>.
+        The active override value, if any exists, shall be shown in the corresponding <literal>RecordingConfiguration</literal> and may not persist after a device restart.
+        If the recording configuration is modified while an override is active, the override shall be removed.
       </para>
       <para>
         A device that indicates support for OverrideSegmentDuration shall support this command.

--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -1480,8 +1480,9 @@ Change Request 2061, 2063, 2065, 2109</revremark>
         When the temporary override is active, the device should attempt to close its currently recording segment and then
         shall record further segments with the new duration provided in this command. The override shall be active for the
         duration specified in the command, once the command expires the device shall resume recording with the original segment
-        duration on its next segment.
-
+        duration on its next segment. The override duration shall not exceed 1 hour.
+      </para>
+      <para>
         When a new override request is sent before the previous override has expired, the new override shall replace the 
         previous override and the new expiration shall apply.
       </para>
@@ -1514,6 +1515,8 @@ Change Request 2061, 2063, 2065, 2109</revremark>
           <listitem>
             <para role="param">env:Sender - ter:InvalidArgVal - ter:NoRecording</para>
             <para role="text">The RecordingConfiguration does not reference an existing recording.</para>
+            <para role="param">env:Sender - ter:InvalidArgVal - ter:BadDuration</para>
+            <para role="text">The value of the duration parameter is invalid.</para>
             <para role="param">env:Receiver - ter:ActionNotSupported - ter:NotImplemented</para>
             <para role="text">This optional method is not implemented.</para>
           </listitem>

--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -1484,6 +1484,9 @@ Change Request 2061, 2063, 2065, 2109</revremark>
         new override shall replace the previous override and the new expiration shall apply.
       </para>
       <para>
+        The active override value, if any exists, shall be shown in the corresponding <literal>RecordingConfiguration</literal>.
+      </para>
+      <para>
         A device that indicates support for OverrideSegmentDuration shall support this command.
       </para>
       <variablelist role="op">

--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -1471,6 +1471,57 @@ Change Request 2061, 2063, 2065, 2109</revremark>
       <para>The requested operation does not exist.</para>
     </section>
     <section>
+      <title>RequestTemporarySegmentDurationOverride</title>
+      <para>RequestTemporarySegmentDurationOverride dynamically updates a RecordingConfiguration to produce smaller
+        recording segments for a limited time. This allows for a client to request faster access to recorded data while
+        reducing the overall storage costs during normal operation.
+      </para>
+      <para>
+        When the temporary override is active, the device should attempt to close its currently recording segment and then
+        shall record further segments with the new duration provided in this command. The override shall be active for the
+        duration specified in the command, once the command expires the device shall resume recording with the original segment
+        duration on its next segment. If a new override request is sent before the previous override has expired, the
+        new override shall replace the previous override and the new expiration shall apply.
+      </para>
+      <para>
+        A device that indicates support for TemporarySegmentDurationOverride shall support this command.
+      </para>
+      <variablelist role="op">
+        <varlistentry>
+          <term>request</term>
+          <listitem>
+            <para role="param">TargetSegmentDuration [xs:duration]</para>
+            <para role="text">The new segment duration to be used for the duration of the override request.</para>
+            <para role="param">Expiration [xs:duration]</para>
+            <para role="text">The duration for which the override request shall be active.</para>
+            <para role="param">RecordingConfiguration [tt:RecordingReference]</para>
+            <para role="text">The recording configuration that needs to use the new segment duration.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>response</term>
+          <listitem>
+            <para role="text">This is an empty message.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>faults</term>
+          <listitem>
+            <para role="param">env:Sender - ter:InvalidArgVal - ter:NoRecording</para>
+            <para role="text">The RecordingConfiguration does not reference an existing recording.</para>
+            <para role="param">env:Receiver - ter:ActionNotSupported - ter:NotImplemented</para>
+            <para role="text">This optional method is not implemented.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>access class</term>
+          <listitem>
+            <para role="access">ACTUATE</para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </section>
+    <section>
       <title>GetServiceCapabilities</title>
       <para>The capabilities reflect optional functions and functionality of a service. The information is static and does not change during device operation. </para>
       <variablelist role="op">
@@ -1591,6 +1642,12 @@ Change Request 2061, 2063, 2065, 2109</revremark>
               Supported encryption modes.
               See tt:EncryptionMode for a list of definitions.
             </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>TemporarySegmentDurationOverrideSupported</term>
+          <listitem>
+            <para>Indicates that the device supports the RequestTemporarySegmentDurationOverride command.</para>
           </listitem>
         </varlistentry>
       </variablelist>

--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -1471,8 +1471,8 @@ Change Request 2061, 2063, 2065, 2109</revremark>
       <para>The requested operation does not exist.</para>
     </section>
     <section>
-      <title>RequestTemporarySegmentDurationOverride</title>
-      <para>RequestTemporarySegmentDurationOverride dynamically updates a RecordingConfiguration to produce smaller
+      <title>OverrideSegmentDuration</title>
+      <para>OverrideSegmentDuration dynamically updates a RecordingConfiguration to produce smaller
         recording segments for a limited time. This allows for a client to request faster access to recorded data while
         reducing the overall storage costs during normal operation.
       </para>
@@ -1484,7 +1484,7 @@ Change Request 2061, 2063, 2065, 2109</revremark>
         new override shall replace the previous override and the new expiration shall apply.
       </para>
       <para>
-        A device that indicates support for TemporarySegmentDurationOverride shall support this command.
+        A device that indicates support for OverrideSegmentDuration shall support this command.
       </para>
       <variablelist role="op">
         <varlistentry>
@@ -1645,9 +1645,9 @@ Change Request 2061, 2063, 2065, 2109</revremark>
           </listitem>
         </varlistentry>
         <varlistentry>
-          <term>TemporarySegmentDurationOverrideSupported</term>
+          <term>OverrideSegmentDurationSupported</term>
           <listitem>
-            <para>Indicates that the device supports the RequestTemporarySegmentDurationOverride command.</para>
+            <para>Indicates that the device supports the OverrideSegmentDuration command.</para>
           </listitem>
         </varlistentry>
       </variablelist>

--- a/wsdl/ver10/recording.wsdl
+++ b/wsdl/ver10/recording.wsdl
@@ -132,6 +132,13 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
+				<xs:attribute name="TemporarySegmentDurationOverrideSupported" type="xs:boolean">
+					<xs:annotation>
+						<xs:documentation>
+							Indicates if the device supports the RequestTemporarySegmentDurationOverride command.
+						</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:complexType>
 			<xs:element name="Capabilities" type="trc:Capabilities"/>
@@ -683,6 +690,32 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:complexType>
+			<xs:complexType name="TemporarySegmentDurationOverrideRequest">
+				<xs:sequence>
+					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
+				</xs:sequence>
+				<xs:attribute name="TargetSegmentDuration" type="xs:duration" minOccurs="1">
+					<xs:annotation>
+						<xs:documentation>The new target duration for recorded segments.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="Expiration" type="xs:duration" minOccurs="1">
+					<xs:annotation>
+						<xs:documentation>The length of time during which the override request is to be in effect.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="RecordingConfiguration" type="tt:RecordingReference" minOccurs="1">
+					<xs:annotation>
+						<xs:documentation>The recording configuration for which the override is requested.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:anyAttribute processContents="lax"/>
+			</xs:complexType>
+			<xs:complexType name="TemporarySegmentDurationOverrideResponse">
+				<xs:sequence>
+					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
+				</xs:sequence>
+			</xs:complexType>
 		</xs:schema>
 	</wsdl:types>
 	<wsdl:message name="GetServiceCapabilitiesRequest">
@@ -811,6 +844,12 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	</wsdl:message>
 	<wsdl:message name="GetExportRecordedDataStateResponse">
 		<wsdl:part name="parameters" element="trc:GetExportRecordedDataStateResponse"/>
+	</wsdl:message>
+	<wsdl:message name="TemporarySegmentDurationOverrideRequest">
+		<wsdl:part name="parameters" element="trc:TemporarySegmentDurationOverrideRequest"/>
+	</wsdl:message>
+	<wsdl:message name="TemporarySegmentDurationOverrideResponse">
+		<wsdl:part name="parameters" element="trc:TemporarySegmentDurationOverrideResponse"/>
 	</wsdl:message>
 	
 	<wsdl:portType name="RecordingPort">
@@ -968,6 +1007,13 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</wsdl:documentation>
 			<wsdl:input message="trc:GetExportRecordedDataStateRequest"/>
 			<wsdl:output message="trc:GetExportRecordedDataStateResponse"/>
+		</wsdl:operation>
+		<wsdl:operation name="RequestTemporarySegmentDurationOverride">
+			<wsdl:documentation>
+			Requests a temporary override of the target segment duration for a recording configuration. 
+			</wsdl:documentation>
+			<wsdl:input message="trc:TemporarySegmentDurationOverrideRequest"/>
+			<wsdl:output message="trc:TemporarySegmentDurationOverrideResponse"/>
 		</wsdl:operation>
 		
 	</wsdl:portType>
@@ -1156,6 +1202,15 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		</wsdl:operation>
 		<wsdl:operation name="GetExportRecordedDataState">
 			<soap:operation soapAction="http://www.onvif.org/ver10/recording/wsdl/GetExportRecordedDataState"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="RequestTemporarySegmentDurationOverride">
+			<soap:operation soapAction="http://www.onvif.org/ver10/recording/wsdl/RequestTemporarySegmentDurationOverride"/>
 			<wsdl:input>
 				<soap:body use="literal"/>
 			</wsdl:input>

--- a/wsdl/ver10/recording.wsdl
+++ b/wsdl/ver10/recording.wsdl
@@ -132,10 +132,10 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
-				<xs:attribute name="TemporarySegmentDurationOverrideSupported" type="xs:boolean">
+				<xs:attribute name="OverrideSegmentDurationSupported" type="xs:boolean">
 					<xs:annotation>
 						<xs:documentation>
-							Indicates if the device supports the RequestTemporarySegmentDurationOverride command.
+							Indicates if the device supports the OverrideSegmentDuration command.
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
@@ -690,7 +690,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:complexType>
-			<xs:complexType name="TemporarySegmentDurationOverrideRequest">
+			<xs:complexType name="OverrideSegmentDurationRequest">
 				<xs:sequence>
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
 				</xs:sequence>
@@ -711,7 +711,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:complexType>
-			<xs:complexType name="TemporarySegmentDurationOverrideResponse">
+			<xs:complexType name="OverrideSegmentDurationResponse">
 				<xs:sequence>
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
 				</xs:sequence>
@@ -845,11 +845,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	<wsdl:message name="GetExportRecordedDataStateResponse">
 		<wsdl:part name="parameters" element="trc:GetExportRecordedDataStateResponse"/>
 	</wsdl:message>
-	<wsdl:message name="TemporarySegmentDurationOverrideRequest">
-		<wsdl:part name="parameters" element="trc:TemporarySegmentDurationOverrideRequest"/>
+	<wsdl:message name="OverrideSegmentDurationRequest">
+		<wsdl:part name="parameters" element="trc:OverrideSegmentDurationRequest"/>
 	</wsdl:message>
-	<wsdl:message name="TemporarySegmentDurationOverrideResponse">
-		<wsdl:part name="parameters" element="trc:TemporarySegmentDurationOverrideResponse"/>
+	<wsdl:message name="OverrideSegmentDurationResponse">
+		<wsdl:part name="parameters" element="trc:OverrideSegmentDurationResponse"/>
 	</wsdl:message>
 	
 	<wsdl:portType name="RecordingPort">
@@ -1008,12 +1008,12 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<wsdl:input message="trc:GetExportRecordedDataStateRequest"/>
 			<wsdl:output message="trc:GetExportRecordedDataStateResponse"/>
 		</wsdl:operation>
-		<wsdl:operation name="RequestTemporarySegmentDurationOverride">
+		<wsdl:operation name="OverrideSegmentDuration">
 			<wsdl:documentation>
 			Requests a temporary override of the target segment duration for a recording configuration. 
 			</wsdl:documentation>
-			<wsdl:input message="trc:TemporarySegmentDurationOverrideRequest"/>
-			<wsdl:output message="trc:TemporarySegmentDurationOverrideResponse"/>
+			<wsdl:input message="trc:OverrideSegmentDurationRequest"/>
+			<wsdl:output message="trc:OverrideSegmentDurationResponse"/>
 		</wsdl:operation>
 		
 	</wsdl:portType>
@@ -1209,8 +1209,8 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				<soap:body use="literal"/>
 			</wsdl:output>
 		</wsdl:operation>
-		<wsdl:operation name="RequestTemporarySegmentDurationOverride">
-			<soap:operation soapAction="http://www.onvif.org/ver10/recording/wsdl/RequestTemporarySegmentDurationOverride"/>
+		<wsdl:operation name="OverrideSegmentDuration">
+			<soap:operation soapAction="http://www.onvif.org/ver10/recording/wsdl/OverrideSegmentDuration"/>
 			<wsdl:input>
 				<soap:body use="literal"/>
 			</wsdl:input>

--- a/wsdl/ver10/recording.wsdl
+++ b/wsdl/ver10/recording.wsdl
@@ -690,7 +690,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:complexType>
-			<xs:element name="OverrideSegmentDurationRequest">
+			<xs:element name="OverrideSegmentDuration">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="TargetSegmentDuration" type="xs:duration">
@@ -846,7 +846,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<wsdl:part name="parameters" element="trc:GetExportRecordedDataStateResponse"/>
 	</wsdl:message>
 	<wsdl:message name="OverrideSegmentDurationRequest">
-		<wsdl:part name="parameters" element="trc:OverrideSegmentDurationRequest"/>
+		<wsdl:part name="parameters" element="trc:OverrideSegmentDuration"/>
 	</wsdl:message>
 	<wsdl:message name="OverrideSegmentDurationResponse">
 		<wsdl:part name="parameters" element="trc:OverrideSegmentDurationResponse"/>

--- a/wsdl/ver10/recording.wsdl
+++ b/wsdl/ver10/recording.wsdl
@@ -693,31 +693,27 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:element name="OverrideSegmentDurationRequest">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
+						<xs:element name="TargetSegmentDuration" type="xs:duration">
+							<xs:annotation>
+								<xs:documentation>The new target duration for recorded segments.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="Expiration" type="xs:duration">
+							<xs:annotation>
+								<xs:documentation>The length of time during which the override request is to be in effect.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="RecordingConfiguration" type="tt:RecordingReference">
+							<xs:annotation>
+								<xs:documentation>The recording configuration for which the override is requested.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
 					</xs:sequence>
-					<xs:attribute name="TargetSegmentDuration" type="xs:duration" minOccurs="1">
-						<xs:annotation>
-							<xs:documentation>The new target duration for recorded segments.</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute name="Expiration" type="xs:duration" minOccurs="1">
-						<xs:annotation>
-							<xs:documentation>The length of time during which the override request is to be in effect.</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute name="RecordingConfiguration" type="tt:RecordingReference" minOccurs="1">
-						<xs:annotation>
-							<xs:documentation>The recording configuration for which the override is requested.</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:anyAttribute processContents="lax"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="OverrideSegmentDurationResponse">
 				<xs:complexType>
-					<xs:sequence>
-						<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
-					</xs:sequence>
+					<xs:sequence></xs:sequence>
 				</xs:complexType>
 			</xs:element>
 		</xs:schema>

--- a/wsdl/ver10/recording.wsdl
+++ b/wsdl/ver10/recording.wsdl
@@ -690,32 +690,36 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:complexType>
-			<xs:complexType name="OverrideSegmentDurationRequest">
-				<xs:sequence>
-					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
-				</xs:sequence>
-				<xs:attribute name="TargetSegmentDuration" type="xs:duration" minOccurs="1">
-					<xs:annotation>
-						<xs:documentation>The new target duration for recorded segments.</xs:documentation>
-					</xs:annotation>
-				</xs:attribute>
-				<xs:attribute name="Expiration" type="xs:duration" minOccurs="1">
-					<xs:annotation>
-						<xs:documentation>The length of time during which the override request is to be in effect.</xs:documentation>
-					</xs:annotation>
-				</xs:attribute>
-				<xs:attribute name="RecordingConfiguration" type="tt:RecordingReference" minOccurs="1">
-					<xs:annotation>
-						<xs:documentation>The recording configuration for which the override is requested.</xs:documentation>
-					</xs:annotation>
-				</xs:attribute>
-				<xs:anyAttribute processContents="lax"/>
-			</xs:complexType>
-			<xs:complexType name="OverrideSegmentDurationResponse">
-				<xs:sequence>
-					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
-				</xs:sequence>
-			</xs:complexType>
+			<xs:element name="OverrideSegmentDurationRequest">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
+					</xs:sequence>
+					<xs:attribute name="TargetSegmentDuration" type="xs:duration" minOccurs="1">
+						<xs:annotation>
+							<xs:documentation>The new target duration for recorded segments.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="Expiration" type="xs:duration" minOccurs="1">
+						<xs:annotation>
+							<xs:documentation>The length of time during which the override request is to be in effect.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="RecordingConfiguration" type="tt:RecordingReference" minOccurs="1">
+						<xs:annotation>
+							<xs:documentation>The recording configuration for which the override is requested.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:anyAttribute processContents="lax"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="OverrideSegmentDurationResponse">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
 		</xs:schema>
 	</wsdl:types>
 	<wsdl:message name="GetServiceCapabilitiesRequest">

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -7759,6 +7759,25 @@ and sample rate. </xs:documentation>
 					</xs:documentation>
 				</xs:annotation>
 			</xs:element>
+			<xs:element name="SegmentDurationOverride" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Value of the active OverrideSegmentDuration parameters if one exists. (readonly)</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Duration" type="xs:duration" minOccurs="1">
+							<xs:annotation>
+								<xs:documentation>Current value of the segment duration.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="Expiration" type="xs:duration" minOccurs="1">
+							<xs:annotation>
+								<xs:documentation>Time remaining until the override expires.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
 		</xs:sequence>
 		<xs:anyAttribute processContents="lax"/>


### PR DESCRIPTION
This adds the `RequestTemporarySegmentDurationOverride` command which allows clients to request that a camera records shorter segments on demand. This allows a client to manage costs by configuring cameras for large segment sizes, but dynamically request shorter segments whenever a end-user needs access to the video that is being recorded right now.

This command is optional, and allows a device to offer a better experience for its cloud recording.