### PR TITLE
Onboarding: define public key format + introduce aliases

### DIFF
--- a/doc/CloudIntegration.xml
+++ b/doc/CloudIntegration.xml
@@ -332,6 +332,7 @@
       <title>deviceSharingCompleted</title>
       <para>This operation notifies the new Operational Cloud Service that the camera was
         successfully configured.</para>
+      <para>The public key shall be a base64 encoded DER-encoded PKCS#10 certification request.</para>
       <variablelist role="op">
         <varlistentry>
           <term>request</term>

--- a/yaml/ver10/cloudintegration/yaml/cloudintegration.yaml
+++ b/yaml/ver10/cloudintegration/yaml/cloudintegration.yaml
@@ -35,13 +35,13 @@ components:
         scope:
           description: The requested access scope
           type: string
-        authorizationServerTrustAnchors:
-          items:
-            $ref: '#/components/schemas/base64DerEncodedAsn1Value'
-          description: The list of certificates with the public keys needed to build the validation policy to validate the TLS certificate of the authorization server.
+        certPathValidationPolicyAlias:
+          description: The alias of the certPathValidationPolicy to be used with this configuration
+          type: string
       required:
         - serverUri
         - clientId
+        - certPathValidationPolicyAlias
 
     uplinkConfiguration:
       type: object
@@ -53,13 +53,13 @@ components:
           description: Authorization level that will be assigned to the uplink connection.
           type: string
           enum: [Administrator, Operator, User]
-        uplinkTrustAnchors:
-          items:
-            $ref: '#/components/schemas/base64DerEncodedAsn1Value'
-          description: The list of certificates with the public keys needed to build the validation policy to validate the TLS certificate of the uplink server.
+        certPathValidationPolicyAlias:
+          description: The alias of the certPathValidationPolicy to be used with this configuration
+          type: string
       required:
         - remoteAddress
         - userLevel
+        - certPathValidationPolicyAlias
 
     deviceConfiguration:
       type: object
@@ -79,11 +79,16 @@ components:
         authorizationServerConfigurations:
           items:
             $ref: '#/components/schemas/authorizationServerConfiguration'
+        certPathValidationPolicies:
+          description: List of certificate validation policies that can be referenced by alias
+          items:
+            $ref: '#/components/schemas/certPathValidationPolicy'
       required:
         - shareToken
         - endpointReferences
         - uplinkConfigurations
         - authorizationServerConfigurations
+        - certPathValidationPolicies
 
     startDeviceSharing:
       type: object
@@ -116,6 +121,20 @@ components:
           enum: [ "Invalid configuration", "Invalid JWT" ]
       required:
         - error
+
+    certPathValidationPolicy:
+      type: object
+      properties:
+        alias:
+          description: The alias to be used for the CertPathValidationPolicy
+          type: string
+        trustAnchors:
+          description: List of trust anchors in base64DerEncodedAsn1Value
+          items:
+            $ref: '#/components/schemas/base64DerEncodedAsn1Value'
+      required:
+        - alias
+        - trustAnchors
 
 paths:
   /startDeviceSharing:


### PR DESCRIPTION
So while prototyping the Onboarding spec, we found 2 things that could be improved upon. The first is that the public key in the deviceCompleted request had an undefined format. Using the PKCS10 CSR made sense, so we added that to the specification.

The other is the handling of the trust anchors. While trying to setup the camera for webrtc, we realized that knowing the alias of the certificate path validation policy would really be helpful to easily reuse it instead of trying to find a policy that matches all trust anchors one by one. For this, we extracted the trust anchors from each model and instead made a `certPathValidationPolicy` object which contains an `alias` and the `trustAnchors`. We can then reference this policy in the authorization server config and uplink configuration using the `alias` as the key. This should also make the whole payload a bit smaller, since we don't need to repeat the trust anchors in each configurations.

You can easily preview the changes in https://editor-next.swagger.io/