### PR TITLE
LensDescription present when Fisheye view mode is present

### DIFF
--- a/doc/Media.xml
+++ b/doc/Media.xml
@@ -4394,36 +4394,6 @@ tns1:Monitoring/ActiveSessions/Metadata
       </section>
     </section>
   </chapter>
-  <appendix xml:id="_Ref425846456">
-    <title>Lens description (Normative)</title>
-    <para>Wide angle lenses produce a geometrically distorted image. The lens description describes where an incoming light beam hits the image sensor. This allows clients to compensate the distortion. This specification describes only the mapping from incoming light beams to sensor location. The actual method of compensating the distortion can be freely chosen by the client and is outside of this specification.</para>
-    <figure>
-      <title>Optical mapping of angle (α) via radius (R) to normalized x/y coordinates</title>
-      <mediaobject>
-        <imageobject>
-          <imagedata fileref="media/Media2/image5.png" contentwidth="147.54mm" />
-        </imageobject>
-      </mediaobject>
-    </figure>
-    <para>The lens projection function is defined <phrase>by a set of points. A smooth mapping is achieved by using </phrase>B-Spline approximation as shown in Figure B-2. </para>
-    <figure>
-      <title>Smooth mapping using B-Splines</title>
-      <mediaobject>
-        <imageobject>
-          <imagedata fileref="media/Media2/image6.jpeg" contentwidth="158.12mm" />
-        </imageobject>
-      </mediaobject>
-    </figure>
-    <para>Lens to imager axis offsets can be described via the so-called LensOffset. Figure B-3 depicts that the compensation of a vertical offset results in a shift of the spline curve.</para>
-    <figure>
-      <title>Compensation of vertical axis offset</title>
-      <mediaobject>
-        <imageobject>
-          <imagedata fileref="media/Media2/image7.jpeg" contentwidth="157.85mm" />
-        </imageobject>
-      </mediaobject>
-    </figure>
-  </appendix>
   <appendix>
     <title>Bibliography</title>
     <para>[ONVIF Display WSDL] ONVIF Media WSDL, ver 2.0, 2010.</para>

--- a/doc/Media.xml
+++ b/doc/Media.xml
@@ -1679,7 +1679,7 @@ Change Request 2430, 2479</revremark>
           <para>Dewarp – Dewarped view mode for device supporting fisheye lens.</para>
         </listitem>
       </itemizedlist>
-      <para>When Fisheye View Mode is present in the VideoSourceConfiguration, the device shall also include the LensDescription (see <xref linkend="_Ref425846456" />).</para>
+      <para>When Fisheye View Mode is present in the VideoSourceConfiguration, the device should also include the LensDescription (see <xref linkend="_Ref425846456" />).</para>
       <section>
         <title>GetVideoSourceConfigurations</title>
         <para>This operation lists all <emphasis>existing</emphasis> video source configurations for a device. This command lists <emphasis>all </emphasis>video source configurations in a device. The client need not know anything about the video source configurations in order to use the command. The device shall support the listing of available video source configurations through the GetVideoSourceConfigurations command.</para>

--- a/doc/Media.xml
+++ b/doc/Media.xml
@@ -1628,58 +1628,7 @@ Change Request 2430, 2479</revremark>
     </section>
     <section>
       <title>Video source configuration</title>
