### PR TITLE
add zoom translation space in FOV space

### DIFF
--- a/doc/PTZ.xml
+++ b/doc/PTZ.xml
@@ -2413,6 +2413,24 @@ tns1:PTZController/PTZPresets/Left
 </tt:RelativeZoomTranslationSpace>
 ]]></programlisting>
       </section>
+      <section xml:id="_Ref469303021">
+        <title>Zoom Translation space in FOV</title>
+        <para>The Relative Zoom Translation Space in FOV is introduced to simplify magnification with dome cameras in graphical user interfaces. When the user wants to modify the magnification of the current camera view, they draw an area centered in the middle of the current FOV, which defines the zoom factor.</para>
+        <para>The zoom factor is represented by the ratio between the width of the desired area (Ww) and the width of the display window used for the video stream (Sw) relative to the current field of view.</para>
+        <para>The relative zoom factor is calculated as <inlineequation><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mi>Z</mml:mi><mml:mi></mml:mi><mml:mo>=</mml:mo><mml:mn>1</mml:mn><mml:mo>/</mml:mo><mml:mi></mml:mi><mml:mo>(</mml:mo><mml:mfrac><mml:mrow><mml:mi>W</mml:mi><mml:mi>w</mml:mi></mml:mrow><mml:mrow><mml:mi>S</mml:mi><mml:mi>w</mml:mi></mml:mrow></mml:mfrac><mml:mo>)</mml:mo><mml:mi></mml:mi></mml:math></inlineequation></para>
+        <para>The Zoom Translation Space in FOV is defined as follows: <footnote xml:id="__FN17__"><para>The proposed minimum value in range for this relative zoom space is 0 to allow reducing the current zoom.</para></footnote></para>
+        <programlisting><![CDATA[<tt:RelativeZoomTranslationSpace>
+  <tt:SpaceURI>
+    http://www.onvif.org/ver10/tptz/ZoomSpaces/TranslationSpaceFOV
+    TranslationSpace
+  </tt:SpaceURI>
+  <tt:XRange>
+    <tt:Min>0</tt:Min>
+    <tt:Max>INF</tt:Max>
+  </tt:XRange>
+</tt:RelativeZoomTranslationSpace>
+]]></programlisting>
+      </section>
     </section>
     <section>
       <title>Continuous Velocity Spaces</title>


### PR DESCRIPTION
This PR adds to Annex A a new space titled "Zoom Translation space in FOV". That new zoom space explains the concept of relative zoom translation space in graphical user interfaces for ptz cameras in relation to it's current FOV. 