### PR TITLE
Added object UUID for parent object

### DIFF
--- a/wsdl/ver10/schema/metadatastream.xsd
+++ b/wsdl/ver10/schema/metadatastream.xsd
@@ -275,6 +275,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:documentation>Object ID of the parent object. eg: License plate object has Vehicle object as parent.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
+				<xs:attribute name="ParentUUID" type="xs:string">
+					<xs:annotation>
+						<xs:documentation>Object UUID of the parent object. eg: License plate object has Vehicle object as parent.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:extension>
 		</xs:complexContent>

--- a/wsdl/ver10/schema/metadatastream.xsd
+++ b/wsdl/ver10/schema/metadatastream.xsd
@@ -344,7 +344,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	<xs:complexType name="ObjectId">
 		<xs:attribute name="ObjectId" type="xs:integer"/>
 		<xs:attribute name="UUID" type="xs:string">
-			<xs:annotation><xs:documentation>Optional unique identifier.</xs:documentation></xs:annotation>
+			<xs:annotation><xs:documentation>Object unique identifier.</xs:documentation></xs:annotation>
 		</xs:attribute>
 	</xs:complexType>
 	<xs:complexType name="Behaviour">


### PR DESCRIPTION
Ref: [Add object attribute UUID. by HansBusch · Pull Request #445 · onvif/specs](https://github.com/onvif/specs/pull/445)
 
When Object ID was extended to include UUID, Parent object ID seems to be missed from extension.

Parent Object ID is an integer attribute of tt:Object and hence we need to add another attribute of type xs:string for Parent UUID as below into tt:Object


```xml
<xs:attribute name="Parent" type="xs:integer">
	<xs:annotation>
		<xs:documentation>Object ID of the parent object. eg: License plate object has Vehicle object as parent.</xs:documentation>
	</xs:annotation>
</xs:attribute>

<!-- Added attribute  -->
<xs:attribute name="ParentUUID" type="xs:string">
	<xs:annotation>
		<xs:documentation>Object UUID of the parent object. eg: License plate object has Vehicle object as parent.</xs:documentation>
	</xs:annotation>
</xs:attribute>
```

Would have been ideal if original Parent attribute was xs:string so that only annotation update to say Object ID or UUID, hence had to add a new option in parallel to xs:string.