-      <para>A VideoSourceConfiguration contains a reference to a VideoSource and a Bounds structure containing either the whole VideoSource pixel area or a sub-portion of it. The Bounds and VideoSource define the image that is streamed to a client. If a VideoSourceConfiguration is used inside a profile its UseCount parameter is increased to indicate that changing this configuration could affect other users. The origin of the bounds is located in the upper left corner of the video source.</para>
-      <para>The Rotate option specifies an optional rotation of the area defined by the Bounds
-        parameters.  Three modes are defined:</para>
-      <variablelist>
-        <varlistentry>
-          <term>Off</term>
-          <listitem><para>The default value meaning that no rotation is present. The optional Degree shall be
-              ignored.</para></listitem>
-        </varlistentry>
-        <varlistentry>
-          <term>On</term>
-          <listitem><para>The device shall apply the rotation value provided by the Degree parameter. If absent a
-              rotation of 180 degree shall be applied.</para></listitem>
-        </varlistentry>
-        <varlistentry>
-          <term>Auto</term>
-          <listitem><para>The device shall take control over the Degree parameter and automatically update it so that a
-              client can query current rotation. The device shall return the current effective
-              rotation via the Degree parameter with the Video source configuration.</para></listitem>
-        </varlistentry>
-      </variablelist>
-      <para>Note that in case of e.g. a 90 degree rotation the width parameter corresponds to the height of the Video and vice versa.</para>
-      <para>The Lens Description option allows to describe the geometric distortion of the Video Source. For details see <xref linkend="_Ref425846456" />.</para>
-      <para>The Scene Orientation options allow a description of the orientation of the scene the video source is capturing. The Scene Orientation can be Below (from the ceiling), Above (from the floor or a table) and Horizon (on a wall). Some devices may support detecting the Scene Orientation automatically.</para>
-      <para>The View Mode option informs a client what type of view is represented by the video source. The view modes enumeration include</para>
-      <itemizedlist>
-        <listitem>
-          <para>Fisheye – Undewarped viewmode from a device supporting fisheye lens.</para>
-        </listitem>
-        <listitem>
-          <para>360Panorama – 360 degree panoramic view.</para>
-        </listitem>
-        <listitem>
-          <para>180Panorama – 180 degree panoramic view.</para>
-        </listitem>
-        <listitem>
-          <para>Quad – View  mode  combining  four  streams  in  single  Quad,  eg.,  applicable  for devices supporting four heads.</para>
-        </listitem>
-        <listitem>
-          <para>Original – Unaltered view from the sensor.</para>
-        </listitem>
-        <listitem>
-          <para>LeftHalf – Viewmode   combining   the   left   side   sensors,   applicable   for   devices supporting multiple sensors.</para>
-        </listitem>
-        <listitem>
-          <para>RightHalf – Viewmode   combining   the   right   side   sensors,   applicable   for   devices supporting multiple sensors.</para>
-        </listitem>
-        <listitem>
-          <para>Dewarp – Dewarped view mode for device supporting fisheye lens.</para>
-        </listitem>
-      </itemizedlist>
-      <para>When Fisheye View Mode is present in the VideoSourceConfiguration, the device should also include the LensDescription (see <xref linkend="_Ref425846456" />).</para>
+      <para>A VideoSourceConfiguration contains a reference to a VideoSource and a Bounds structure containing either the whole VideoSource pixel area or a sub-portion of it. The Bounds and VideoSource define the image that is streamed to a client. If a VideoSourceConfiguration is used inside a profile its UseCount parameter is increased to indicate that changing this configuration could affect other users.</para>
       <section>
         <title>GetVideoSourceConfigurations</title>
         <para>This operation lists all <emphasis>existing</emphasis> video source configurations for a device. This command lists <emphasis>all </emphasis>video source configurations in a device. The client need not know anything about the video source configurations in order to use the command. The device shall support the listing of available video source configurations through the GetVideoSourceConfigurations command.</para>

--- a/doc/Media.xml
+++ b/doc/Media.xml
@@ -1629,6 +1629,7 @@ Change Request 2430, 2479</revremark>
     <section>
       <title>Video source configuration</title>
       <para>A VideoSourceConfiguration contains a reference to a VideoSource and a Bounds structure containing either the whole VideoSource pixel area or a sub-portion of it. The Bounds and VideoSource define the image that is streamed to a client. If a VideoSourceConfiguration is used inside a profile its UseCount parameter is increased to indicate that changing this configuration could affect other users.</para>
