### PR TITLE
Add recommendation to avoid invalid attributes content due to segment override

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -2304,6 +2304,9 @@ secfrac = "." 1*6DIGIT</programlisting>
           </tbody>
         </tgroup>
       </table>
+      <para>For storage target systems that do not allow attribute changes during write the
+        attribute Duration should be omitted when the total duration of the file may change while it
+        is written e.g. due to an override segment duration request.</para>
     </section>
     <section xml:id="_refCloudRecordingObjectExamples">
       <title>Examples</title>


### PR DESCRIPTION
Note that this issue also applies to the pending seek-table.