### PR TITLE
Add option to specify token type which should be used by the device for the authorization

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -936,6 +936,8 @@
         <para>Access to the device can be granted to users bearing either an ID Token or an Access
           Token, as long as the claims specified in <xref linkend="_Ref395181339"/> are
           present.</para>
+        <para>If the JWTs are requested by the device, is possible to specify with TokenType which 
+          of above tokens should be used for the authorization.</para>
         <para>Any request for ID tokens must include <emphasis>openid</emphasis> in the
             <emphasis>scope</emphasis> request parameter.</para>
       </section>
@@ -1026,6 +1028,15 @@
                 <entry>
                   <para>The unique identifier of the certification path validation policy to be
                     used for validating the server certificate</para>
+                </entry>
+              </row>
+              <row>
+                <entry>
+                  <para>TokenType</para>
+                </entry>
+                <entry>
+                  <para>Token type which should be used for authorization when multiple tokens 
+                    are returned by the authorization server</para>
                 </entry>
               </row>
             </tbody>

--- a/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
+++ b/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
@@ -990,9 +990,9 @@
 							<xs:documentation>The unique identifier of the certification path validation policy to be used for validating the server certificate.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="TokenType" type="tas:AuthorizationServerTokenType" minOccurs="0">
+					<xs:element name="TokenType" type="xs:string" minOccurs="0">
 						<xs:annotation>
-							<xs:documentation>Token type which should be used for authorization when multiple tokens are returned by the authorization server.</xs:documentation>
+							<xs:documentation>Token type which should be used for authorization when multiple tokens are returned by the authorization server, tas:AuthorizationServerTokenType lists the acceptable values</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	 <!-- first ONVIF then Vendor -->

--- a/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
+++ b/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
@@ -938,6 +938,21 @@
 				</xs:restriction>
 			</xs:simpleType>
 			<!--===============================-->
+			<xs:simpleType name="AuthorizationServerTokenType">
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="access_token">
+						<xs:annotation>
+							<xs:documentation>Access token</xs:documentation>
+						</xs:annotation>
+					</xs:enumeration>
+					<xs:enumeration value="id_token">
+						<xs:annotation>
+							<xs:documentation>ID token</xs:documentation>
+						</xs:annotation>
+					</xs:enumeration>
+				</xs:restriction>
+			</xs:simpleType>
+			<!--===============================-->
 			<xs:complexType name="AuthorizationServerConfigurationData">
 				<xs:sequence>
 					<xs:element name="ServerUri" type="xs:anyURI">
@@ -973,6 +988,11 @@
 					<xs:element name="CertPathValidationPolicyID" type="tas:CertPathValidationPolicyID" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The unique identifier of the certification path validation policy to be used for validating the server certificate.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="TokenType" type="tas:AuthorizationServerTokenType" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>Token type which should be used for authorization when multiple tokens are returned by the authorization server.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	 <!-- first ONVIF then Vendor -->


### PR DESCRIPTION
When the AuthorizationServerConfiguration and JWTConfiguration are setup to provide single sign on for the device web interface and the OIDC2AuthorizationCode flow is used, it is ambiguous whether the device should use ID tokens or access tokens. Both are possible and it may be a matter of preference depending on the specifics of the authorization server and its configuration. 
OIDC Core spec says that an ID token shall be always validated and access token may be optionally validated by the client. However current ONVIF spec accepts either access tokens or ID tokens for externally requested tokens, so it would also seem usable to allow usage of access tokens for some configurations instead of restricting SSO use only to ID tokens. 
This change adds optional AuthorizationServerConfiguration field to specify which token should be used in case of ambiguity, which is limited to OIDC2AuthorizationCode flow for tokens requested from the device. Some other proposals for the field name: _OidcTokenValidation_, _SsoTokenType_.