### PR TITLE
Clarify misuse of JWT in Uplink and WebRTC specs

### DIFF
--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -303,7 +303,7 @@
       </section>
       <section>
         <title>Access token authentication</title>
-        <para>Device signaling support for access token based authentication shall include <literal>AccessToken</literal> in the list of AuthorizationModes of GetServiceCapabilities response. Device shall signal value greater than 0 for MaxConfigurations in AuthorizationServer.GetServiceCapabilities response from the Security service.</para>
+        <para>Device signaling support for access token based authentication shall include <literal>AccessToken</literal> in the list of AuthorizationModes of GetServiceCapabilities response. Device shall signal value greater than 0 for AuthorizationServer.MaxConfigurations in GetServiceCapabilities response from the Security service.</para>
         <para>To authenticate with the remote client or service, the local service shall include the access token retrieved from the configured <literal>AuthorizationServer</literal> in the Authorization header when sending the upgrade request.</para>
         <para>The remote client shall validate the access token.</para>
       </section>

--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -303,7 +303,7 @@
       </section>
       <section>
         <title>Access token authentication</title>
-        <para>To signal that a device supports this authentication mechanism, it shall include <literal>JWT</literal> in the supported <literal>AuthorizationModes</literal> in the GetServiceCapabilities response. It shall also have a value greater than 0 in the <literal>MaxConfigurations</literal> under AuthorizationServer in the GetServiceCapabilities response from the Security service.</para>
+        <para>To signal that a device supports this authentication mechanism, it shall include <literal>AccessToken</literal> in the supported <literal>AuthorizationModes</literal> in the GetServiceCapabilities response. It shall also have a value greater than 0 in the <literal>MaxConfigurations</literal> under AuthorizationServer in the GetServiceCapabilities response from the Security service.</para>
         <para>For the local service to authenticate with the remote service, it shall include the access token retrieved from the configured <literal>AuthorizationServer</literal> in the <literal>Authorization</literal> header when sending the upgrade request.</para> 
         <para>The remote client shall validate the access token.</para>        
       </section>

--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -292,20 +292,20 @@
       <para>Note that for the following discussion the roles of client and server are swapped.</para>
       <para>The remote client shall authenticate itself using a valid server certificate. The local
         service shall verify the validity of the remote certificate according to RFC 6125.</para>
+      <para>The device shall assign any tunneled HTTP or RTSP request the UserLevel that is configured for the configuration without the need of further authentication request headers. </para>
       <section>
         <title>mTLS authentication</title>
+        <para>To signal that a device supports this authentication mechanism, it shall include <literal>mTLS</literal> in the supported <literal>AuthorizationModes</literal> in the GetServiceCapabilities response.</para>
         <para>When using mTLS authentication, the local service shall authenticate itself at the
           remote client using TLS client authentication according to RFC 5246 or subsequent
           specifications.</para>
         <para>To uniquely identify a local service on remote client, it is recommended to have a unique client certificate installed on each local service. For example, CN field or Serial number of installed certificate could be used to uniquely identify the local service.</para>
-        <para>The device shall assign any tunneled HTTP or RTSP request the UserLevel that is configured for the configuration without the need of further authentication request headers. </para>
       </section>
       <section>
-        <title>JWT authentication</title>
-        <para>When using JWT authentication, the local service shall provide a JWT token when sending the upgrade request.</para>
-        <para>The remote client shall validate the JWT token provided following the JWT specification as defined in the Core specification.</para>
-        <para>The device shall assign any tunneled HTTP or RTSP request the UserLevel that is configured for the configuration without the need of further authentication request headers.</para>
-        <para>When a device indicates JsonWebToken is supported through its Capabilities, then it shall support JWT authentication in this specification.</para>
+        <title>Access token authentication</title>
+        <para>To signal that a device supports this authentication mechanism, it shall include <literal>JWT</literal> in the supported <literal>AuthorizationModes</literal> in the GetServiceCapabilities response. It shall also have a value greater than 0 in the <literal>MaxConfigurations</literal> under AuthorizationServer in the GetServiceCapabilities response from the Security service.</para>
+        <para>For the local service to authenticate with the remote service, it shall include the access token retrieved from the configured <literal>AuthorizationServer</literal> in the <literal>Authorization</literal> header when sending the upgrade request.</para> 
+        <para>The remote client shall validate the access token.</para>        
       </section>
     </section>
     <section>
