### PR TITLE
Adjust Belongings

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -2164,9 +2164,9 @@
                   </entry>
                 </row>
                 <row>
-                  <entry morerows="9">
-                    <para>Belonging</para>
-                  </entry>
+                  <entry morerows="8">
+                  <para>Belongings</para>
+                </entry>
                   <entry morerows="1">
                     <para>Bag</para>
                   </entry>
@@ -2177,7 +2177,7 @@
                     <para>xs:string</para>
                   </entry>
                   <entry>
-                    <para>bd:KnapsackCategory</para>
+                    <para>bd:BagCategory</para>
                   </entry>
                 </row>
                 <row>
@@ -2217,45 +2217,6 @@
                   </entry>
                 </row>
                 <row>
-                  <entry>
-                    <para>LiftSomething</para>
-                  </entry>
-                  <entry>
-                    <para>N/A</para>
-                  </entry>
-                  <entry>
-                    <para>xs:boolean</para>
-                  </entry>
-                  <entry>
-                    <para>N/A</para>
-                  </entry>
-                </row>
-                <row>
-                  <entry morerows="1">
-                    <para>Box</para>
-                  </entry>
-                  <entry>
-                    <para>Color</para>
-                  </entry>
-                  <entry>
-                    <para>tt:ColorDescriptor</para>
-                  </entry>
-                  <entry>
-                    <para>N/A</para>
-                  </entry>
-                </row>
-                <row>
-                  <entry>
-                    <para>Lug</para>
-                  </entry>
-                  <entry>
-                    <para>xs:boolean</para>
-                  </entry>
-                  <entry>
-                    <para>N/A</para>
-                  </entry>
-                </row>
-                <row>
                   <entry morerows="1">
                     <para>Cart</para>
                   </entry>
@@ -2281,17 +2242,39 @@
                   </entry>
                 </row>
                 <row>
+                  <entry morerows="2">
+                  <para>Weapon</para>
+                </entry>
                   <entry>
-                    <para>Weapon</para>
+                    <para>Category</para>
+                  </entry>
+                  <entry>
+                    <para>xs:string</para>
+                  </entry>
+                  <entry>
+                    <para>bd:WeaponCategory</para>
+                  </entry>
+                </row>
+                <row>
+                  <entry>
+                    <para>Color</para>
+                  </entry>
+                  <entry>
+                    <para>tt:ColorDescriptor</para>
                   </entry>
                   <entry>
                     <para>N/A</para>
                   </entry>
+                </row>
+                <row>
                   <entry>
-                    <para>xs:boolean</para>
+                    <para>Pose</para>
                   </entry>
                   <entry>
-                    <para>N/A</para>
+                    <para>xs:string</para>
+                  </entry>
+                  <entry>
+                    <para>bd:WeaponPose</para>
                   </entry>
                 </row>
                 <row>

--- a/wsdl/ver20/analytics/humanbody.xsd
+++ b/wsdl/ver20/analytics/humanbody.xsd
@@ -337,7 +337,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:element name="Pose" type="xs:string" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Describes how the weapon is helo. Acceptable values are defined in bd:WeaponPose.</xs:documentation> 
+					<xs:documentation>Describes how the weapon is held. Acceptable values are defined in bd:WeaponPose.</xs:documentation> 
 				</xs:annotation> 
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>

--- a/wsdl/ver20/analytics/humanbody.xsd
+++ b/wsdl/ver20/analytics/humanbody.xsd
@@ -225,18 +225,21 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		</xs:sequence>
 		<xs:anyAttribute processContents="lax"/> 
 	</xs:complexType>
-	<xs:simpleType name="KnapsackCategory">
+	<xs:simpleType name="BagCategory">
 		<xs:restriction base="xs:string">
-			<xs:enumeration value="SingleShoulderBag"/>
+			<xs:enumeration value="ShoulderBag"/>
 			<xs:enumeration value="Backpack"/>
-			<xs:enumeration value="Other"/>
+			<xs:enumeration value="ToteBag"/>
+			<xs:enumeration value="Briefcase"/>
+			<xs:enumeration value="SingleShoulderBag"/>		<!-- Deprecated, use ShoulderBag -->
+			<xs:enumeration value="Other"/>					<!-- Deprecated, better omit -->
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="Bag">
 		<xs:sequence>
 			<xs:element name="Category" type="xs:string" minOccurs="0">
 			<xs:annotation>
-				<xs:documentation>Describe the Category of the Bag, acceptable values are defined in bd:KnapsackCategory.</xs:documentation> 
+				<xs:documentation>Describe the Category of the Bag, acceptable values are defined in bd:BagCategory.</xs:documentation> 
 			</xs:annotation> 
 			</xs:element>
 			<xs:element name="Color" type="tt:ColorDescriptor" minOccurs="0">
@@ -285,7 +288,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:enumeration value="BabyCarriage"/>
 			<xs:enumeration value="TwoWheelVehicle"/>
 			<xs:enumeration value="Tricyle"/>
-			<xs:enumeration value="Other"/>
+			<xs:enumeration value="Other"/>					<!-- Deprecated, better omit -->
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="Cart">
@@ -304,7 +307,43 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		</xs:sequence>
 		<xs:anyAttribute processContents="lax"/> 
 	</xs:complexType>
