### PR TITLE
Align specification capability names to schema.

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -4000,7 +4000,7 @@
             <tbody valign="top">
               <row>
                 <entry>
-                  <para>MaxAuthorizationServerConfigurations</para>
+                  <para>MaxConfigurations</para>
                 </entry>
                 <entry>
                   <para>Indicates the maximum number of  authorization server configurations that
@@ -4009,7 +4009,7 @@
               </row>
               <row>
                 <entry>
-                  <para>AuthorizationServerConfigurationTypesSupported</para>
+                  <para>ConfigurationTypesSupported</para>
                 </entry>
                 <entry>
                   <para>A list of authorization server configuration types that is supported by the


### PR DESCRIPTION
Editorial fix for #467.