@@ -403,9 +403,9 @@
               <entry>AuthorizationServer</entry>
               <entry>
                 <para>AuthorizationServerConfiguration token referring to an authorization server
-                  that provides JWT token to authorize with the uplink server.</para>
+                  that provides an access token to authorize with the uplink server.</para>
                 <para>If the <literal>AuthorizationServer</literal> token is present in the
-                    <literal>UplinkConfiguration</literal> the device shall use JWT authentication
+                    <literal>UplinkConfiguration</literal> the device shall use access token authentication
                   mechanism.</para>
               </entry>
             </row>

--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -295,7 +295,7 @@
       <para>The device shall assign any tunneled HTTP or RTSP request the UserLevel that is configured for the configuration without the need of further authentication request headers. </para>
       <section>
         <title>mTLS authentication</title>
-        <para>To signal that a device supports this authentication mechanism, it shall include <literal>mTLS</literal> in the supported <literal>AuthorizationModes</literal> in the GetServiceCapabilities response.</para>
+        <para>Device signaling support for mTLS based authentication shall include <literal>mTLS</literal> in the list of <literal>AuthorizationModes</literal> of GetServiceCapabilities response.</para>
         <para>When using mTLS authentication, the local service shall authenticate itself at the
           remote client using TLS client authentication according to RFC 5246 or subsequent
           specifications.</para>
@@ -303,9 +303,9 @@
       </section>
       <section>
         <title>Access token authentication</title>
-        <para>To signal that a device supports this authentication mechanism, it shall include <literal>AccessToken</literal> in the supported <literal>AuthorizationModes</literal> in the GetServiceCapabilities response. It shall also have a value greater than 0 in the <literal>MaxConfigurations</literal> under AuthorizationServer in the GetServiceCapabilities response from the Security service.</para>
-        <para>For the local service to authenticate with the remote service, it shall include the access token retrieved from the configured <literal>AuthorizationServer</literal> in the <literal>Authorization</literal> header when sending the upgrade request.</para> 
-        <para>The remote client shall validate the access token.</para>        
+        <para>Device signaling support for access token based authentication shall include <literal>AccessToken</literal> in the list of AuthorizationModes of GetServiceCapabilities response. Device shall signal value greater than 0 for MaxConfigurations in AuthorizationServer.GetServiceCapabilities response from the Security service.</para>
+        <para>To authenticate with the remote client or service, the local service shall include the access token retrieved from the configured <literal>AuthorizationServer</literal> in the Authorization header when sending the upgrade request.</para>
+        <para>The remote client shall validate the access token.</para>
       </section>
     </section>
     <section>

--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -313,7 +313,7 @@
       <para>In case a connection is dropped the device shall reconnect automatically. Each client
         should use an individual ascending interval strategy to avoid that all clients reconnect at
         the same time.</para>
-      <para>Both a client and a device shall provide their access token using the Authorization header
+      <para>A client as well as a device shall provide their access token using the Authorization header
         or via query parameter on the WebSocket URI as defined by [RFC6750] Section 2.3.</para>
       <para>Once the WebSocket is open, both device and client shall immediately send a register command
         as specified in section <xref linkend="section_register"/> when they receive the HTTP 101 switching

--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -114,9 +114,6 @@
     <para>IETF RFC 8656 - Traversal Using Relays around NAT (TURN)</para>
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
         xlink:href="http://tools.ietf.org/html/rfc8856"/>&gt;</para>
-    <para>IETF RFC 7519 - JSON Web Token (JWT)</para>
-    <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
-      xlink:href="http://tools.ietf.org/html/rfc7519"/>&gt;</para>
     <para>IETF RFC 6749 - The OAuth 2.0 Authorization Framework</para>
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="http://tools.ietf.org/html/rfc6749"/>&gt;</para>
@@ -316,7 +313,7 @@
       <para>In case a connection is dropped the device shall reconnect automatically. Each client
         should use an individual ascending interval strategy to avoid that all clients reconnect at
         the same time.</para>
