### PR TITLE
Annex Cipher Reference ONVIF Advanced Security Specification

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -4,12 +4,12 @@
   <info>
     <title>Advanced Security Service Specification</title>
     <titleabbrev>Security Configuration</titleabbrev>
-    <releaseinfo>24.06</releaseinfo>
+    <releaseinfo>24.12</releaseinfo>
     <author>
       <orgname>ONVIF™</orgname>
       <uri>www.onvif.org</uri>
     </author>
-    <pubdate>June 2024</pubdate>
+    <pubdate>December 2024</pubdate>
     <mediaobject>
       <imageobject>
         <imagedata fileref="media/logo.png" contentwidth="60mm"/>
@@ -155,6 +155,14 @@
           <personname>Sriram Bhetanabottla, Hans Busch</personname>
         </author>
         <revremark>Improve readability of section on authorization server. Move JWT example to annex.</revremark>
+      </revision>
+      <revision>
+        <revnumber>24.12</revnumber>
+        <date>December-2024</date>
+        <author>
+          <personname>Kieran McCartan</personname>
+        </author>
+        <revremark>Added an annex with a TLS 1.2 / TLS 1.3 Cipher list.</revremark>
       </revision>
     </revhistory>
   </info>
@@ -4867,6 +4875,55 @@ CSeq: 2
 User-Agent: ./onvifClient
 Accept: application/sdp]]></programlisting>
   </appendix>
+
+  <appendix xml:id= "b14_55m_51d">
+    <title>Cipher Reference</title>
+
+	<para>This Annex is <b>NOT</b> meant to be an exhaustive and definitive Cipher list that ONVIF is advocating as part of the ONVIF standard that readers of this specification are to use but just a guide, to a small subset of ciphers covering TLS 1.2 / 1.3 that are common recommendations issued as guidance by the bodies Cloudflare, IETF (TLS 1.2, TLS1.3), Mozilla, and ciphersuite.info (TLS 1.2, TLS 1.3).</para>
+
+	<para>While TLS 1.2 and 1.3 are both currently viable, we would suggest that TLS 1.3 is preferred. Do note that the table is not ordered by the strength of the cipher.</para>
+
+    <table>
+        <title>TLS 1.3 / 1.2 Cipher list</title>
+	<tgroup cols="2">
+            <colspec colname="c1" colwidth="50*"/>
+            <colspec colname="c2" colwidth="50*"/>
+	   <thead>
+		<row>
+		   <entry><para>Minimum Protocol</para></entry><entry><para>IANA Name</para></entry>
+		</row>
+	   </thead>
+
+	   <tbody valign="top">
+		<row>
+		   <entry><para>TLS 1.3</para></entry><entry><para>TLS_AES_256_GCM_SHA384</para></entry>
+		</row>
+		<row>
+		   <entry><para>TLS 1.3</para></entry><entry><para>TLS_CHACHA20_POLY1305_SHA256</para></entry>
+		</row>
+		<row>
+		   <entry><para>TLS 1.2</para></entry><entry><para>TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256</para></entry>
+		</row>
+		<row>
+		   <entry><para>TLS 1.2</para></entry><entry><para>TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256</para></entry>
+		</row>
+		<row>
+		   <entry><para>TLS 1.2</para></entry><entry><para>TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256</para></entry>
+		</row>
+		<row>
+		   <entry><para>TLS 1.2</para></entry><entry><para>TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256</para></entry>
+		</row>
+		<row>
+		   <entry><para>TLS 1.2</para></entry><entry><para>TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384</para></entry>
+		</row>
+		<row>
+		   <entry><para>TLS 1.2</para></entry><entry><para>TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384</para></entry>
+		</row>
+	   </tbody>
+	</tgroup>
+    </table>
+  </appendix>
+
   <appendix role="revhistory">
     <title>Revision History</title>
     <para/>


### PR DESCRIPTION
This PR has been created off the back of issue #483 and note as per my comment in the issue I am not defining  or proposing algorithms of digital signature and key exchange etc this is I believe outside the ONVIF Standards scope of reference.

I have created as suggested an additional Annex to the ONVIF Advanced Security Specification with a small subset of ciphers covering TLS 1.2 / 1.3 that are common recommendations issued as guidance by the bodies Cloudflare, IETF (TLS 1.2, TLS1.3), Mozilla, and ciphersuite.info (TLS 1.2, TLS 1.3).

I also wish to use this PR to gather information from other ONVIF members as to further extend the PR as appropriate.

N.B. I have not included the following two cipher suites of TLS1.3  TLS_AES_128_CCM_SHA256 and TLS_AES_128_CCM_8_SHA256 only due to the fact that neither Cloudflare nor Mozilla recommended them. I will be happy to include them should there be a consensuses reached on them. 
