### PR TITLE
CertPathValidationPolicyID added to Dot1XConfiguration

### DIFF
--- a/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
+++ b/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
@@ -553,6 +553,11 @@
 			</xs:complexType>
 			<xs:complexType name="Dot1XStageExtension">
 				<xs:sequence>
+					<xs:element name="CertPathValidationPolicyID" type="tas:CertPathValidationPolicyID" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>The unique identifier of the certification path validation policy to be used for validating the authorization server certificate.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
 				</xs:sequence>
 			</xs:complexType>


### PR DESCRIPTION
There are 802.1X Port Based Authentication methods (e.g. PEAP and EAP-TLS) that require verification of the authorization server's certificate. However, there is no way to point CertPathValidationPolicyID in Dot1XConfiguration.

The goal of that PR is add CertPathValidationPolicyID to Dot1XConfiguration.
It has been added to Dot1XStageExtension as it looks like only one expandable place in Dot1XConfiguration.

