### PR TITLE
Updated entry point for device service over Uplink

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -1352,9 +1352,15 @@
       <section>
         <title>General</title>
         <para>An ONVIF compliant device shall support a number of Web Services which are defined in this and related specifications. </para>
-        <para>The device management service is the entry point for all other services of the device and therefore also the target service for the ONVIF defined WS-Discovery behaviour, see chapter <xref linkend="_Ref199745942" />.</para>
+        <para>The device management service is the entry point for all other services of the device
+          and therefore also the target service for the ONVIF defined WS-Discovery behaviour, see
+          chapter <xref linkend="_Ref199745942"/> or the target for accessing device over Uplink
+          connection.</para>
         <para>The entry point for the device management service is fixed to:</para>
         <programlisting><![CDATA[http://onvif_host/onvif/device_service
+]]></programlisting>
+        <para>The entry point for the device management service accessed over Uplink is fixed to:</para>
+        <programlisting><![CDATA[https://onvif_host/onvif/device_service
 ]]></programlisting>
       </section>
       <section>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -1357,10 +1357,7 @@
           chapter <xref linkend="_Ref199745942"/> or the target for accessing device over Uplink
           connection.</para>
         <para>The entry point for the device management service is fixed to:</para>
-        <programlisting><![CDATA[http://onvif_host/onvif/device_service
-]]></programlisting>
-        <para>The entry point for the device management service accessed over Uplink is fixed to:</para>
-        <programlisting><![CDATA[https://onvif_host/onvif/device_service
+        <programlisting><![CDATA[/onvif/device_service
 ]]></programlisting>
       </section>
       <section>


### PR DESCRIPTION
Ref: https://github.com/onvif/wg_profile_cloud/issues/9

Entry point for device service needs to have HTTPS url scheme to access device over Uplink and the PR updates core spec to clarify such requirement. 

**Note**
 - Since Core spec never refers to other service specs, Uplink spec reference is NOT included in list of references

Should we use a different term for Uplink but convey same meaning like 'access device over reverse tunnel'? Suggestions welcome. 