### PR TITLE
WebRTC: clarify bandwidth adjustment

### DIFF
--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -648,11 +648,10 @@ Server -> Device: { "method": "trickle", "params": {"session": "s1", "candidate"
       client based on the available bandwidth or other limiting factors. For example, a specific
       profile for mobile clients, another one for high quality streaming, etc.</para>
       <para>Devices should estimate available uplink bandwidth and reduce stream
-       bitrate as needed to avoid packet loss. It may be achieved by switching the currently
-       streamed profile into a profile with a lower bitrate encoding. Devices are allowed to
-       switch only between profiles with the same video source and same video codec. Once there
-       is enough available bandwidth, devices should aim to switch back to the initially selected
-       profile.</para>
+        bitrate as needed to avoid packet loss. It may be achieved by selecting video stream 
+        from another profile with the same video source and the same video codec.
+        Once there is enough available bandwidth, devices should aim to switch back to the desired 
+        configuration.</para>
     </section>
     <section xml:id="section_xyt_v12_v5b">
       <title>Feedback mechanisms</title>


### PR DESCRIPTION
Clarifies WebRTC bandwidth adjustment. Bandwidth adjustment should not be switching between the profiles, as profiles include other things in addition to the video (like metadata configuration, audio, ptz, etc).
Suggested change is to explicitly mention adjustment of video stream only.