-      <para>Both a client and a device shall provide their JWT access token using the Authorization header
+      <para>Both a client and a device shall provide their access token using the Authorization header
         or via query parameter on the WebSocket URI as defined by [RFC6750] Section 2.3.</para>
       <para>Once the WebSocket is open, both device and client shall immediately send a register command
         as specified in section <xref linkend="section_register"/> when they receive the HTTP 101 switching
@@ -340,10 +337,6 @@
               </row>
             </thead>
             <tbody>
-              <row>
-                <entry><para>JWT</para></entry>
-                <entry><para>Encoded according to RFC 7519</para></entry>
-              </row>
               <row>
                 <entry><para>SDP</para></entry>
                 <entry><para>SDP according to RFC 8866 with \r\n escaping</para></entry>
@@ -374,7 +367,7 @@
         <varlistentry>
           <term>request</term>
           <listitem>
-            <para role="param">authorization [JWT]</para>
+            <para role="param">authorization [string]</para>
             <para role="text">Access token that authorizes the device or client.</para>
             <para role="param">id optional [string]</para>
             <para role="text">The unique ID of the device or client.</para>
@@ -393,7 +386,7 @@
             <term>faults</term>
             <listitem>
               <para role="param">401 Authorization failed</para>
-              <para role="text">The JWT token cannot be verified, does not include the required claims or has expired.</para>
+              <para role="text">The access token cannot be verified or has expired.</para>
             </listitem>
           </varlistentry>
       </variablelist>
@@ -408,7 +401,7 @@
           <listitem>
               <para role="param">peer optional [string]</para>
             <para role="text">The ID of the peer to connect to.</para>
-            <para role="param">authorization [JWT]</para>
+            <para role="param">authorization [string]</para>
             <para role="text">Access token that authorizes the device or client.</para>
             <para role="param">session optional [string]</para>
             <para role="text">The ID assigned by the signaling server to the session.</para>
@@ -431,7 +424,7 @@
           <term>faults</term>
           <listitem>
             <para role="param">401 Authorization failed</para>
-            <para role="text">The JWT token cannot be verified, does not include the required claims or has expired.</para>
+            <para role="text">The access token cannot be verified or has expired.</para>
               <para role="param">403 Forbidden</para>
               <para role="text">The client is not authorized to connect to the provided peer.</para>
             <para role="param">480 Temporary unavailable.</para>
@@ -621,13 +614,13 @@
       <para>The following example shows the flow using JSON-RPC 2.0. Note that for improved
           readability the mandatory JSON version string is not shown.</para>
       <programlisting><![CDATA[
-Client -> Server: { "method": "register", "params": {"authorization": "JWT..."}, "id":1}
+Client -> Server: { "method": "register", "params": {"authorization": "access token"}, "id":1}
 Server -> Client: { "result": { "id": "client-a1" }, "id": 1}
-Device -> Server: { "method": "register", "params": {"authorization": "JWT..."}, "id":1}
+Device -> Server: { "method": "register", "params": {"authorization": "access token"}, "id":1}
 Server -> Device: { "result": { "id": "device-b1" }, "id": 1}
 
 Client -> Server: { "method": "connect", 
-                "params": {"authorization": "JWT...", "peer": "device-b1"}, "id":2}
+                "params": {"authorization": "access token", "peer": "device-b1"}, "id":2}
 Server -> Device: { "method": "connect", 
                 "params": {"session": "s1", "iceServers": [{"urls": ["stun:1.2.3.4"]}], 
                 "id":2}

--- a/wsdl/ver10/uplink/wsdl/uplink.wsdl
+++ b/wsdl/ver10/uplink/wsdl/uplink.wsdl
@@ -40,7 +40,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:simpleType name="AuthorizationModes">
 				<xs:restriction base="xs:string">
 					<xs:enumeration value="mTLS"></xs:enumeration>	<!-- TLS with Client Certificate -->
-					<xs:enumeration value="JWT"></xs:enumeration>	<!-- JWT token -->
+					<xs:enumeration value="AccessToken"></xs:enumeration>	<!-- Access token obtained from AuthorizationServer -->
 				</xs:restriction>
 			</xs:simpleType>
 			<xs:complexType name="Capabilities">


### PR DESCRIPTION
Updated the Uplink and WebRTC specs to remove mention of JWT since it was mostly used incorrectly. Wording now refers to access tokens.