### PR TITLE
Segment Playback XML syntax fixes

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -2558,7 +2558,7 @@ secfrac = "." 1*6DIGIT</programlisting>
         specified time range. Multiple operations at the same time can be queued and processed sequentially. While the operation is being executed 
         the segments must not be deleted until they are uploaded (but the following ones can be). Segments should be uploaded in chronological order.
         Progression can be tracked with <literal>GetExportRecordedSegmentState</literal>. Operations can be cancelled at any time with <literal>StopExportRecordedSegments</literal>.
-        The segment names used shall follow <xref linkend="_refCloudRecordingSegmentObjects">Cloud Recording Segment Objects format</xref>, with <literal>counter</literal> starting 
+        The segment names used shall follow <xref linkend="_refCloudRecordingSegmentObjects"/>, with <literal>counter</literal> starting 
         at zero for the first segment of each export operation, unless the OmitSequenceNumber is set to True.
       </para>
       <para>

--- a/wsdl/ver10/recording.wsdl
+++ b/wsdl/ver10/recording.wsdl
@@ -693,7 +693,9 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 											<xs:documentation>As defined in RFC 6381 including section 3 Codecs.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
+									<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
 								</xs:sequence>
+								<xs:anyAttribute processContents="lax"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element name="HasMoreResults" type="xs:boolean" minOccurs="1">
@@ -772,6 +774,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					</xs:element>
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	 <!-- first Vendor then ONVIF -->
 				</xs:sequence>
+				<xs:anyAttribute processContents="lax"/>
 			</xs:complexType>
 			<xs:element name="StopExportRecordedSegments">
 				<xs:complexType>
@@ -1447,6 +1450,42 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		</wsdl:operation>
 		<wsdl:operation name="OverrideSegmentDuration">
 			<soap:operation soapAction="http://www.onvif.org/ver10/recording/wsdl/OverrideSegmentDuration"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="ListRecordedSegments">
+			<soap:operation soapAction="http://www.onvif.org/ver10/recording/wsdl/ListRecordedSegments"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="ExportRecordedSegments">
+			<soap:operation soapAction="http://www.onvif.org/ver10/recording/wsdl/ExportRecordedSegments"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="StopExportRecordedSegments">
+			<soap:operation soapAction="http://www.onvif.org/ver10/recording/wsdl/StopExportRecordedSegments"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="GetExportRecordedSegmentState">
+			<soap:operation soapAction="http://www.onvif.org/ver10/recording/wsdl/GetExportRecordedSegmentState"/>
 			<wsdl:input>
 				<soap:body use="literal"/>
 			</wsdl:input>

--- a/wsdl/ver10/recording.wsdl
+++ b/wsdl/ver10/recording.wsdl
@@ -695,13 +695,13 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 									</xs:element>
 									<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
 								</xs:sequence>
-								<xs:attribute name="Finished" type="xs:boolean">
-									<xs:annotation>
-										<xs:documentation>Indicator that the search has completed. Otherwise a new request needs to be sent to continue the search.</xs:documentation>
-									</xs:annotation>
-								</xs:attribute>
 								<xs:anyAttribute processContents="lax"/>
 							</xs:complexType>
+						</xs:element>
+						<xs:element name="HasMoreResults" type="xs:boolean" minOccurs="1">
+							<xs:annotation>
+								<xs:documentation>A value indicating that the search has reached the maximum count and a new request must be sent to continue the search.</xs:documentation>
+							</xs:annotation>
 						</xs:element>
 					</xs:sequence>
 				</xs:complexType>
@@ -787,12 +787,22 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="StopExportRecordedSegmentsResponse">
-				<xs:complexType>
-					<xs:sequence/>
-				</xs:complexType>
-			</xs:element>
+			<xs:element name="StopExportRecordedSegmentsResponse" />
 
