### PR TITLE
Add require statement for non-optional scene description attributes.

### DIFF
--- a/wsdl/ver10/schema/common.xsd
+++ b/wsdl/ver10/schema/common.xsd
@@ -163,14 +163,14 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	<!--  Event and Analytics Types    -->
 	<!--===============================-->
 	<xs:complexType name="Vector">
-		<xs:attribute name="x" type="xs:float"/>
-		<xs:attribute name="y" type="xs:float"/>
+		<xs:attribute name="x" type="xs:float" use="required"/>
+		<xs:attribute name="y" type="xs:float" use="required"/>
 	</xs:complexType>
 	<xs:complexType name="Rectangle">
-		<xs:attribute name="bottom" type="xs:float"/>
-		<xs:attribute name="top" type="xs:float"/>
-		<xs:attribute name="right" type="xs:float"/>
-		<xs:attribute name="left" type="xs:float"/>
+		<xs:attribute name="bottom" type="xs:float" use="required"/>
+		<xs:attribute name="top" type="xs:float" use="required"/>
+		<xs:attribute name="right" type="xs:float" use="required"/>
+		<xs:attribute name="left" type="xs:float" use="required"/>
 	</xs:complexType>
 	<xs:complexType name="Polygon">
 		<xs:sequence>


### PR DESCRIPTION
Both Vector and Rectangle with missing mandatory attributes are undefined.