### PR TITLE
Related to Issue 557: clarify usage of class type definitions

### DIFF
--- a/wsdl/ver10/schema/metadatastream.xsd
+++ b/wsdl/ver10/schema/metadatastream.xsd
@@ -219,7 +219,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:element name="Extension" type="tt:ClassDescriptorExtension" minOccurs="0"/>  <!-- Deprecated --> 
 			<xs:element name="Type" type="tt:StringLikelihood" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>ONVIF recommends to use this 'Type' element instead of 'ClassCandidate' and 'Extension' above for new design. Acceptable values are defined in tt:ObjectType.</xs:documentation>
+					<xs:documentation>For well-defined values see tt:ObjectType. Other type definitions like tt:VehicleType may be applied as well.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- reserved for ONVIF -->

--- a/wsdl/ver10/schema/metadatastream.xsd
+++ b/wsdl/ver10/schema/metadatastream.xsd
@@ -215,16 +215,8 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	</xs:complexType>
 	<xs:complexType name="ClassDescriptor">
 		<xs:sequence>
-			<xs:element name="ClassCandidate" minOccurs="0" maxOccurs="unbounded">
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element name="Type" type="tt:ClassType"/>
-						<xs:element name="Likelihood" type="xs:float"/>
-						<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- reserved for ONVIF -->
-					</xs:sequence>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="Extension" type="tt:ClassDescriptorExtension" minOccurs="0"/>
+			<xs:element name="ClassCandidate" type="tt:ClassCandidate" minOccurs="0" maxOccurs="unbounded"/> <!-- Deprecated -->
+			<xs:element name="Extension" type="tt:ClassDescriptorExtension" minOccurs="0"/>  <!-- Deprecated --> 
 			<xs:element name="Type" type="tt:StringLikelihood" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>ONVIF recommends to use this 'Type' element instead of 'ClassCandidate' and 'Extension' above for new design. Acceptable values are defined in tt:ObjectType.</xs:documentation>
@@ -233,20 +225,19 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- reserved for ONVIF -->
 		</xs:sequence>
 	</xs:complexType>
-	<xs:complexType name="ClassDescriptorExtension">
+	<xs:complexType name="ClassCandidate"> <!-- Deprecated -->
+		<xs:sequence>
+			<xs:element name="Type" type="tt:ClassType"/>
+			<xs:element name="Likelihood" type="xs:float"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ClassDescriptorExtension"> <!-- Deprecated -->
 		<xs:sequence>
 			<xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="OtherTypes" type="tt:OtherType" maxOccurs="unbounded"/>
-			<xs:element name="Extension" type="tt:ClassDescriptorExtension2" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
-	<xs:complexType name="ClassDescriptorExtension2">
-		<xs:sequence>
-			<xs:any namespace="##targetNamespace" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-		</xs:sequence>
-		<xs:anyAttribute processContents="lax"/>
-	</xs:complexType>
-	<xs:complexType name="OtherType">
+	<xs:complexType name="OtherType"> <!-- Deprecated -->
 		<xs:sequence>
 			<xs:element name="Type" type="xs:string">
 				<xs:annotation>


### PR DESCRIPTION
Clarify that class types may use definitions beyond tt:ObjectType

Restructure schema to ease reading of preferred and not deprecated types.

The schema changes constist of:

* Move first deprecated class definition into its own type to improve readability.
* Drop historical never used extension point.
* The changes do not change any existing instance documents.