### PR TITLE
Remove JsonWebToken requirement from uplink

### DIFF
--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -299,16 +299,12 @@
           specifications.</para>
         <para>To uniquely identify a local service on remote client, it is recommended to have a unique client certificate installed on each local service. For example, CN field or Serial number of installed certificate could be used to uniquely identify the local service.</para>
         <para>The device shall assign any tunneled HTTP or RTSP request the UserLevel that is configured for the configuration without the need of further authentication request headers. </para>
-        <para>When a device indicates supported authorization mode as mTLS through its Capabilities,
-          then it shall support mTLS authentication in this specification.</para>
       </section>
       <section>
         <title>JWT authentication</title>
         <para>When using JWT authentication, the local service shall provide a JWT token when sending the upgrade request.</para>
         <para>The remote client shall validate the JWT token provided following the JWT specification as defined in the Core specification.</para>
         <para>The device shall assign any tunneled HTTP or RTSP request the UserLevel that is configured for the configuration without the need of further authentication request headers.</para>
-        <para>When a device indicates supported authorization mode as JWT through its Capabilities,
-          then it shall support JWT authentication in this specification.</para>
       </section>
     </section>
     <section>

--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -299,13 +299,16 @@
           specifications.</para>
         <para>To uniquely identify a local service on remote client, it is recommended to have a unique client certificate installed on each local service. For example, CN field or Serial number of installed certificate could be used to uniquely identify the local service.</para>
         <para>The device shall assign any tunneled HTTP or RTSP request the UserLevel that is configured for the configuration without the need of further authentication request headers. </para>
+        <para>When a device indicates supported authorization mode as mTLS through its Capabilities,
+          then it shall support mTLS authentication in this specification.</para>
       </section>
       <section>
         <title>JWT authentication</title>
         <para>When using JWT authentication, the local service shall provide a JWT token when sending the upgrade request.</para>
         <para>The remote client shall validate the JWT token provided following the JWT specification as defined in the Core specification.</para>
         <para>The device shall assign any tunneled HTTP or RTSP request the UserLevel that is configured for the configuration without the need of further authentication request headers.</para>
-        <para>When a device indicates JsonWebToken is supported through its Capabilities, then it shall support JWT authentication in this specification.</para>
+        <para>When a device indicates supported authorization mode as JWT through its Capabilities,
+          then it shall support JWT authentication in this specification.</para>
       </section>
     </section>
     <section>


### PR DESCRIPTION
Ref: [Security Service Specification](https://onvif.org/specs/srv/security/ONVIF-Security-Service-Spec.pdf)
- SetJWTConfiguration and GetJWTConfiguration APIs are tied to JsonWebToken  capability
  - They deal with 'incoming JWT' and not the outgoing JWT as presented for uplink/webrtc/osr etc.,

Ref: [Uplink Specification](https://www.onvif.org/specs/srv/uplink/ONVIF-Uplink-Spec.pdf)
- When a device indicates **JsonWebToken** is supported through its Capabilities, then it shall support JWT authentication in this specification.
  - JWT authentication in uplink context is for an 'outgoing jwt' presented to remote server for validation and hence should not refer **JsonWebToken** capability.

The proposal addresses the issue in uplink specification.