+			<xs:complexType name="ExportRecordedSegmentStatus">
+				<xs:sequence>
+					<xs:element name="Segment" type="trc:UploadSegmentResult" minOccurs="0" maxOccurs="unbounded">
+						<xs:annotation>
+							<xs:documentation>Information about the segment(s) to be exported.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="HasMoreSegments" type="xs:boolean" minOccurs="1">
+						<xs:annotation>
+							<xs:documentation>A value indicating that the export has reached the maximum count and a new request must be sent to query the export state of further segments.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+				</xs:sequence>
+			</xs:complexType>
 			<xs:simpleType name="UploadStatus">
 				<xs:restriction base="xs:string">
 					<xs:enumeration value="Pending"/>
@@ -823,17 +833,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="GetExportRecordedSegmentStateResponse">
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element name="Segment" type="trc:UploadSegmentResult" minOccurs="0" maxOccurs="unbounded">
-							<xs:annotation>
-								<xs:documentation>Information about the segment(s) to be exported.</xs:documentation>
-							</xs:annotation>
-						</xs:element>
-					</xs:sequence>
-				</xs:complexType>
-			</xs:element>
+			<xs:element name="GetExportRecordedSegmentStateResponse" type="trc:ExportRecordedSegmentStatus" />
 
 			<!--===============================-->
 			<xs:complexType name="RecordingOptions">

--- a/wsdl/ver10/recording.wsdl
+++ b/wsdl/ver10/recording.wsdl
@@ -695,13 +695,13 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 									</xs:element>
 									<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
 								</xs:sequence>
+								<xs:attribute name="Finished" type="xs:boolean">
+									<xs:annotation>
+										<xs:documentation>Indicator that the search has completed. Otherwise a new request needs to be sent to continue the search.</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
 								<xs:anyAttribute processContents="lax"/>
 							</xs:complexType>
-						</xs:element>
-						<xs:element name="HasMoreResults" type="xs:boolean" minOccurs="1">
-							<xs:annotation>
-								<xs:documentation>A value indicating that the search has reached the maximum count and a new request must be sent to continue the search.</xs:documentation>
-							</xs:annotation>
 						</xs:element>
 					</xs:sequence>
 				</xs:complexType>
@@ -787,22 +787,12 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="StopExportRecordedSegmentsResponse" />
+			<xs:element name="StopExportRecordedSegmentsResponse">
+				<xs:complexType>
+					<xs:sequence/>
+				</xs:complexType>
+			</xs:element>
 
-			<xs:complexType name="ExportRecordedSegmentStatus">
-				<xs:sequence>
-					<xs:element name="Segment" type="trc:UploadSegmentResult" minOccurs="0" maxOccurs="unbounded">
-						<xs:annotation>
-							<xs:documentation>Information about the segment(s) to be exported.</xs:documentation>
-						</xs:annotation>
-					</xs:element>
-					<xs:element name="HasMoreSegments" type="xs:boolean" minOccurs="1">
-						<xs:annotation>
-							<xs:documentation>A value indicating that the export has reached the maximum count and a new request must be sent to query the export state of further segments.</xs:documentation>
-						</xs:annotation>
-					</xs:element>
-				</xs:sequence>
-			</xs:complexType>
 			<xs:simpleType name="UploadStatus">
 				<xs:restriction base="xs:string">
 					<xs:enumeration value="Pending"/>
@@ -833,7 +823,17 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="GetExportRecordedSegmentStateResponse" type="trc:ExportRecordedSegmentStatus" />
+			<xs:element name="GetExportRecordedSegmentStateResponse">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Segment" type="trc:UploadSegmentResult" minOccurs="0" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>Information about the segment(s) to be exported.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
 
 			<!--===============================-->
 			<xs:complexType name="RecordingOptions">


### PR DESCRIPTION
This PR includes small fixes syntactical fixes:
* xref must not have a body
* Only a single return value is allowed.
Proposal to change `HasMoreSegments` by `Finished` or `IsLast` member to avoid the second parameter.
* A method definition must contain a sequence in the response.
Otherwise Microsoft creates a weird stub.
* Add extension points.
* Add soap binding