### PR TITLE
Fix WebRTC examples to use peer instead of DeviceId

### DIFF
--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -612,7 +612,7 @@ Device -> Server: { "method": "register", "params": {"authorization": "JWT..."},
 Server -> Device: { "result": { "id": "device-b1" }, "id": 1}
 
 Client -> Server: { "method": "connect", 
-              "params": {"authorization": "JWT...", "DeviceID": "device-b1"}, "id":2}
+              "params": {"authorization": "JWT...", "peer": "device-b1"}, "id":2}
 Server -> Device: { "method": "connect", 
                 "params": {"session": "s1", "iceServers": [{"urls": ["stun:1.2.3.4"]}], "id":2}
   Device -> Server: { "result": {}, "id": 2}


### PR DESCRIPTION
As discussed during telco, the example was obsolete and related to an old version of the spec. Updates it to use the new field name