### PR TITLE
Minor updates to the onboarding specification

### DIFF
--- a/doc/CloudIntegration.xml
+++ b/doc/CloudIntegration.xml
@@ -279,21 +279,21 @@
       <para>The share token must be a JWT and must include the following claims:</para>
       <itemizedlist>
         <listitem>
-          <para><emphasis>xaddr</emphasis>: The URI where the PCS will be accepting the incoming
+          <para><emphasis>onvif:xaddr</emphasis>: The URI where the PCS will be accepting the incoming
             requests from the OCS</para>
         </listitem>
         <listitem>
-          <para><emphasis>SerialNumber</emphasis>: The serial number of the device.</para>
+          <para><emphasis>onvif:sn</emphasis>: The serial number of the device.</para>
         </listitem>
         <listitem>
-          <para><emphasis>Model</emphasis>: The device model.</para>
+          <para><emphasis>onvif:model</emphasis>: The device model.</para>
         </listitem>
         <listitem>
-          <para><emphasis>Manufacturer</emphasis>: The manufactor of the device.</para>
+          <para><emphasis>onvif:manufacturer</emphasis>: The manufacturer of the device.</para>
         </listitem>
       </itemizedlist>
-      <para>The claims <emphasis>SerialNumber</emphasis>, <emphasis>Model</emphasis> and
-          <emphasis>Manufacturer</emphasis> shall match the values returned by GetDeviceInformation
+      <para>The claims <emphasis>onvif:sn</emphasis>, <emphasis>onvif:model</emphasis> and
+          <emphasis>onvif:manufacturer</emphasis> shall match the values returned by GetDeviceInformation
         of the Device service.</para>
       </section>
   </chapter>

--- a/yaml/ver10/cloudintegration/yaml/cloudintegration.yaml
+++ b/yaml/ver10/cloudintegration/yaml/cloudintegration.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.1
+openapi: 3.0.3
 info:
   title: Cloud Integration Specification
   contact:
@@ -12,113 +12,103 @@ info:
 
 components:
   schemas:
-    Base64DERencodedASN1Value:
+    base64DerEncodedAsn1Value:
       description: This schema is the equivalent of tas:Base64DERencodedASN1Value in the Security Service specification.
       type: string
       format: byte
-      examples: [ Base64DERencodedASN1Value ]
 
-    EndpointReferenceType:
+    endpointReferenceType:
       description: This schema is the equivalent of wsa:EndpointReferenceType in the WA-Addressing 1.0 specification.
       type: string
       format: uri
 
-    AuthorizationServerConfiguration:
+    authorizationServerConfiguration:
       type: object
       description: This schema is the equivalent of tas:AuthorizationServerConfigurationData
       properties:
-        ServerURI:
+        serverUri:
           description: Authorization server address
           type: string
-        ClientID:
+        clientId:
           description: Client identifier issued by the authorization server
           type: string
-        Scope:
+        scope:
           description: The requested access scope
           type: string
-        AuthorizationServerTrustAnchor:
+        authorizationServerTrustAnchors:
           items:
-            $ref: '#/components/schemas/Base64DERencodedASN1Value'
+            $ref: '#/components/schemas/base64DerEncodedAsn1Value'
           description: The list of certificates with the public keys needed to build the validation policy to validate the TLS certificate of the authorization server.
       required:
-        - ServerURI
-        - ClientID
+        - serverUri
+        - clientId
 
-    UplinkConfiguration:
+    uplinkConfiguration:
       type: object
       properties:
-        RemoteAddress:
+        remoteAddress:
           description: Uniform resource locator by which the remote client can be reached.
-          $ref: '#/components/schemas/EndpointReferenceType'
-        UserLevel:
+          $ref: '#/components/schemas/endpointReferenceType'
+        userLevel:
           description: Authorization level that will be assigned to the uplink connection.
           type: string
           enum: [Administrator, Operator, User]
-        UplinkTrustAnchor:
+        uplinkTrustAnchors:
           items:
-            $ref: '#/components/schemas/Base64DERencodedASN1Value'
+            $ref: '#/components/schemas/base64DerEncodedAsn1Value'
           description: The list of certificates with the public keys needed to build the validation policy to validate the TLS certificate of the uplink server.
       required:
