### PR TITLE
Fix missing requirement added under PR#481

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -1024,8 +1024,10 @@
                   <para>CertPathValidationPolicyID</para>
                 </entry>
                 <entry>
-                  <para>The unique identifier of the certification path validation policy to be
-                    used for validating the server certificate</para>
+                  <para>The unique identifier of the certification path validation policy to be used
+                    for validating the server certificate. If not configured, server certificate
+                    validation behavior is undefined and the device may either apply a vendor
+                    specific default validation policy or skip validation at all.</para>
                 </entry>
               </row>
             </tbody>


### PR DESCRIPTION
Ref: https://www.onvif.org/specs/srv/security/ONVIF-Security-Service-Spec.pdf
- Section 4.6.3 Authorization server configuration
  - Table 5 Authorization server settings
    - CertPathValidationPolicyID : The unique identifier of the certification path validation policy to be used for validating the server certificate

Fix missing requirement added under https://github.com/onvif/specs/pull/481