### PR TITLE
schema validation issue for annotation block

### DIFF
--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -401,7 +401,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<!--===============================-->
 			<xs:simpleType name="HardwareTypes">
 				<xs:annotation>
-					All hardware types specified are related to network devices supporting ONVIF specification.
+					<xs:documentation>All hardware types specified are related to network devices supporting ONVIF specification.</xs:documentation>
 				</xs:annotation>
 				<xs:restriction base="xs:string">
 					<xs:enumeration value="Camera">


### PR DESCRIPTION
Ref: Device management wsdl 
- https://github.com/onvif/specs/blob/development/wsdl/ver10/device/wsdl/devicemgmt.wsdl#L402
  - Schema validation error  
    - "Element 'xs:annotation' cannot have character [children], because the type's content type is element-only."

This PR fixes the validation error.