### PR TITLE
Include optional alias when exporting segments

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -6587,14 +6587,15 @@ onvif://www.onvif.org/name/ARV-453
         <programlisting><![CDATA[Topic: tns1:Monitoring/AsynchronousOperationStatus
 <tt:MessageDescription IsProperty="true">
   <tt:Source>
-    <tt:SimpleItemDescription Name=“Token" Type=“tt:ReferenceToken"/>
-    <tt:SimpleItemDescription Name=“OperationName" Type=“xs:string"/>
-    <tt:SimpleItemDescription Name=“ServiceName" Type=“xs:string“/>
+    <tt:SimpleItemDescription Name="Token" Type="tt:ReferenceToken"/>
+    <tt:SimpleItemDescription Name="OperationName" Type="xs:string"/>
+    <tt:SimpleItemDescription Name="ServiceName" Type="xs:string"/>
   </tt:Source>
   <tt:Data>
-    <tt:SimpleItemDescription Name=“Progress" Type="xs:float"/> <!– [0.0,1.0] -- >
-    <tt:ElementItemDescription Name=“FileProgressStatus" Type=“tt:ArrayOfFileProgress"/> <!– optional ->
-    <tt:ElementItemDescription Name=“Error" Type=“soapenv:Fault"/> <!– optional ->
+    <tt:SimpleItemDescription Name="Progress" Type="xs:float"/> <!– [0.0,1.0] -- >
+    <tt:ElementItemDescription Name="FileProgressStatus" Type="tt:ArrayOfFileProgress"/> <!– optional ->
+    <tt:ElementItemDescription Name="Error" Type="soapenv:Fault"/> <!– optional ->
+    <tt:ElementItemDescription Name="Alias" Type="xs:string"/> <!– optional ->
   </tt:Data>
 </tt:MessageDescription>
 ]]></programlisting>

--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -1745,15 +1745,18 @@ Change Request 2061, 2063, 2065, 2109</revremark>
       <para>Request an export of the selected time range from existing locally recorded data. As
         such an operation could take longer, this method immediately returns an operation token. The
         device shall emit events as defined in section 8.9.7 Asynchronous Operation Status of the
-        ONVIF Core specification. The Initialized event shall be emitted when returning the
-        operation token. Progress updates shall be sent to inform clients about the progress of the
+        ONVIF Core specification. The device shall include the Alias parameter in the event if provided in the request.
+        The Initialized event shall be emitted when returning the operation token.
+        Progress updates shall be sent to inform clients about the progress of the
         export. Finally a Deleted event shall be emitted to signal completion or aborting of the
         operation when e.g. StopExportRecordedSegments has been executed. A device signaling support 
         for SegmentExport shall support this function.</para>
-      <para>The StoragePath shall be the path as defined in the Object Storage annex appended to the
-        StorageUri from the StorageConfiguration. By default the segments are exported to the storage that is
-        configured for the recording. When the parameter StorageToken is provided this target will
-        be used.</para>
+      <para>An event shall be raised for each segment being uploaded to the Object Storage, which means the 
+        ArrayOfFileProgress shall have only a single element each time. The FileProgress element shall have the FileName 
+        element be the path as defined in the Object Storage annex appended to the
+        StorageUri from the StorageConfiguration.</para>
+      <para>By default the segments are exported to the storage that is configured for the recording. 
+        When the parameter StorageToken is provided this target will be used.</para>
       <para>Note that a client may subscribe to tns1:Monitoring/AsynchronousOperationStatus for
         enumeration and monitoring of active and queued exports.</para>
       <variablelist role="op">
@@ -1762,6 +1765,8 @@ Change Request 2061, 2063, 2065, 2109</revremark>
           <listitem>
             <para role="param">Time [tt:DateTimeRange]</para>
             <para role="param">RecordingToken [tt:RecordingReference]</para>
+            <para role="param">Alias - optional [xs:string]</para>
+            <para role="text">If provided, shall be included in the Monitoring/AsynchronousOperationStatus event.</para>
             <para role="param">StorageToken - optional [tt:ReferenceToken]</para>
             <para role="text">If provided, overrides the Target's storage configuration.</para>
             <para role="param">Track - optional [tt:TrackType]</para>

--- a/wsdl/ver10/recording.wsdl
+++ b/wsdl/ver10/recording.wsdl
@@ -731,6 +731,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 								<xs:documentation>The recording configuration token.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
+						<xs:element name="Alias" type="xs:string" minOccurs="0" maxOccurs="1">
+							<xs:annotation>
+								<xs:documentation>An optional alias that shall be included in the Monitoring/AsynchronousOperationStatus event.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
 						<xs:element name="StorageToken" type="tt:ReferenceToken" minOccurs="0" maxOccurs="1">
 							<xs:annotation>
 								<xs:documentation>If provided, overrides the Target's storage configuration.</xs:documentation>


### PR DESCRIPTION
This PR introduces changes discussed during the F2F in Naples, Italy.

The changes add a new Alias field which can be used by a client to provide a contextual field to more easily link export requests between different components of a cloud system.

Added clarification on how the event shall be used to provide feedback to clients.