### PR TITLE
Require same ID for certificates and their associated key.

### DIFF
--- a/addon/tls-configuration.adoc
+++ b/addon/tls-configuration.adoc
@@ -159,7 +159,7 @@ This section provides common terms and definitions used in this specification.
 
 == Technical specification version requirement
 
-Implementation of ONVIF Network Interface Specifications, version 22.06 or later is required for conformance to TLS configuration add-on.
+Implementation of ONVIF Network Interface Specifications, version 25.12 or later is required for conformance to TLS configuration add-on.
 
 == Requirement levels
 
@@ -329,7 +329,7 @@ The TLSConfiguration is a set of interfaces needed to configure functionality re
 
 Device shall support the following Security Configuration Service capabilities:
 
-* *Device shall support key configuration as defined by the “RSAKeyPairGeneration” capability.*
+* *Device shall support key configuration as defined by the “KeyPairGeneration” capability.*
 * *Device shall support key generation status with both the “GetKeyStatus” function and with “tns1:Advancedsecurity/Keystore/KeyStatus” event notification.*
 * *Device shall support “MaximumNumberOfKeys” capability of at least 16 to allow flexibility in certificate configuration.*
 * *Device shall support certificate configuration as defined by each of the "SelfSignedCertificateCreationWithRSA" and the "PKCS10ExternalCertificationWithRSA" capabilities.*
@@ -340,7 +340,7 @@ Device shall support the following Security Configuration Service capabilities:
 
 ==== Client requirements
 
-* *Client shall be able to do key management using "CreateRSAKeyPair and DeleteKey " operations as described in the Security Service Specification.*
+* *Client shall be able to do key management using "CreateRSAKeyPair and CreateEccKeyPair" operations as described in the Security Service Specification.*
 * *Client shall be able to verify key status using "GetKeyStatus" service or subscribing to event tns1:Advancedsecurity/Keystore/KeyStatus as defined in the Security Service Specification.*
 * *Client shall be able to do certificate management using ", CreatePKCS10CSR, UploadCertificate, DeleteCertificate, CreateCertificationPath and DeleteCertificationPath " operations as described in the Security Service Specification.*
 * *Client shall be able to do* TLS Server Operations *using "ReplaceServerCertificateAssignment " operation as described in the Security Service Specification.*
@@ -356,13 +356,12 @@ Device shall support the following Security Configuration Service capabilities:
 | |CreateCertificationPath |Security |M
 | |CreatePKCS10CSR |Security |M
 | |CreateRSAKeyPair |Security |M
+| |CreateECCKeyPair |Security |M
 | |CreateSelfSignedCertificate |Security |M
 | |DeleteCertificate |Security |M
 | |DeleteCertificationPath |Security |M
-| |DeleteKey |Security |M
 | |GetAllCertificates |Security |M
 | |GetAllCertificationPaths |Security |M
-| |GetAllKeys |Security |M
 | |GetAssignedServerCertificates |Security |M
 | |GetCertificate |Security |M
 | |GetCertificationPath |Security |M
@@ -385,13 +384,12 @@ Device shall support the following Security Configuration Service capabilities:
 | |CreateCertificationPath |Security |M
 | |CreatePKCS10CSR |Security |M
 | |CreateRSAKeyPair |Security |M
+| |CreateECCKeyPair |Security |M
 | |CreateSelfSignedCertificate |Security |O
 | |DeleteCertificate |Security |M
 | |DeleteCertificationPath |Security |M
-| |DeleteKey |Security |M
 | |GetAllCertificates |Security |O
 | |GetAllCertificationPaths |Security |O
-| |GetAllKeys |Security |O
 | |GetAssignedServerCertificates |Security |O
 | |GetCertificate |Security |O
 | |GetCertificationPath |Security |O

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -1419,8 +1419,8 @@
           identified by certification path validation policy IDs, and IEEE 802.1X configurations
           shall be uniquely identified by IEEE 802.1X configuration IDs.</para>
         <para>It shall be noted that while IDs within a specific type shall be unique, no
