### PR TITLE
Update of Media Signing specification

### DIFF
--- a/doc/MediaSigning.xml
+++ b/doc/MediaSigning.xml
@@ -58,6 +58,12 @@
       signing feature, and also how an ONVIF client should validate the authenticity of a signed
       stream. Audio is outside of scope.</para>
   </chapter>
+  <chapter xml:id="chapter_spec_version">
+    <title>Specification version v1.0</title>
+    <para>This number should be updated when an update to the specification breaks the bitstream
+      format or when new features are added. Such features could be new ways of hashing or support
+      of more codecs.</para>
+  </chapter>
   <chapter xml:id="chapter_a3s_njq_bwb">
     <title>Normative references</title>
     <para>ITU-T Recommendation, H.264: Advanced video coding for generic audiovisual services</para>
@@ -72,6 +78,8 @@
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://oid-info.com/"/>&gt;</para>
     <para>IETF RFC 6234 - US Secure Hash Algorithms (SHA and SHA-based HMAC and HKDF)</para>
     <para role="reference">&lt;<link xlink:href="http://tools.ietf.org/html/rfc6234" xmlns:xlink="http://www.w3.org/1999/xlink"/>&gt;</para>
+    <para>Reference implementation of this specification</para>
+    <para role="reference">&lt;<link xlink:href="https://github.com/onvif/signed-media-framework" xmlns:xlink="http://www.w3.org/1999/xlink"/>&gt;</para>
   </chapter>
   <chapter xml:id="chapter_b3s_njq_bwb">
     <title>Terms and Definitions</title>
@@ -909,10 +917,12 @@
             <para>Version = 1</para>
           </listitem>
           <listitem>
-            <para>Software version (3 byte)</para>
-            <para>If applicable write the software version used by the device in
-              major, minor, patch form. For example, software version "v2.35.215" is written
-              to three bytes as [2, 35, 215].</para>
+            <para>Specification version (3 byte)</para>
+            <para>The major and minor bytes should be set to the version of this specification, that
+              is, [1, 0]; See Chapter <xref linkend="chapter_spec_version"/>.</para>
+            <para>The patch byte is reserved by the open-source reference implementation code
+              (github.com/onvif/signed-media-framework). Should be set to 0 if not using
+              signed-media-framework.</para>
           </listitem>
           <listitem>
             <para>Signing triggered by partial-GOP (1 byte)</para>


### PR DESCRIPTION
This commit explains the difference between Firmware version and Software version. To differentiate between them the 'software' has been changed to 'specification'. Further, a version of the specification has been added.