+      <para>For any children element of the VideoSourceConfiguration that is not defined here, follow the Media2 specification definitions.</para>
       <section>
         <title>GetVideoSourceConfigurations</title>
         <para>This operation lists all <emphasis>existing</emphasis> video source configurations for a device. This command lists <emphasis>all </emphasis>video source configurations in a device. The client need not know anything about the video source configurations in order to use the command. The device shall support the listing of available video source configurations through the GetVideoSourceConfigurations command.</para>

--- a/doc/Media.xml
+++ b/doc/Media.xml
@@ -1628,7 +1628,58 @@ Change Request 2430, 2479</revremark>
     </section>
     <section>
       <title>Video source configuration</title>
-      <para>A VideoSourceConfiguration contains a reference to a VideoSource and a Bounds structure containing either the whole VideoSource pixel area or a sub-portion of it. The Bounds and VideoSource define the image that is streamed to a client. If a VideoSourceConfiguration is used inside a profile its UseCount parameter is increased to indicate that changing this configuration could affect other users.</para>
+      <para>A VideoSourceConfiguration contains a reference to a VideoSource and a Bounds structure containing either the whole VideoSource pixel area or a sub-portion of it. The Bounds and VideoSource define the image that is streamed to a client. If a VideoSourceConfiguration is used inside a profile its UseCount parameter is increased to indicate that changing this configuration could affect other users. The origin of the bounds is located in the upper left corner of the video source.</para>
+      <para>The Rotate option specifies an optional rotation of the area defined by the Bounds
+        parameters.  Three modes are defined:</para>
+      <variablelist>
+        <varlistentry>
+          <term>Off</term>
+          <listitem><para>The default value meaning that no rotation is present. The optional Degree shall be
+              ignored.</para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>On</term>
+          <listitem><para>The device shall apply the rotation value provided by the Degree parameter. If absent a
+              rotation of 180 degree shall be applied.</para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Auto</term>
+          <listitem><para>The device shall take control over the Degree parameter and automatically update it so that a
+              client can query current rotation. The device shall return the current effective
+              rotation via the Degree parameter with the Video source configuration.</para></listitem>
+        </varlistentry>
+      </variablelist>
+      <para>Note that in case of e.g. a 90 degree rotation the width parameter corresponds to the height of the Video and vice versa.</para>
+      <para>The Lens Description option allows to describe the geometric distortion of the Video Source. For details see <xref linkend="_Ref425846456" />.</para>
+      <para>The Scene Orientation options allow a description of the orientation of the scene the video source is capturing. The Scene Orientation can be Below (from the ceiling), Above (from the floor or a table) and Horizon (on a wall). Some devices may support detecting the Scene Orientation automatically.</para>
+      <para>The View Mode option informs a client what type of view is represented by the video source. The view modes enumeration include</para>
+      <itemizedlist>
+        <listitem>
+          <para>Fisheye – Undewarped viewmode from a device supporting fisheye lens.</para>
+        </listitem>
+        <listitem>
+          <para>360Panorama – 360 degree panoramic view.</para>
+        </listitem>
+        <listitem>
+          <para>180Panorama – 180 degree panoramic view.</para>
+        </listitem>
+        <listitem>
+          <para>Quad – View  mode  combining  four  streams  in  single  Quad,  eg.,  applicable  for devices supporting four heads.</para>
+        </listitem>
+        <listitem>
+          <para>Original – Unaltered view from the sensor.</para>
+        </listitem>
+        <listitem>
+          <para>LeftHalf – Viewmode   combining   the   left   side   sensors,   applicable   for   devices supporting multiple sensors.</para>
+        </listitem>
+        <listitem>
+          <para>RightHalf – Viewmode   combining   the   right   side   sensors,   applicable   for   devices supporting multiple sensors.</para>
+        </listitem>
+        <listitem>
+          <para>Dewarp – Dewarped view mode for device supporting fisheye lens.</para>
+        </listitem>
+      </itemizedlist>
+      <para>When Fisheye View Mode is present in the VideoSourceConfiguration, the device shall also include the LensDescription (see <xref linkend="_Ref425846456" />).</para>
       <section>
         <title>GetVideoSourceConfigurations</title>
         <para>This operation lists all <emphasis>existing</emphasis> video source configurations for a device. This command lists <emphasis>all </emphasis>video source configurations in a device. The client need not know anything about the video source configurations in order to use the command. The device shall support the listing of available video source configurations through the GetVideoSourceConfigurations command.</para>
