### PR TITLE
clarify requirements for fault for rule/module creation

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -3257,8 +3257,11 @@ xmlns:acme="http://www.acme.com/schema"&gt;
         </section>
         <section>
           <title>CreateRules</title>
-          <para>A device signaling support for rules via the RuleSupport capability shall support this operation to add rules to an AnalyticsConfiguration. If all rules can not be created as requested, the device responds with a fault message.
-          The device shall accept adding of analytics rules with an empty Parameter definition. Note that the resulted configuration may include a set of default parameter values.</para>
+          <para>A device signaling support for rules via the RuleSupport capability shall support
+            this operation to add rules to an AnalyticsConfiguration. If all rules can not be
+            created as requested, the device shall respond with a fault message. The device shall
+            accept adding of analytics rules with an empty Parameter definition. Note that the
+            resulted configuration may include a set of default parameter values.</para>
           <variablelist role="op">
             <varlistentry>
               <term>request</term>
@@ -3302,7 +3305,10 @@ xmlns:acme="http://www.acme.com/schema"&gt;
         </section>
         <section>
           <title>ModifyRules</title>
-          <para>A device signaling support for modifying rules via the RuleOptionsSupported capability shall support this operation. If all rules can not be modified as requested, the device responds with a fault message. A device may reject a request to change the rule type.</para>
+          <para>A device signaling support for modifying rules via the RuleOptionsSupported
+            capability shall support this operation. If all rules can not be modified as requested,
+            the device shall respond with a fault message. A device may reject a request to change
+            the rule type.</para>
           <para>A device should interpret parameters not present in the payload as unchanged. Note that this does not always result in unchanged values of such parameters, since some parameters may change due to dependency on others.</para>
           <variablelist role="op">
             <varlistentry>
@@ -3542,7 +3548,10 @@ xmlns:acme="http://www.acme.com/schema"&gt;
         </section>
         <section>
           <title>CreateAnalyticsModules</title>
-          <para>A device signaling support for analytics modules via the AnalyticsModuleSupport capability shall support this method to add analytics modules to an analytics configuration. </para>
+          <para>A device signaling support for analytics modules via the AnalyticsModuleSupport
+            capability shall support this method to add analytics modules to an analytics
+            configuration. If all modules can not be created as requested, the device shall respond
+            with a fault message. </para>
           <para>The device shall accept adding of analytics modules with an empty Parameter definition. Note that the resulted configuration may include a set of default parameter values.</para>
           <variablelist role="op">
             <varlistentry>
@@ -3587,7 +3596,11 @@ xmlns:acme="http://www.acme.com/schema"&gt;
         </section>
         <section>
           <title>ModifyAnalyticsModules</title>
-          <para>A device signaling support for analytics modules via the AnalyticsModuleOptionsSupported capability shall support this method to modify analytics module configurations. A device may reject a request to change the module type.</para>
+          <para>A device signaling support for analytics modules via the
+            AnalyticsModuleOptionsSupported capability shall support this method to modify analytics
+            module configurations. If all modules can not be modified as requested, the device shall
+            respond with a fault message. A device may reject a request to change the module
+            type.</para>
           <para>A device should interpret parameters not present in the payload as unchanged. Note that this does not always result in unchanged values of such parameters, since some parameters may change due to dependency on others.</para>
           <variablelist role="op">
             <varlistentry>


### PR DESCRIPTION
Clarify requirements to return fault for Rules/Module creation/modification.

**Spec References**

- CreateRules
  - If all rules can not be created as requested, the **device responds with** a fault message.
- ModifyRules
  - If all rules can not be modified as requested, the **device responds with** a fault message.

**Problem statement, applicable for rules/modules** 
 - Assume a request sent with an unsupported options value for a parameter OR
 - Assume a request sent with an unsupported parameter

**Interpretation ambiguity**
  - Since there is no SHALL tag for that requirement, its a bit open if device accepts/adjusts what it can handle vs throwing a fault back.

**Clarification/Proposals**

- CreateRules (text update)
  - If all rules can not be created as requested, the device **shall respond** with a fault message.

- ModifyRules (text update)
  - If all rules can not be modified as requested, the device **shall respond** with a fault message.

- CreateAnalyticsModules (text missing, hence addition)
  - If all modules can not be created as requested, the device shall respond with a fault message.
 
 - ModifyAnalyticsModules (text missing, hence addition)
   - If all modules can not be modified as requested, the device shall respond with a fault message.

**DTT 24.12**
  - Profile M tests do not include any negative tests for checking fault codes, so impact on conformance should be minimal.
    - If such a test need to be added is a topic to discuss?