-	<xs:complexType name="Belonging">
+	<xs:simpleType name="WeaponCategory">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Knife"/>
+			<xs:enumeration value="Rifle"/>
+			<xs:enumeration value="Pistol"/>
+			<xs:enumeration value="Revolver"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="WeaponPose">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="InHolster"/>
+			<xs:enumeration value="InHand"/>
+			<xs:enumeration value="Aiming"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="Weapon">
+		<xs:sequence>
+			<xs:element name="Category" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Describe the Category of the Weapon, acceptable values are defined in bd:WeaponCategory.</xs:documentation> 
+				</xs:annotation> 
+			</xs:element>
+			<xs:element name="Color" type="tt:ColorDescriptor" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Describe the Color of the Cart, acceptable values are defined in tt:ColorDescriptor.</xs:documentation> 
+				</xs:annotation> 
+			</xs:element>
+			<xs:element name="Pose" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Describes how the weapon is helo. Acceptable values are defined in bd:WeaponPose.</xs:documentation> 
+				</xs:annotation> 
+			</xs:element>
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:anyAttribute processContents="lax"/> 
+	</xs:complexType>
+	<xs:complexType name="Belonging">		<!-- Deprecated, see Belongings -->
 		<xs:sequence>
 			<xs:element name="Bag" type="bd:Bag" minOccurs="0"> 
 			<xs:annotation> 
@@ -335,6 +374,33 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:annotation> 
 				<xs:documentation>Describe if the body carries the Weapon.</xs:documentation> 
 			</xs:annotation> 
+			</xs:element>			
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:anyAttribute processContents="lax"/> 
+	</xs:complexType>
+
+	<xs:complexType name="Belongings">
+		<xs:sequence>
+			<xs:element name="Bag" type="bd:Bag" minOccurs="0" maxOccurs="unbounded"> 
+				<xs:annotation> 
+					<xs:documentation>Describes a bag the body is wearing.</xs:documentation> 
+				</xs:annotation> 
+			</xs:element>
+			<xs:element name="Umbrella" type="bd:Umbrella" minOccurs="0"> 
+				<xs:annotation> 
+					<xs:documentation>Describes an umbrella carried by the body.</xs:documentation> 
+				</xs:annotation> 
+			</xs:element> 
+			<xs:element name="Cart" type="bd:Cart" minOccurs="0"> 	
+				<xs:annotation> 
+					<xs:documentation>Describes a cart pushed by the body.</xs:documentation> 
+				</xs:annotation> 
+			</xs:element>
+			<xs:element name="Weapon" type="bd:Weapon" minOccurs="0" maxOccurs="unbounded"> 	
+				<xs:annotation> 
+					<xs:documentation>Describe a waepon the body carries.</xs:documentation> 
+				</xs:annotation> 
 			</xs:element>			
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
@@ -402,7 +468,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element> 			
 			<xs:element name="Belonging" type="bd:Belonging" minOccurs="0"> 
 			<xs:annotation> 
-				<xs:documentation>Describe the Belonging of the body.</xs:documentation> 
+				<xs:documentation>Deprecated set of belongings. Use Belongings.</xs:documentation> 
 			</xs:annotation> 
 			</xs:element> 		
 			<xs:element name="Behaviour" type="bd:Behaviour" minOccurs="0"> 
@@ -410,6 +476,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				<xs:documentation>Describe the Behaviour of the body.</xs:documentation> 
 			</xs:annotation> 
 			</xs:element> 
+			<xs:element name="Belongings" type="bd:Belongings" minOccurs="0"> 
+				<xs:annotation> 
+					<xs:documentation>Set of belongings.</xs:documentation> 
+				</xs:annotation> 
+			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- reserved for ONVIF -->
 		</xs:sequence>
 		<xs:anyAttribute processContents="lax"/> 

--- a/wsdl/ver20/analytics/humanbody.xsd
+++ b/wsdl/ver20/analytics/humanbody.xsd
@@ -231,6 +231,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:enumeration value="Backpack"/>
 			<xs:enumeration value="ToteBag"/>
 			<xs:enumeration value="Briefcase"/>
+			<xs:enumeration value="Suitcase"/>
 			<xs:enumeration value="SingleShoulderBag"/>		<!-- Deprecated, use ShoulderBag -->
 			<xs:enumeration value="Other"/>					<!-- Deprecated, better omit -->
 		</xs:restriction>
@@ -331,7 +332,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:element name="Color" type="tt:ColorDescriptor" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Describe the Color of the Cart, acceptable values are defined in tt:ColorDescriptor.</xs:documentation> 
+					<xs:documentation>Describe the Color of the weapon, acceptable values are defined in tt:ColorDescriptor.</xs:documentation> 
 				</xs:annotation> 
 			</xs:element>
 			<xs:element name="Pose" type="xs:string" minOccurs="0">


### PR DESCRIPTION
This PR is a followup of #552 to introduce a reworked version of Belonging called Belongings.

## Bag
* Body can now carry multiple bags. 
* The KnapsackType name has been adjusted to BagType (no effect on interoperability, just more clarity)
* Additional BagTypes have been added.

## Umbrella
unchanged
## LiftSomething
has been removed as this should reside in Behaviour
## Box
has been removed as the definition is unclear. Should be reinserted with better definition
## Cart
unchanged
## Weapon
* Added type bd:Weapon with standard field type and color.
* Added additional field Pose.