-          requirement exists for the uniqueness of IDs across different types. For example, there
-          may be a key and a certificate in the keystore that share the same ID.</para>
+          requirement exists for the uniqueness of IDs across different types. Especially the
+          certificate and its associated key shall share the same ID.</para>
         <para>Devices may assign the ID of a deleted identified object to another, subsequently
           generated object. However, devices should avoid re-using IDs as long as possible to avoid
           race conditions on the client side.</para>
@@ -1484,8 +1484,10 @@
           operations:</para>
         <itemizedlist>
           <listitem>
-            <para>A key shall not be deleted if it is referenced by a certificate or a security
-              feature.</para>
+            <para>A certificate and its public key or keypair shall share the same ID.</para>
+          </listitem>
+          <listitem>
+            <para>Deleting a certificate implicitly deletes the associated keys.</para>
           </listitem>
           <listitem>
             <para>A certificate shall not be deleted if it is referenced by a certification path, a
@@ -2077,15 +2079,16 @@
           </section>
           <section xml:id="_Ref363540841">
             <title>DeleteKey</title>
-            <para>This operation deletes a key from the device’s keystore. An ONVIF conformant
-              device shall support this command.</para>
-            <para>Keys are uniquely identified using key IDs. If no key is stored under the
-              requested key ID in the keystore, a device shall produce an InvalidArgVal fault. If a
-              reference exists for the specified key, a device shall produce the corresponding fault
-              and shall not delete the key. If there is a key under the requested key ID stored in
-              the keystore and the key could not be deleted, a device shall produce a KeyDeletion
-              fault. If the key has the status <emphasis>generating</emphasis>, a device shall abort
-              the generation of the key and delete from the keystore all data generated for this
+            <para>This operation tries to delete a key from the device’s keystore. An ONVIF
+              conformant device shall support this command for backward compatibility reasons. For
+              backward compatibility with older clients a device shall not return a fault if the
+              requested key ID is not in the keystore because it may have been deleted together with
+              the certificate.ignore the command if the associated key was </para>
+            <para>If a reference exists for the specified key, a device may produce the
+              corresponding fault. If there is a key under the requested key ID stored in the
+              keystore and the key could not be deleted, a device shall produce a KeyDeletion fault.
+              If the key has the status <emphasis>generating</emphasis>, a device shall abort the
+              generation of the key and delete from the keystore all data generated for this
               key.</para>
             <para>After a key is successfully deleted, the device may assign its former ID to other
               keys.</para>
@@ -2110,7 +2113,7 @@
                   <para role="param">ter:Receiver - ter:Action - ter:KeyDeletionFailed</para>
                   <para role="text"> Deleting the key with the requested KeyID failed.</para>
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:KeyID</para>
-                  <para role="text"> No key is stored under the requested KeyID.</para>
+                  <para role="text">Deprectead: No key is stored under the requested KeyID.</para>
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:ReferenceExists</para>
                   <para role="text"> A reference exists for the object that is to be deleted.</para>
                 </listitem>
@@ -2263,9 +2266,9 @@
             <para>The generated certificate shall not contain a unique identifier as specified in
               RFC 5280, Sect. 4.1.2.8. The device shall not mark the generated certificate as
               trusted.</para>
-            <para>Certificates are uniquely identified using certificate IDs. If the command was
-              successful, the device generates a new ID for the generated certificate and returns
-              this ID.</para>
+            <para>The resulting certificate will  get the key ID assigned as certificate ID. If a
+              certificate already existed with this ID the device shall replace the existing
+              certificate.</para>
             <para>If the device does not have enough storage capacity for storing the certificate to
               be created, the maximum number of certificates reached fault shall be produced and no
               certificate shall be generated.</para>
