### PR TITLE
Update MediaSigning.xml with additional timestamp

### DIFF
--- a/doc/MediaSigning.xml
+++ b/doc/MediaSigning.xml
@@ -914,7 +914,7 @@
         <itemizedlist>
           <listitem>
             <para>Tag version (1 byte)</para>
-            <para>Version = 1</para>
+            <para>Version = 1-2</para>
           </listitem>
           <listitem>
             <para>Specification version (3 byte)</para>
@@ -933,9 +933,18 @@
           </listitem>
           <listitem>
             <para>The UTC (8 bytes) based time represented by the number of 100-nanosecond intervals
-              since January 1, 1601 of the I-frame leading the GOP.</para>
-            <para>The timestamp value is a 64 bit parameter and the 8 bytes should be written with
+              since January 1, 1601 of the frame leading the (partial) GOP.</para>
+            <para>The start timestamp value is a 64 bit parameter and the 8 bytes should be written with
               little endian.</para>
+          </listitem>
+          <listitem>
+            <para>Only present from tag version 2.</para>
+            <para>The UTC (8 bytes) based time represented by the number of 100-nanosecond intervals
+              since January 1, 1601 of the frame leading the upcoming (partial) GOP.</para>
+            <para>The end timestamp value is a 64 bit parameter and the 8 bytes should be written with
+              little endian.</para>
+            <para>The duration of the signed (partial) GOP can now be calculated as duration =
+              "end timestamp" - "start timestamp". Note that the end timestamp is exclusive.</para>
           </listitem>
           <listitem>
             <para>GOP counter (4 bytes)</para>


### PR DESCRIPTION
To get a proper marked duration of a signed GOP two timestamps should be transmitted. Currently, only a start timestamp is added. This change will add an end timestamp. Even though it is technically possible to compute a duration after receiving 2 SEIs it will never be correctly marked.