### PR TITLE
clarify webrtc enable register trigger

### DIFF
--- a/doc/Media2.xml
+++ b/doc/Media2.xml
@@ -2147,7 +2147,7 @@
       </section>
       <section xml:id="section_wvd_dzg_ryb">
         <title>SetWebRTCConfigurations</title>
-        <para>The operation shall synchronise tr2:WebRTCConfiguration list with the one stored on
+        <para>This operation shall synchronise tr2:WebRTCConfiguration list with the one stored on
           device by creating new entries, updating existing ones, and deleting those omitted from
           the input. The operation shall be supported if the WebRTC capability is present. The
           device shall attempt to establish a connection to each signaling server where the

--- a/doc/Media2.xml
+++ b/doc/Media2.xml
@@ -2148,7 +2148,9 @@
       <section xml:id="section_wvd_dzg_ryb">
         <title>SetWebRTCConfigurations</title>
         <para>This operation sets the WebRTC configuration for the device. The operation shall be
-          supported if the WebRTC capability is present.</para>
+          supported if the WebRTC capability is present. The device shall attempt to establish a
+          connection to each signaling server where the <emphasis role="bold">Enabled</emphasis>
+          parameter is set to true in the associated tr2:WebRTCConfiguration.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>

--- a/doc/Media2.xml
+++ b/doc/Media2.xml
@@ -2150,7 +2150,8 @@
         <para>This operation sets the WebRTC configuration for the device. The operation shall be
           supported if the WebRTC capability is present. The device shall attempt to establish a
           connection to each signaling server where the <emphasis role="bold">Enabled</emphasis>
-          parameter is set to true in the associated tr2:WebRTCConfiguration.</para>
+          parameter is set to true in the associated tr2:WebRTCConfiguration. This operation shall
+          update the complete configuration set as specific configuration cannot be referenced. </para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>

--- a/doc/Media2.xml
+++ b/doc/Media2.xml
@@ -2147,11 +2147,12 @@
       </section>
       <section xml:id="section_wvd_dzg_ryb">
         <title>SetWebRTCConfigurations</title>
-        <para>This operation sets the WebRTC configuration for the device. The operation shall be
-          supported if the WebRTC capability is present. The device shall attempt to establish a
-          connection to each signaling server where the <emphasis role="bold">Enabled</emphasis>
-          parameter is set to true in the associated tr2:WebRTCConfiguration. This operation shall
-          update the complete configuration set as specific configuration cannot be referenced. </para>
+        <para>The operation shall synchronise tr2:WebRTCConfiguration list with the one stored on
+          device by creating new entries, updating existing ones, and deleting those omitted from
+          the input. The operation shall be supported if the WebRTC capability is present. The
+          device shall attempt to establish a connection to each signaling server where the
+            <emphasis role="bold">Enabled</emphasis> parameter is set to true in the associated
+          tr2:WebRTCConfiguration. </para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>


### PR DESCRIPTION
Ref: https://github.com/onvif/specs/issues/564

>What is the trigger for the device (acting webrtc client) to set up a websocket (+register) towards signaling server? Should we clarify with a requirement similar to what we had with Uplink?

The PR addresses the discussion and clarifies the webrtc register trigger for 'enabled' configurations.