### PR TITLE
Clarify delete interfaces for object storage

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -669,7 +669,7 @@ Change Request 2061, 2063, 2065, 2109</revremark>
       <title>DeleteRecording</title>
       <para>DeleteRecording shall delete a recording object. Whenever a recording is deleted, the device shall delete all the tracks that are part of the recording, and it shall delete all the Recording Jobs that record into the recording. For each deleted recording job, the device shall also delete all the receiver objects associated with the recording job that are automatically created using the AutoCreateReceiver field of the recording job configuration structure and are not used in any other recording job.</para>
       <para>This method is optional. It shall be available if the Recording/DynamicRecordings capability is TRUE.</para>
-      <para>This method has no affect on the data stored in external targets for e.g. Object Storage
+      <para>This method has no effect on the data stored in external targets for e.g. Object Storage
         S3. </para>
       <variablelist role="op">
         <varlistentry>

--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -669,6 +669,8 @@ Change Request 2061, 2063, 2065, 2109</revremark>
       <title>DeleteRecording</title>
       <para>DeleteRecording shall delete a recording object. Whenever a recording is deleted, the device shall delete all the tracks that are part of the recording, and it shall delete all the Recording Jobs that record into the recording. For each deleted recording job, the device shall also delete all the receiver objects associated with the recording job that are automatically created using the AutoCreateReceiver field of the recording job configuration structure and are not used in any other recording job.</para>
       <para>This method is optional. It shall be available if the Recording/DynamicRecordings capability is TRUE.</para>
+      <para>This method has no affect on the data stored in external targets for e.g. Object Storage
+        S3. </para>
       <variablelist role="op">
         <varlistentry>
           <term>request</term>
@@ -849,6 +851,8 @@ Change Request 2061, 2063, 2065, 2109</revremark>
       <title>DeleteTrack</title>
       <para>DeleteTrack shall remove a track from a recording. All the data in the track shall be deleted.</para>
       <para>This method is optional. It shall be available if the Recording/DynamicTracks capability is TRUE.</para>
+      <para>This method has no affect on the data stored in external targets for e.g. Object Storage
+        S3. </para>
       <variablelist role="op">
         <varlistentry>
           <term>request</term>

--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -851,7 +851,7 @@ Change Request 2061, 2063, 2065, 2109</revremark>
       <title>DeleteTrack</title>
       <para>DeleteTrack shall remove a track from a recording. All the data in the track shall be deleted.</para>
       <para>This method is optional. It shall be available if the Recording/DynamicTracks capability is TRUE.</para>
-      <para>This method has no affect on the data stored in external targets for e.g. Object Storage
+      <para>This method has no effect on the data stored in external targets for e.g. Object Storage
         S3. </para>
       <variablelist role="op">
         <varlistentry>


### PR DESCRIPTION
Clarify that Delete Recording/Track interfaces does not affect data stored in external targets.
  - Clarification added based on the query https://github.com/onvif/wg_profile_cloud/issues/15