### PR TITLE
Fix media signing binding

### DIFF
--- a/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
+++ b/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
@@ -4096,6 +4096,7 @@
 	</wsdl:binding>
 	<!--==========================================-->
 	<wsdl:binding name="MediaSigningBinding" type="tas:MediaSigning">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
 		<wsdl:operation name="AddMediaSigningCertificateAssignment">
 			<soap:operation soapAction="http://www.onvif.org/ver10/advancedsecurity/wsdl/AddMediaSigningCertificateAssignment"/>
 			<wsdl:input>


### PR DESCRIPTION
In advancedsecurity.wsdl, the newly added MediaSigningBinding doesn't have this line:
`<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>`
which is present in other bindings. This causes some tools to fail to generate code from this WSDL file.