@@ -2723,7 +2726,8 @@
               produced.</para>
             <para>The certificate shall be returned in DER encoding.</para>
             <para>It shall be noted that this command does not return the private key that is
-              associated with the public key in the certificate.</para>
+              associated with the public key in the certificate but only a boolean flag whether such
+              a key is present in the key store.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
@@ -2795,10 +2799,8 @@
           </section>
           <section>
             <title>DeleteCertificate</title>
-            <para>This operation deletes a certificate from the device’s keystore. An ONVIF
-              compliant device shall support this command.</para>
-            <para>The operation shall not delete the public key that is contained in the certificate
-              from the keystore.</para>
+            <para>This operation deletes a certificate and its associated key from the device’s
+              keystore. An ONVIF compliant device shall support this command.</para>
             <para>Certificates are uniquely identified using certificate IDs. If no certificate is
               stored under the requested certificate ID in the keystore, an InvalidArgVal fault is
               produced. If there is a certificate under the requested certificate ID stored in the
@@ -5125,15 +5127,6 @@
               </row>
               <row>
                 <entry>
-                  <para>NoPrivateKeySharing</para>
-                </entry>
-                <entry>
-                  <para>Indicates the device requires that each certificate with private key has its
-                    own unique key.</para>
-                </entry>
-              </row>
-              <row>
-                <entry>
                   <para>SetCertPath</para>
                 </entry>
                 <entry>
@@ -5469,15 +5462,6 @@
                       <para>UploadCertificateWithPrivateKeyInPKCS12</para>
                     </listitem>
                     <listitem>
-                      <para>GetCertificate</para>
-                    </listitem>
-                    <listitem>
-                      <para>GetAllCertificates</para>
-                    </listitem>
-                    <listitem>
-                      <para>DeleteCertificate</para>
-                    </listitem>
-                    <listitem>
                       <para>GetCertificationPath</para>
                     </listitem>
                     <listitem>
@@ -5509,15 +5493,6 @@
                       <para>Creating a CSR with the CreatePKCS10CSR command.</para>
                     </listitem>
                     <listitem>
-                      <para>GetCertificate</para>
-                    </listitem>
-                    <listitem>
-                      <para>GetAllCertificates</para>
-                    </listitem>
-                    <listitem>
-                      <para>DeleteCertificate</para>
-                    </listitem>
-                    <listitem>
                       <para>Uploading the certificate created for the CSR as well as the certificate
                         of the created certificate’s signer with the UploadCertificate
                         command.</para>
@@ -5535,15 +5510,6 @@
                   <itemizedlist>
                     <listitem>
                       <para>CreateSelfSignedCertificate</para>
-                    </listitem>
-                    <listitem>
-                      <para>GetCertificate</para>
-                    </listitem>
-                    <listitem>
-                      <para>GetAllCertificates</para>
-                    </listitem>
-                    <listitem>
-                      <para>DeleteCertificate</para>
                     </listitem>
                   </itemizedlist>
                   <para>If true, the following operations shall be supported:</para>

--- a/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
+++ b/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
@@ -434,6 +434,11 @@
 							<xs:documentation>The base64-encoded DER representation of the X.509 certificate.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
+					<xs:element name="HasPrivateKey" type="xs:boolean" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>The keystore has a matching private key.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
 					<xs:any minOccurs="0" maxOccurs="unbounded" namespace="##any" processContents="lax"/>   <!-- first ONVIF then Vendor -->
 				</xs:sequence>
 				<xs:anyAttribute processContents="lax"/>


### PR DESCRIPTION
This PR picks up part of Sriram's proposal to simplify key handling.

* GetAllKeys and DeleteKey have been remove from the Addon. They have been kept in the specification for backward compatibility reasons.
* HasPrivateKey boolean has been added to the certificate information.

Note that these changes have some impact on the DTT:
* Test cases not applicable for NoPrivatekeySharing need to be removed
* Negative test cases on key deletion need to be skipped.
* Additional test steps for consistent certificate and key ID may be added.