### PR TITLE
Allow only single list of trust anchors, as the list can already cont…

### DIFF
--- a/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
+++ b/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
@@ -1083,9 +1083,9 @@
 							<xs:documentation>If present, this is the list of keys provided out of band to verify the origin and integrity of the JWT.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="ValidationPolicy" type="tas:CertPathValidationPolicyID" minOccurs="0" maxOccurs="unbounded">
+					<xs:element name="ValidationPolicy" type="tas:CertPathValidationPolicyID" minOccurs="0">
 						<xs:annotation>
-							<xs:documentation>If present, the device will validate the certification path of the Open ID Connect servers. The OIDC server iso considered to be valid if its certificate is validated by one of the provided certification path validation policies.</xs:documentation>
+							<xs:documentation>If present, the device will validate the certification path of the Open ID Connect servers. The OIDC server iso considered to be valid if its certificate is validated by the provided certification path validation policy.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	   <!-- first ONVIF then Vendor -->


### PR DESCRIPTION
This fix removes requirement for supporting multiple lists of trust anchors as the CeritificateCertPathValidationPolicy already can hold many trust anchors.