### PR TITLE
Remove GetExportRecordedSegmentsState

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -1794,48 +1794,6 @@ Change Request 2061, 2063, 2065, 2109</revremark>
       </variablelist>
     </section>
     <section>
-      <title>GetExportRecordedSegmentState</title>
-      <para>Lists individual segments of an ongoing ExportRecordedSegments operation. A device
-        signaling support for SegmentExport shall support this function.</para>
-      <para>A device shall support retrieving information while an export is progressing or within
-        10 seconds after its regular completion.</para>
-      <variablelist role="op">
-        <varlistentry>
-          <term>request</term>
-          <listitem>
-            <para role="param">OperationToken [tt:ReferenceToken]</para>
-            <para role="param">StartTime [xs:dateTime]</para>
-            <para role="text">The start index for the segment results.</para>
-            <para role="param">MaxResults - optional [xs:int]</para>
-            <para role="text">The maximum number of segment results to be provided in the response.</para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term>response</term>
-          <listitem>
-            <para role="param">Segment - optional, unbounded [trc:UploadSegmentResult]</para>
-            <para role="param">HasMoreSegments [xs:boolean]</para>
-            <para role="text">A value indicating that the export has reached the maximum count and a new request must be sent to query the export state of further segments.</para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term>faults</term>
-          <listitem>
-            <para role="param">env:Sender - ter:InvalidArgVal - ter:NoOperation</para>
-            <para role="text">The referenced operation does not exist.</para>
-            <para role="param">env:Sender - ter:InvalidArgVal - ter:BadDuration</para>
-            <para role="text">The value of the time parameter is invalid.</para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term>access class</term>
-          <listitem>
-            <para role="access">READ_MEDIA</para>
-          </listitem>
-        </varlistentry>
-      </variablelist>
-    </section>
-    <section>
       <title>StopExportRecordedSegments</title>
       <para>Stops the selected ExportRecordedSegments operation. A device signaling support for
         SegmentExport shall support this function.</para>

--- a/wsdl/ver10/recording.wsdl
+++ b/wsdl/ver10/recording.wsdl
@@ -755,32 +755,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:complexType name="UploadSegmentResult">
-				<xs:sequence>
-					<xs:element name="StartTime" type="xs:dateTime">
-						<xs:annotation>
-							<xs:documentation>Same precision as defined in the Recording Control specification for segment objects.</xs:documentation>
-						</xs:annotation>
-					</xs:element>
-					<xs:element name="EndTime" type="xs:dateTime">
-						<xs:annotation>
-							<xs:documentation>Same precision as defined in the Recording Control specification for segment objects.</xs:documentation>
-						</xs:annotation>
-					</xs:element>
-					<xs:element name="MediaType" type="xs:string">
-						<xs:annotation>
-							<xs:documentation>As defined in RFC 6381 including section 3 Codecs.</xs:documentation>
-						</xs:annotation>
-					</xs:element>
-					<xs:element name="Status" type="trc:UploadStatus">
-						<xs:annotation>
-							<xs:documentation>See trc:UploadStatus for allowed values.</xs:documentation>
-						</xs:annotation>
-					</xs:element>
-					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	 <!-- first Vendor then ONVIF -->
-				</xs:sequence>
-				<xs:anyAttribute processContents="lax"/>
-			</xs:complexType>
+
 			<xs:element name="StopExportRecordedSegments">
 				<xs:complexType>
 					<xs:sequence>
@@ -795,58 +770,6 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:element name="StopExportRecordedSegmentsResponse">
 				<xs:complexType>
 					<xs:sequence/>
-				</xs:complexType>
-			</xs:element>
-
-			<xs:complexType name="ExportRecordedSegmentStatus">
-				<xs:sequence>
-					<xs:element name="Segment" type="trc:UploadSegmentResult" minOccurs="0" maxOccurs="unbounded">
-						<xs:annotation>
-							<xs:documentation>Information about the segment(s) to be exported.</xs:documentation>
-						</xs:annotation>
-					</xs:element>
-					<xs:element name="HasMoreResults" type="xs:boolean" minOccurs="1">
-						<xs:annotation>
-							<xs:documentation>A value indicating that the export has reached the maximum count and a new request must be sent to query the export state of further segments.</xs:documentation>
-						</xs:annotation>
-					</xs:element>
-				</xs:sequence>
-			</xs:complexType>
-			<xs:simpleType name="UploadStatus">
-				<xs:restriction base="xs:string">
-					<xs:enumeration value="Pending"/>
-					<xs:enumeration value="Completed"/>
-					<xs:enumeration value="Failed"/>
-					<xs:enumeration value="Exporting"/>
-				</xs:restriction>
-			</xs:simpleType>
-
-			<xs:element name="GetExportRecordedSegmentState">
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element name="OperationToken" type="tt:ReferenceToken">
-							<xs:annotation>
-								<xs:documentation>Unique ExportRecordedSegment operation token</xs:documentation>
-							</xs:annotation>
-						</xs:element>
-						<xs:element name="StartTime" type="xs:dateTime">
-							<xs:annotation>
-								<xs:documentation>The start index for the segment results.</xs:documentation>
-							</xs:annotation>
-						</xs:element>
-						<xs:element name="MaxResults" type="xs:int" minOccurs="0">
-							<xs:annotation>
-								<xs:documentation>The maximum number of segment results to be provided in the response.</xs:documentation>
-							</xs:annotation>
-						</xs:element>
-					</xs:sequence>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="GetExportRecordedSegmentStateResponse">
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element name="Results" type="trc:ExportRecordedSegmentStatus"/> 
-					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
 


### PR DESCRIPTION
This PR removes the GetExportRecordedSegmentState function from the proposal.

We want to remove the GetState since we have all the information through the events being sent by the device, so it is redundant and may cause memory issues if device has to keep details about all segments to be exported.