### PR TITLE
fix capability typo RSAKeyLenghts

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -4460,7 +4460,8 @@
                   <para>If true, the list of supported password-based encryption algorithms as
                     indicated by the PasswordBasedEncryptionAlgorithms capability shall contain at
                     least the algorithm <phrase>pbeWithSHAAnd3-KeyTripleDES-CBC</phrase>.</para>
-                  <para>If true, at least one capability between EllipticCurves and RSAKeyLenghts shall be specified.</para>
+                  <para>If true, at least one capability between EllipticCurves and RSAKeyLengths
+                    shall be specified.</para>
                 </entry>
               </row>
               <row>
@@ -4525,7 +4526,8 @@
                   </itemizedlist>
                   <para>If true, MaximumNumberOfCertificates&gt;=2 and MaximumNumberOfCertificationPaths&gt;0 shall hold.</para>
                   <para>If true, MaximumNumberOfKeys&gt;=2 shall hold.</para>
-                  <para>If true and the capability RSAKeyLenghts is not empty the following condition shall be fulfilled:</para>
+                  <para>If true and the capability RSAKeyLengths is not empty the following
+                    condition shall be fulfilled:</para>
                   <itemizedlist>
                     <listitem>
                       <para>The capability RSAKeyPairGeneration shall be specified .</para>
@@ -4570,7 +4572,8 @@
                       <para>Key pair generation as signaled by the RSAKeyPairGeneration or ECCKeyPairGeneration capability or key pair upload as signaled by the PKCS8 capability or key pair upload as signaled by the PKCS12CertificateWithRSAPrivateKeyUpload capability</para>
                     </listitem>
                   </itemizedlist>
-                  <para>If true and the capability RSAKeyLenghts is not empty the following conditions shall be fulfilled:</para>
+                  <para>If true and the capability RSAKeyLengths is not empty the following
+                    conditions shall be fulfilled:</para>
                   <itemizedlist>
                     <listitem>
                       <para>The capability RSAKeyPairGeneration shall be specified .</para>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -4460,8 +4460,7 @@
                   <para>If true, the list of supported password-based encryption algorithms as
                     indicated by the PasswordBasedEncryptionAlgorithms capability shall contain at
                     least the algorithm <phrase>pbeWithSHAAnd3-KeyTripleDES-CBC</phrase>.</para>
-                  <para>If true, at least one capability between EllipticCurves and RSAKeyLengths
-                    shall be specified.</para>
+                  <para>If true, at least one capability between EllipticCurves and RSAKeyLengths shall be specified.</para>
                 </entry>
               </row>
               <row>
@@ -4526,8 +4525,7 @@
                   </itemizedlist>
                   <para>If true, MaximumNumberOfCertificates&gt;=2 and MaximumNumberOfCertificationPaths&gt;0 shall hold.</para>
                   <para>If true, MaximumNumberOfKeys&gt;=2 shall hold.</para>
-                  <para>If true and the capability RSAKeyLengths is not empty the following
-                    condition shall be fulfilled:</para>
+                  <para>If true and the capability RSAKeyLengths is not empty the following condition shall be fulfilled:</para>
                   <itemizedlist>
                     <listitem>
                       <para>The capability RSAKeyPairGeneration shall be specified .</para>
@@ -4572,8 +4570,7 @@
                       <para>Key pair generation as signaled by the RSAKeyPairGeneration or ECCKeyPairGeneration capability or key pair upload as signaled by the PKCS8 capability or key pair upload as signaled by the PKCS12CertificateWithRSAPrivateKeyUpload capability</para>
                     </listitem>
                   </itemizedlist>
-                  <para>If true and the capability RSAKeyLengths is not empty the following
-                    conditions shall be fulfilled:</para>
+                  <para>If true and the capability RSAKeyLengths is not empty the following conditions shall be fulfilled:</para>
                   <itemizedlist>
                     <listitem>
                       <para>The capability RSAKeyPairGeneration shall be specified .</para>


### PR DESCRIPTION
Ref: https://www.onvif.org/specs/srv/security/ONVIF-Security-Service-Spec.pdf
- This PR fixes the typo in capability name in the specification from **RSAKeyLenghts** to **RSAKeyLengths** as defined in https://www.onvif.org/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl