### PR TITLE
Clarify the meaning of Peer and cleanup diagram

### DIFF
--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -397,7 +397,7 @@
           <term>request</term>
           <listitem>
             <para role="param">peer optional [string]</para>
-            <para role="text">The ID of the peer to connect to. This Id is defined outside of this specification and must be negociated out-of-band.</para>
+            <para role="text">The ID of the peer to connect to. This Id is defined outside of this specification and must be negotiated out-of-band.</para>
             <para role="param">authorization [JWT]</para>
             <para role="text">Access token that authorizes the device or client.</para>
             <para role="param">session optional [string]</para>

--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -72,7 +72,7 @@
       and devices to establish a peer-to-peer connection between a client and a device using a
       signaling server.</para>
     <para>Sending PTZ and other commands via WebRTC datachannels is outside of the scope of this 
-      version of the specifcation.</para>
+      version of the specification.</para>
   </chapter>
   <chapter xml:id="chapter_uxt_v12_v5b">
     <title>Normative references</title>
@@ -163,16 +163,6 @@
               <entry align="left">
                 <para>A server that manages the WebRTC connections between clients and
                   devices.</para>
-              </entry>
-            </row>
-            <row>
-              <entry align="left">
-                <para>
-                  <emphasis role="bold">Peer ID</emphasis>
-                </para>
-              </entry>
-              <entry>
-                <para>A peer's assigned ID provided by the signaling server.</para>
               </entry>
             </row>
             <row>
@@ -406,14 +396,14 @@
         <varlistentry>
           <term>request</term>
           <listitem>
-              <para role="param">peer optional [string]</para>
-            <para role="text">The ID of the peer to connect to.</para>
+            <para role="param">peer optional [string]</para>
+            <para role="text">The ID of the peer to connect to. This Id is defined outside of this specification and must be negociated out-of-band.</para>
             <para role="param">authorization [JWT]</para>
             <para role="text">Access token that authorizes the device or client.</para>
             <para role="param">session optional [string]</para>
             <para role="text">The ID assigned by the signaling server to the session.</para>
             <para role="param">profile optional [string]</para>
-              <para role="text">Optional token of the media streaming profile to use.</para>
+            <para role="text">Token of the media streaming profile to use.</para>
             <para role="param">iceServers optional unbounded [RTCIceServer]</para>
             <para role="text">List of STUN and TURN servers to be used. </para>
           </listitem>

--- a/doc/media/WebRTC/webrtc_signaling_flow.svg
+++ b/doc/media/WebRTC/webrtc_signaling_flow.svg
@@ -274,13 +274,13 @@
      font-weight="400"
      style="font-weight:400;font-size:339.592px;font-family:'Liberation Sans', sans-serif;stroke-width:27.2272"
      id="tspan130"><tspan
-       x="4665.918"
+       x="4005.918"
        y="3721.4338"
        class="TextPosition"
        id="tspan128"
        style="stroke-width:27.2272"><tspan
          style="fill:#000000;stroke:none;stroke-width:27.2272"
-         id="tspan126">register(JWT)</tspan></tspan></tspan></text>
+         id="tspan126">register(Authorization)</tspan></tspan></tspan></text>
 
 
     <path
@@ -310,7 +310,7 @@
        x="11297.766"
        style="stroke-width:27.2272"><tspan
          id="tspan194"
-         style="fill:#000000;stroke:none;stroke-width:27.2272">register(JWT, GUID, name)</tspan></tspan></tspan></text>
+         style="fill:#000000;stroke:none;stroke-width:27.2272">register(Authorization)</tspan></tspan></tspan></text>
 
 
 
@@ -338,10 +338,10 @@
        id="tspan232"
        class="TextPosition"
        y="5310.4731"
-       x="3905.5669"
+       x="3605.5669"
        style="stroke-width:27.2272"><tspan
          id="tspan230"
-         style="fill:#000000;stroke:none;stroke-width:27.2272">connect(JWT, Peer-ID)</tspan></tspan></tspan></text>
+         style="fill:#000000;stroke:none;stroke-width:27.2272">connect(Authorization, Peer)</tspan></tspan></tspan></text>
 
 
 
@@ -974,7 +974,7 @@
        y="3341.3225"
        x="12808.768"><tspan
          id="tspan246-9"
-         style="fill:#000000;stroke:none;stroke-width:27.2272">(GUID)</tspan></tspan></tspan></text>
+         style="fill:#000000;stroke:none;stroke-width:27.2272">(ID)</tspan></tspan></tspan></text>
 
 
 <path


### PR DESCRIPTION
As discussed in F2F, I've clarified the meaning of the Peer field, to properly specify that it is negociated out of band to the signaling protocol itself. As currently specified, the client must rely on an external system to discover the peer ids of whichever camera it wants to play.

I've also cleaned up the diagram a bit to remove some obsolete concepts and non mandatory fields.