### PR TITLE
Change 'a HTTP' to 'an HTTP' (onvif#492)

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -2336,8 +2336,8 @@ DATE: when response was generated
 	  <section>
 	  <title>Get Device Hashing Algorithm</title>               
           <para>Follow the below workflow to get the latest device Hashing Algorithm:</para>
-		  <para>1. The ONVIF client should send a HTTP or RTSP requests without an Authorization header.</para>
-		  <para>2. The device responds with a HTTP or RTSP 401 message, that includes a challenge for each digest algorithm currently it was set, in its order of preference.</para>
+		  <para>1. The ONVIF client should send an HTTP or RTSP requests without an Authorization header.</para>
+		  <para>2. The device responds with an HTTP or RTSP 401 message, that includes a challenge for each digest algorithm currently it was set, in its order of preference.</para>
 		  <para>Note: There is no ONVIF API to get the current hashing algorithm of a device, ONVIF clients should depend on HTTP or RTSP digest challenge response.</para>
       <para>See differing example responses below for the given HTTP request:</para>
       <programlisting><![CDATA[POST /onvif/device_service HTTP/1.1
@@ -5562,7 +5562,7 @@ onvif://www.onvif.org/name/ARV-453
       </section>
       <section xml:id="_Toc251861725">
         <title>GetRemoteUser</title>
-        <para>This operation returns the configured remote user (if any). A device that signals support for remote user handling via the Security Capability RemoteUserHandling shall support this operation. The user is only valid for the WS-UserToken profile or as a HTTP / RTSP user.</para>
+        <para>This operation returns the configured remote user (if any). A device that signals support for remote user handling via the Security Capability RemoteUserHandling shall support this operation. The user is only valid for the WS-UserToken profile or as an HTTP / RTSP user.</para>
         <para>Password derivation is outside of the scope of this specification.</para>
         <variablelist role="op">
           <varlistentry>

--- a/doc/Media.xml
+++ b/doc/Media.xml
@@ -3604,7 +3604,7 @@ The ForcePersistence element is obsolete and should always assumed to be true.
       <title>Snapshot</title>
       <section>
         <title>GetSnapshotUri</title>
-        <para>A Network client uses the GetSnapshotUri command to obtain a JPEG snhapshot from the device. The returned URI shall remain valid indefinitely even if the profile is changed. The ValidUntilConnect, ValidUntilReboot and Timeout Parameter shall be set accordingly (ValidUntilConnect=false, ValidUntilReboot=false, timeout=PT0S). The URI can be used for acquiring a JPEG image through a HTTP GET operation. </para>
+        <para>A Network client uses the GetSnapshotUri command to obtain a JPEG snhapshot from the device. The returned URI shall remain valid indefinitely even if the profile is changed. The ValidUntilConnect, ValidUntilReboot and Timeout Parameter shall be set accordingly (ValidUntilConnect=false, ValidUntilReboot=false, timeout=PT0S). The URI can be used for acquiring a JPEG image through an HTTP GET operation. </para>
         <para>The image encoding will always be JPEG regardless of the encoding setting in the media profile. The JPEG settings (like resolution or quality) should be taken from the profile if suitable. The provided image shall be updated automatically and independent from calls to GetSnapshotUri.</para>
         <para>A device supporting the media service should support this command. A device shall support this command when the SnapshotUri capability is set to true.</para>
         <variablelist role="op">

--- a/doc/Media2.xml
+++ b/doc/Media2.xml
@@ -1379,7 +1379,7 @@
       <title>Snapshot</title>
       <section>
         <title>GetSnapshotUri</title>
-        <para>A Network client uses the GetSnapshotUri command to obtain a JPEG snapshot from the device. The returned URI shall remain valid indefinitely even if the profile parameters change. The URI can be used for acquiring one or more JPEG images through a HTTP GET operation. </para>
+        <para>A Network client uses the GetSnapshotUri command to obtain a JPEG snapshot from the device. The returned URI shall remain valid indefinitely even if the profile parameters change. The URI can be used for acquiring one or more JPEG images through an HTTP GET operation. </para>
         <para>The image encoding will always be JPEG regardless of the encoding setting in the media profile. The JPEG settings (like resolution or quality) should be taken from the profile if suitable. The provided image shall be updated automatically and independent from calls to GetSnapshotUri.</para>
         <para>A device shall support this command when the SnapshotUri capability is set to true.</para>
         <variablelist role="op">

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -3163,14 +3163,14 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<wsdl:operation name="GetRemoteUser">
 			<wsdl:documentation>This operation returns the configured remote user (if any). A device supporting remote user
 				handling shall support this operation. The user is only valid for the WS-UserToken profile or
-				as a HTTP / RTSP user.<br/>
+				as an HTTP / RTSP user.<br/>
 				The algorithm to use for deriving the password is described in section 5.12.2.1 of the core specification.</wsdl:documentation>
 			<wsdl:input message="tds:GetRemoteUserRequest"/>
 			<wsdl:output message="tds:GetRemoteUserResponse"/>
 		</wsdl:operation>
 		<wsdl:operation name="SetRemoteUser">
 			<wsdl:documentation>This operation sets the remote user. A device supporting remote user handling shall support this
-				operation. The user is only valid for the WS-UserToken profile or as a HTTP / RTSP user.<br/>
+				operation. The user is only valid for the WS-UserToken profile or as an HTTP / RTSP user.<br/>
 				The password that is set shall always be the original (not derived) password.<br/>
 				If UseDerivedPassword is set password derivation shall be done by the device when connecting to a
 				remote device.The algorithm to use for deriving the password is described in section 5.12.2.1 of the core specification.<br/>

--- a/wsdl/ver10/media/wsdl/media.wsdl
+++ b/wsdl/ver10/media/wsdl/media.wsdl
@@ -2869,7 +2869,7 @@ the PTZ position shall be repeated within the metadata stream.</wsdl:documentati
 device. The returned URI shall remain valid indefinitely even if the profile is changed. The
 ValidUntilConnect, ValidUntilReboot and Timeout Parameter shall be set accordingly
 (ValidUntilConnect=false, ValidUntilReboot=false, timeout=PT0S). The URI can be used for
-acquiring a JPEG image through a HTTP GET operation. The image encoding will always be
+acquiring a JPEG image through an HTTP GET operation. The image encoding will always be
 JPEG regardless of the encoding setting in the media profile. The Jpeg settings
 (like resolution or quality) may be taken from the profile if suitable. The provided
 image will be updated automatically and independent from calls to GetSnapshotUri.</wsdl:documentation>

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -3903,7 +3903,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			</xs:element>
 			<xs:element name="Status" type="xs:boolean">
 				<xs:annotation>
-					<xs:documentation>Indicates whether or not a certificate is used in a HTTPS configuration.</xs:documentation>
+					<xs:documentation>Indicates whether or not a certificate is used in an HTTPS configuration.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->

--- a/wsdl/ver20/media/wsdl/media.wsdl
+++ b/wsdl/ver20/media/wsdl/media.wsdl
@@ -1839,7 +1839,7 @@ the PTZ position shall be repeated within the metadata stream.</wsdl:documentati
 		<wsdl:operation name="GetSnapshotUri">
 			<wsdl:documentation>A client uses the GetSnapshotUri command to obtain a JPEG snapshot from the
 device. The returned URI shall remain valid indefinitely even if the profile is changed. The URI can be used for
-acquiring a JPEG image through a HTTP GET operation. The image encoding will always be
+acquiring a JPEG image through an HTTP GET operation. The image encoding will always be
 JPEG regardless of the encoding setting in the media profile. The Jpeg settings
 (like resolution or quality) may be taken from the profile if suitable. The provided
 image will be updated automatically and independent from calls to GetSnapshotUri.</wsdl:documentation>


### PR DESCRIPTION
This commit changes the 10 instances of ' a HTTP' found using grep, to ' an HTTP' (there where 10 instances of 'an HTTP' before.