-        - RemoteAddress
-        - UserLevel
+        - remoteAddress
+        - userLevel
 
-    DeviceConfiguration:
+    deviceConfiguration:
       type: object
       properties:
-        ShareToken:
+        shareToken:
           description: The share token, to prove permission to share the device.
           type: string
           format: byte
-        EndpointReferences:
+        endpointReferences:
           description: The endpoint to be notified to inform that the operation was completed. It may be more then one if the requesting cloud has redundant URIs to receive the notification.
           items:
-            $ref: '#/components/schemas/EndpointReferenceType'
-        UplinkConfiguration:
+            $ref: '#/components/schemas/endpointReferenceType'
+        uplinkConfigurations:
           description: Per-device uplink configuration
           items:
-            $ref: '#/components/schemas/UplinkConfiguration'
-        AuthorizationServerConfiguration:
+            $ref: '#/components/schemas/uplinkConfiguration'
+        authorizationServerConfigurations:
           items:
-            $ref: '#/components/schemas/AuthorizationServerConfiguration'
+            $ref: '#/components/schemas/authorizationServerConfiguration'
       required:
-        - ShareToken
-        - EndpointReferences
-        - UplinkConfiguration
-        - AuthorizationServerConfiguration
+        - shareToken
+        - endpointReferences
+        - uplinkConfigurations
+        - authorizationServerConfigurations
 
-    DeviceInformation:
+    startDeviceSharing:
       type: object
       properties:
-        ShareToken:
-          description: The share token, to know what device the public key is associated to.
-          $ref: '#/components/schemas/Base64DERencodedASN1Value'
-        DevicePublicKey:
-          description: The public key of the device.
-          $ref: '#/components/schemas/Base64DERencodedASN1Value'
-      required:
-        - ShareToken
-        - DevicePublicKey
-
-    StartDeviceSharing:
-      type: object
-      properties:
-        DeviceConfigurations:
+        deviceConfigurations:
           items:
-            $ref: '#/components/schemas/DeviceConfiguration'
+            $ref: '#/components/schemas/deviceConfiguration'
           description: For each camera requested to be shared, it is necessary to pass both the shared token and the endpoint reference.
       required:
-        - DeviceConfigurations
+        - deviceConfigurations
 
-    DeviceSharingCompleted:
+    deviceSharingCompleted:
       type: object
       properties:
-        DevicesInformation:
-          $ref: '#/components/schemas/DeviceInformation'
-          description: For each shared device, the share token and the public key will be provided.
+        shareToken:
+          description: The share token, to know what device the public key is associated to.
+          $ref: string
+        devicePublicKey:
+          description: The public key of the device.
+          $ref: '#/components/schemas/base64DerEncodedAsn1Value'
       required:
-        - DevicesInformation
+        - shareToken
+        - devicePublicKey
 
-    DeviceSharingError:
+    deviceSharingError:
       type: object
       properties:
         error:
@@ -137,7 +127,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/StartDeviceSharing'
+              $ref: '#/components/schemas/startDeviceSharing'
       responses:
         '200':
           description: Success
@@ -146,7 +136,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceSharingError'
+                $ref: '#/components/schemas/deviceSharingError'
 
   /deviceSharingCompleted:
     post:
@@ -157,7 +147,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeviceSharingCompleted'
+              $ref: '#/components/schemas/deviceSharingCompleted'
       responses:
         '200':
           description: Success

--- a/yaml/ver10/cloudintegration/yaml/cloudintegration.yaml
+++ b/yaml/ver10/cloudintegration/yaml/cloudintegration.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.1
 info:
   title: Cloud Integration Specification
   contact:


### PR DESCRIPTION
While prototyping this specification, came up with some required changes:
- updated the claims in the share token to be lower-case and include the `onvif:` namespace to respect the claims convention from IANA
- updated the cloudintegration.yaml file to be camel-case to follow standard JSON conventions
- lowered the required version to 3.0.3 so online studios can actually validate it and offer the swagger for it (note: this version change could be reverted to 3.1.1 if needed)
- modified callback response to OCS to remove unneeded DevicesInformation object definition and now simply returns the shareToken and public key

Possible changes needed in the future:
- Define the structure of the public key being sent to the OCS
- Possibly review how the trust anchors are provided and include the policy alias in the data models