@@ -4393,6 +4444,36 @@ tns1:Monitoring/ActiveSessions/Metadata
       </section>
     </section>
   </chapter>
+  <appendix xml:id="_Ref425846456">
+    <title>Lens description (Normative)</title>
+    <para>Wide angle lenses produce a geometrically distorted image. The lens description describes where an incoming light beam hits the image sensor. This allows clients to compensate the distortion. This specification describes only the mapping from incoming light beams to sensor location. The actual method of compensating the distortion can be freely chosen by the client and is outside of this specification.</para>
+    <figure>
+      <title>Optical mapping of angle (α) via radius (R) to normalized x/y coordinates</title>
+      <mediaobject>
+        <imageobject>
+          <imagedata fileref="media/Media2/image5.png" contentwidth="147.54mm" />
+        </imageobject>
+      </mediaobject>
+    </figure>
+    <para>The lens projection function is defined <phrase>by a set of points. A smooth mapping is achieved by using </phrase>B-Spline approximation as shown in Figure B-2. </para>
+    <figure>
+      <title>Smooth mapping using B-Splines</title>
+      <mediaobject>
+        <imageobject>
+          <imagedata fileref="media/Media2/image6.jpeg" contentwidth="158.12mm" />
+        </imageobject>
+      </mediaobject>
+    </figure>
+    <para>Lens to imager axis offsets can be described via the so-called LensOffset. Figure B-3 depicts that the compensation of a vertical offset results in a shift of the spline curve.</para>
+    <figure>
+      <title>Compensation of vertical axis offset</title>
+      <mediaobject>
+        <imageobject>
+          <imagedata fileref="media/Media2/image7.jpeg" contentwidth="157.85mm" />
+        </imageobject>
+      </mediaobject>
+    </figure>
+  </appendix>
   <appendix>
     <title>Bibliography</title>
     <para>[ONVIF Display WSDL] ONVIF Media WSDL, ver 2.0, 2010.</para>

--- a/doc/Media2.xml
+++ b/doc/Media2.xml
@@ -982,6 +982,7 @@
             <para>Dewarp – Dewarped view mode for device supporting fisheye lens.</para>
           </listitem>
         </itemizedlist>
+        <para>When Fisheye View Mode is present in the VideoSourceConfiguration, the device shall also include the LensDescription (see <xref linkend="_Ref425846456" />).</para>
       </section>
       <section>
         <title>Video encoder configuration</title>

--- a/doc/Media2.xml
+++ b/doc/Media2.xml
@@ -982,7 +982,7 @@
             <para>Dewarp – Dewarped view mode for device supporting fisheye lens.</para>
           </listitem>
         </itemizedlist>
-        <para>When Fisheye View Mode is present in the VideoSourceConfiguration, the device shall also include the LensDescription (see <xref linkend="_Ref425846456" />).</para>
+        <para>When Fisheye View Mode is present in the VideoSourceConfiguration, the device should also include the LensDescription (see <xref linkend="_Ref425846456" />).</para>
       </section>
       <section>
         <title>Video encoder configuration</title>


### PR DESCRIPTION
This proposal adds a requirement for the device to provide a LensDescription element when the ViewMode is set to Fisheye. With this new requirement, clients will have the required information to dewarp the received video stream.

Note: Brought a lot of the changes from Media2 into Media1 since the VideoSourceConfiguration is the same for Media1 and Media2. 