### PR TITLE
Video/fix uplink streaming not mandatory

### DIFF
--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -331,15 +331,15 @@
           example given in the specification. Since http/2 streams may be closed by either side when
           the content-length has been reached clients shall use a value large enough for the
           connection life time.</para>
-        <para>A device shall signal support for StreamingOverUplink capability if media streaming
-          over uplink via RTSP over HTTP or RTSP over WebSockets is supported.</para>
+        <para>A device shall support media streaming over uplink via RTSP over HTTP or RTSP over
+          WebSockets if StreamingOverUplink capability is supported.</para>
         <para>A device signaling support for RTSP streaming via its capability RTSPStreaming should
           support the same on the uplink.</para>
       </section>
       <section>
         <title>RTSP over WebSockets</title>
-        <para>A device shall signal support for StreamingOverUplink capability if media streaming
-          over uplink via RTSP over HTTP or RTSP over WebSockets is supported.</para>
+        <para>A device shall support media streaming over uplink via RTSP over HTTP or RTSP over
+          WebSockets if StreamingOverUplink capability is supported.</para>
         <para>A device signaling support for websockets over RTSP via its capability
           RTSPWebSocketUri should support RFC 8441 on the uplink.</para>
       </section>

--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -316,6 +316,10 @@
           various mechanisms for streaming Video, Audio and Metadata. This specification defines how
           to apply streaming over http/2. Usage of other communication mechanisms like UDP unicast
           and multicast are outside of the scope of this specification.</para>
+
+        <para>ONVIF recommends to use WebRTC based media streaming for low latency peer to peer
+          streaming use cases rather than media streaming over Uplink. ONVIF specified streaming
+          over WebRTC is outside the scope of this specification. </para>
       </section>
       <section>
         <title>RTSP over HTTP</title>
@@ -327,11 +331,17 @@
           example given in the specification. Since http/2 streams may be closed by either side when
           the content-length has been reached clients shall use a value large enough for the
           connection life time.</para>
+        <para>A device shall signal support for StreamingOverUplink capability if media streaming
+          over uplink via RTSP over HTTP or RTSP over WebSockets is supported.</para>
+        <para>A device signaling support for RTSP streaming via its capability RTSPStreaming should
+          support the same on the uplink.</para>
       </section>
       <section>
         <title>RTSP over WebSockets</title>
+        <para>A device shall signal support for StreamingOverUplink capability if media streaming
+          over uplink via RTSP over HTTP or RTSP over WebSockets is supported.</para>
         <para>A device signaling support for websockets over RTSP via its capability
-          RTSPWebSocketUri shall support RFC 8441 on the uplink.</para>
+          RTSPWebSocketUri should support RFC 8441 on the uplink.</para>
       </section>
     </section>
   </chapter>
@@ -527,6 +537,11 @@
         <varlistentry>
           <term>AuthorizationModes</term>
           <listitem><para>Supported authorization mode [mTLS, JWT]</para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>StreamingOverUplink</term>
+          <listitem><para>Signals support for media streaming over uplink</para>
+          </listitem>
         </varlistentry>
       </variablelist>
     </section>

--- a/wsdl/ver10/uplink/wsdl/uplink.wsdl
+++ b/wsdl/ver10/uplink/wsdl/uplink.wsdl
@@ -62,6 +62,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:documentation>Supported authorization mode [mTLS JWT] as defined by tup:AuthorizationModes.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
+				<xs:attribute name="StreamingOverUplink" type="xs:boolean">
+					<xs:annotation>
+						<xs:documentation>Signals support for media streaming over uplink.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:complexType>
 			<xs:element name="Capabilities" type="tup:Capabilities"/>


### PR DESCRIPTION
Copy of PR https://github.com/onvif/specs/pull/498 for the branch made on base.
As a follow up of cloud profile discussions in SanDiego, below changes are done 

- Reduced requirement level 
  - streaming over uplink via websockets from mandatory to recommended.
- Added capability based requirement 
  - RTSP streaming over uplink as recommended feature.

**To be discussed**
- Should we refer to RFC2326 and/or RFC7826 in rtsp related requirement or is it enough as proposed to refer to streaming service capability?
  - Alternate Proposal 
    - A device signaling support for RTSP streaming via its capability RTSPStreaming should
          support RFC7826 on the uplink.

**2024/12/19 Update** 
  - As a follow up of discussion in VEWG Telco on 12/5, a new capability has been added to wrap media streaming over uplink using either of the transports RTSP over HTTP or RTSP over Websockets.
  - Added WebRTC as recommendation for P2P low latency usecases.
  
  **2025/01/08 Update** 
- Addressed Bosch feedback