### PR TITLE
Related to Issue 557: clarify usage of type definitions

### DIFF
--- a/wsdl/ver10/schema/metadatastream.xsd
+++ b/wsdl/ver10/schema/metadatastream.xsd
@@ -216,7 +216,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	<xs:complexType name="ClassDescriptor">
 		<xs:sequence>
 			<xs:element name="ClassCandidate" type="tt:ClassCandidate" minOccurs="0" maxOccurs="unbounded"/> <!-- Deprecated -->
-			<xs:element name="Extension" type="tt:ClassDescriptorExtension" minOccurs="0"/>  <!-- Deprecated -->
+			<xs:element name="Extension" type="tt:ClassDescriptorExtension" minOccurs="0"/>  <!-- Deprecated --> 
 			<xs:element name="Type" type="tt:StringLikelihood" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>For well-defined values see tt:ObjectType. Other type definitions like tt:VehicleType may be applied as well.</xs:documentation>


### PR DESCRIPTION
Related to Issue 557: clarify usage of type definitions other than tt;ObjectType.
Restructure schema to ease reading of preferred and not deprecated types.

The schema changes constist of:
* Move first deprecated class definition into its own type to improve readability.
* Drop historical never used extension point.
The changes do not change any existing instance documents.