### PR TITLE
Addressed Moto review feedback

### DIFF
--- a/doc/MediaSigning.xml
+++ b/doc/MediaSigning.xml
@@ -386,11 +386,11 @@
         which they should be hashed and put in the list of hashes
         [h_ach, hash(P4), hash(B2), hash(B3)].</para>
       <para>A hash (<code>gophash</code>) of the list of hashes is added to metadata, <code>gophash
-          = H(h_anch, hash(P1), hash(P2), ..., hash(PN))</code>. The <code>gophash</code> simplifies
-        validation, since verifying each hash in the list of hashes is only necessary when
-        verification of the <code>gophash</code> fails. Another benefit is that the bytestream is
-        prepared for the future, where a low-bitrate alternative can be added by omitting the list
-        of hashes.</para>
+          = H(h_anch, hash(NALUnit1), hash(NALUnit2), ..., hash(NALUnitN))</code>. The
+          <code>gophash</code> simplifies validation, since verifying each hash in the list of
+        hashes is only necessary when verification of the <code>gophash</code> fails. Another
+        benefit is that the bytestream is prepared for the future, where a low-bitrate alternative
+        can be added by omitting the list of hashes.</para>
       <para>To preserve the order of GOPs the hash of the I-frame of the previous GOP is also added
         to metadata, that is, <code>hash(Iprevious) = h_anch_previous</code>. For the very first GOP
         a static and pre-defined hash should be used; See the TLV section below.</para>
@@ -936,7 +936,7 @@
               an unsigned 16 bit value.</para>
           </listitem>
           <listitem>
-            <para>(Partial) GOP hash (h bytes)</para>
+            <para>(Partial) GOP hash  (<code>gophash</code>) (h bytes)</para>
             <para>The hash of the list of NAL Unit hashes. This hash is used to verify the entire
               GOP in one operation. Upon failure, the list of hashes, if present, is used to detect
               missing NAL Units. Number of bytes depends on the hash function used.</para>


### PR DESCRIPTION
Addressed below comments from Moto

- On page 20
  - **Existing** 
    - for the GOP hash ve do not point to the variable as we do for h_anch_previous. So, if I look for gophash I do not find in in the TLV specs. Could a small change like this make sense?
  - **Proposed** 
    - (Partial) GOP hash **(gophash)** (h bytes) The hash of the list of NAL Unit hashes. This hash is used to verify the entire GOP in one operation. Upon failure, the list of hashes, if present, is used to detect missing NAL Units. Number of bytes depends on the hash function used.

- Also on page 9 we have this sentence
  - **Existing**
    - A hash (gophash) of the list of hashes is added to metadata, gophash = H(h_anch, hash(P1), hash(P2), ..., hash(PN)). 
      - This is the case when B frames aren't used, not the generic one, based on the order of NAL units. Since in the previous paragraph we state that the mechanism works on NAL units in order not to make any difference between P and B frames, with or without multiple slices per frame, I think it should be changed to
  - **Proposed**
    - A hash (gophash) of the list of hashes is added to metadata, **gophash = H(h_anch, hash(NALUnit1), hash(NALUnit2), ..., hash(NALUnitN)).** 