### PR TITLE
Add support for license plate color.

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -1366,6 +1366,10 @@
                     <para>State province or authority that issue the license plate.</para>
                   </entry>
                 </row>
+              <row>
+                <entry>Color</entry>
+                <entry>Background color of the license plate</entry>
+              </row>
               </tbody>
             </tgroup>
           </table>

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -1367,8 +1367,9 @@
                   </entry>
                 </row>
               <row>
-                <entry>Color</entry>
-                <entry>Background color of the license plate</entry>
+                <entry><para>Color</para></entry>
+                <entry><para>Optional background color of the license plate in case of vehicle objects.
+                  For license plate objects use color descriptor.</para></entry>
               </row>
               </tbody>
             </tgroup>

--- a/wsdl/ver10/schema/metadatastream.xsd
+++ b/wsdl/ver10/schema/metadatastream.xsd
@@ -138,6 +138,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:element name="Type" type="tt:StringLikelihood"/>  <!-- tt:VehicleType lists the acceptable values" --> 
 			<xs:element name="Brand" type="tt:StringLikelihood" minOccurs="0" maxOccurs="1"/> 
 			<xs:element name="Model" type="tt:StringLikelihood" minOccurs="0" maxOccurs="1"/> 
+			<xs:element name="Color" type="tt:ColorDescriptor" minOccurs="0"/> 
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>      <!-- first ONVIF then vendor --> 
 		</xs:sequence> 
 		<xs:anyAttribute processContents="lax"/> 


### PR DESCRIPTION
Some countries use a background color code to uniquely identify a vehicle.