### PR TITLE
Simplify certificate key handling via AutoDeleteKey

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -20,24 +20,9 @@
       <holder>ONVIF™ All rights reserved.</holder>
     </copyright>
     <legalnotice>
-      <para>Recipients of this document may copy, distribute, publish, or display this document so
-        long as this copyright notice, license and disclaimer are retained with all copies of the
-        document. No license is granted to modify this document.</para>
-      <para>THIS DOCUMENT IS PROVIDED "AS IS," AND THE CORPORATION AND ITS MEMBERS AND THEIR
-        AFFILIATES, MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT
-        LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
-        NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THIS DOCUMENT ARE SUITABLE FOR ANY PURPOSE;
-        OR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY PATENTS, COPYRIGHTS,
-        TRADEMARKS OR OTHER RIGHTS.</para>
-      <para>IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FOR ANY
-        DIRECT, INDIRECT, SPECIAL, INCIDENTAL, PUNITIVE OR CONSEQUENTIAL DAMAGES, ARISING OUT OF OR
-        RELATING TO ANY USE OR DISTRIBUTION OF THIS DOCUMENT, WHETHER OR NOT (1) THE CORPORATION,
-        MEMBERS OR THEIR AFFILIATES HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES, OR (2)
-        SUCH DAMAGES WERE REASONABLY FORESEEABLE, AND ARISING OUT OF OR RELATING TO ANY USE OR
-        DISTRIBUTION OF THIS DOCUMENT.  THE FOREGOING DISCLAIMER AND LIMITATION ON LIABILITY DO NOT
-        APPLY TO, INVALIDATE, OR LIMIT REPRESENTATIONS AND WARRANTIES MADE BY THE MEMBERS AND THEIR
-        RESPECTIVE AFFILIATES TO THE CORPORATION AND OTHER MEMBERS IN CERTAIN WRITTEN POLICIES OF
-        THE CORPORATION.</para>
+      <para>Recipients of this document may copy, distribute, publish, or display this document so long as this copyright notice, license and disclaimer are retained with all copies of the document. No license is granted to modify this document.</para>
+      <para>THIS DOCUMENT IS PROVIDED "AS IS," AND THE CORPORATION AND ITS MEMBERS AND THEIR AFFILIATES, MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THIS DOCUMENT ARE SUITABLE FOR ANY PURPOSE; OR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.</para>
+      <para>IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, PUNITIVE OR CONSEQUENTIAL DAMAGES, ARISING OUT OF OR RELATING TO ANY USE OR DISTRIBUTION OF THIS DOCUMENT, WHETHER OR NOT (1) THE CORPORATION, MEMBERS OR THEIR AFFILIATES HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES, OR (2) SUCH DAMAGES WERE REASONABLY FORESEEABLE, AND ARISING OUT OF OR RELATING TO ANY USE OR DISTRIBUTION OF THIS DOCUMENT.  THE FOREGOING DISCLAIMER AND LIMITATION ON LIABILITY DO NOT APPLY TO, INVALIDATE, OR LIMIT REPRESENTATIONS AND WARRANTIES MADE BY THE MEMBERS AND THEIR RESPECTIVE AFFILIATES TO THE CORPORATION AND OTHER MEMBERS IN CERTAIN WRITTEN POLICIES OF THE CORPORATION.</para>
     </legalnotice>
     <revhistory>
       <revision>
@@ -65,8 +50,7 @@
         <author>
           <personname>Dirk Stegemann, Stefan Andersson</personname>
         </author>
-        <revremark>Change Request 1268, 1276, 1349, 1350, 1351, 1352, 1376, 1377, 1378, 1379, 1380,
-          1381, 1382, 1390</revremark>
+        <revremark>Change Request 1268, 1276, 1349, 1350, 1351, 1352, 1376, 1377, 1378, 1379, 1380, 1381, 1382, 1390</revremark>
       </revision>
       <revision>
         <revnumber>1.1</revnumber>
@@ -74,8 +58,7 @@
         <author>
           <personname>Dirk Stegemann</personname>
         </author>
-        <revremark>Change Request 1528, 1529, 1530, 1531, 1532, 1533, 1534, 1535, 1536, 1543,
-          1554</revremark>
+        <revremark>Change Request 1528, 1529, 1530, 1531, 1532, 1533, 1534, 1535, 1536, 1543, 1554</revremark>
       </revision>
       <revision>
         <revnumber>1.2</revnumber>
@@ -83,8 +66,7 @@
         <author>
           <personname>Dirk Stegemann</personname>
         </author>
-        <revremark>Change Request 1552, 1555, 1565, 1580, 1583, 1590, 1615, 1616, 1617, 1618, 1619.
-          Added certificate-based client authentication</revremark>
+        <revremark>Change Request 1552, 1555, 1565, 1580, 1583, 1590, 1615, 1616, 1617, 1618, 1619. Added certificate-based client authentication</revremark>
       </revision>
       <revision>
         <revnumber>1.3</revnumber>
@@ -132,8 +114,7 @@
         <author>
           <personname>Oksana Tyushkina, Rick Boer</personname>
         </author>
-        <revremark>Fix typo in commands names. Fix inconsistency in Security
-          NoMatchingPrivateKey</revremark>
+        <revremark>Fix typo in commands names. Fix inconsistency in Security NoMatchingPrivateKey</revremark>
       </revision>
       <revision>
         <revnumber>22.06</revnumber>
@@ -141,8 +122,7 @@
         <author>
           <personname>Hans Busch</personname>
         </author>
-        <revremark>Fix fault namespace prefix and remove requirement to accept missing MAC when
-          passphrase is present.</revremark>
+        <revremark>Fix fault namespace prefix and remove requirement to accept missing MAC when passphrase is present.</revremark>
       </revision>
       <revision>
         <revnumber>22.12</revnumber>
@@ -150,8 +130,7 @@
         <author>
           <personname>Hans Busch</personname>
         </author>
-        <revremark>Do not require to support multiple identical pathes. Remove CRL requirement on
-          client authentication.</revremark>
+        <revremark>Do not require to support multiple identical pathes. Remove CRL requirement on client authentication.</revremark>
       </revision>
       <revision>
         <revnumber>23.06</revnumber>
@@ -167,8 +146,7 @@
         <author>
           <personname>Ottavio Campana, Fredrik Svensson</personname>
         </author>
-        <revremark>Added support for ECC cryptography, JSON Web Tokens, Authorization Servers using
-          OAuth2 and OpenID Connect.</revremark>
+        <revremark>Added support for ECC cryptography, JSON Web Tokens, Authorization Servers using OAuth2 and OpenID Connect.</revremark>
       </revision>
       <revision>
         <revnumber>24.06</revnumber>
@@ -176,20 +154,15 @@
         <author>
           <personname>Sriram Bhetanabottla, Hans Busch</personname>
         </author>
-        <revremark>Improve readability of section on authorization server. Move JWT example to
-          annex.</revremark>
+        <revremark>Improve readability of section on authorization server. Move JWT example to annex.</revremark>
       </revision>
       <revision>
         <revnumber>24.12</revnumber>
         <date>Dec-2024</date>
         <author>
-          <personname>Fredrik Svensson, Sriram Bhetanabottla, Hans Busch, Jose Melancon, Sujith
-            Raman, Kieran McCartan</personname>
+          <personname>Fredrik Svensson, Sriram Bhetanabottla, Hans Busch, Jose Melancon, Sujith Raman, Kieran McCartan</personname>
         </author>
-        <revremark>Add media signing capabilities and operations. Clarify JWT and OAuth sections.
-          Add CertPathValidationPolicyId to AuthorizationServer &amp; StorageConfiguration.
-          Recommend strong signature selection. Update CreateEccKeyPair and Curve name references.
-          Add annex on TLS ciphers.</revremark>
+        <revremark>Add media signing capabilities and operations. Clarify JWT and OAuth sections.  Add CertPathValidationPolicyId to AuthorizationServer &amp; StorageConfiguration. Recommend strong signature selection. Update CreateEccKeyPair and Curve name references. Add annex on TLS ciphers.</revremark>
       </revision>
     </revhistory>
   </info>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -20,9 +20,24 @@
       <holder>ONVIF™ All rights reserved.</holder>
     </copyright>
     <legalnotice>
-      <para>Recipients of this document may copy, distribute, publish, or display this document so long as this copyright notice, license and disclaimer are retained with all copies of the document. No license is granted to modify this document.</para>
-      <para>THIS DOCUMENT IS PROVIDED "AS IS," AND THE CORPORATION AND ITS MEMBERS AND THEIR AFFILIATES, MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THIS DOCUMENT ARE SUITABLE FOR ANY PURPOSE; OR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.</para>
-      <para>IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, PUNITIVE OR CONSEQUENTIAL DAMAGES, ARISING OUT OF OR RELATING TO ANY USE OR DISTRIBUTION OF THIS DOCUMENT, WHETHER OR NOT (1) THE CORPORATION, MEMBERS OR THEIR AFFILIATES HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES, OR (2) SUCH DAMAGES WERE REASONABLY FORESEEABLE, AND ARISING OUT OF OR RELATING TO ANY USE OR DISTRIBUTION OF THIS DOCUMENT.  THE FOREGOING DISCLAIMER AND LIMITATION ON LIABILITY DO NOT APPLY TO, INVALIDATE, OR LIMIT REPRESENTATIONS AND WARRANTIES MADE BY THE MEMBERS AND THEIR RESPECTIVE AFFILIATES TO THE CORPORATION AND OTHER MEMBERS IN CERTAIN WRITTEN POLICIES OF THE CORPORATION.</para>
+      <para>Recipients of this document may copy, distribute, publish, or display this document so
+        long as this copyright notice, license and disclaimer are retained with all copies of the
+        document. No license is granted to modify this document.</para>
+      <para>THIS DOCUMENT IS PROVIDED "AS IS," AND THE CORPORATION AND ITS MEMBERS AND THEIR
+        AFFILIATES, MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+        LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+        NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THIS DOCUMENT ARE SUITABLE FOR ANY PURPOSE;
+        OR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY PATENTS, COPYRIGHTS,
+        TRADEMARKS OR OTHER RIGHTS.</para>
+      <para>IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FOR ANY
+        DIRECT, INDIRECT, SPECIAL, INCIDENTAL, PUNITIVE OR CONSEQUENTIAL DAMAGES, ARISING OUT OF OR
+        RELATING TO ANY USE OR DISTRIBUTION OF THIS DOCUMENT, WHETHER OR NOT (1) THE CORPORATION,
+        MEMBERS OR THEIR AFFILIATES HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES, OR (2)
+        SUCH DAMAGES WERE REASONABLY FORESEEABLE, AND ARISING OUT OF OR RELATING TO ANY USE OR
+        DISTRIBUTION OF THIS DOCUMENT.  THE FOREGOING DISCLAIMER AND LIMITATION ON LIABILITY DO NOT
+        APPLY TO, INVALIDATE, OR LIMIT REPRESENTATIONS AND WARRANTIES MADE BY THE MEMBERS AND THEIR
+        RESPECTIVE AFFILIATES TO THE CORPORATION AND OTHER MEMBERS IN CERTAIN WRITTEN POLICIES OF
+        THE CORPORATION.</para>
     </legalnotice>
     <revhistory>
       <revision>
@@ -50,7 +65,8 @@
         <author>
           <personname>Dirk Stegemann, Stefan Andersson</personname>
         </author>
-        <revremark>Change Request 1268, 1276, 1349, 1350, 1351, 1352, 1376, 1377, 1378, 1379, 1380, 1381, 1382, 1390</revremark>
+        <revremark>Change Request 1268, 1276, 1349, 1350, 1351, 1352, 1376, 1377, 1378, 1379, 1380,
+          1381, 1382, 1390</revremark>
       </revision>
       <revision>
         <revnumber>1.1</revnumber>
@@ -58,7 +74,8 @@
         <author>
           <personname>Dirk Stegemann</personname>
         </author>
-        <revremark>Change Request 1528, 1529, 1530, 1531, 1532, 1533, 1534, 1535, 1536, 1543, 1554</revremark>
+        <revremark>Change Request 1528, 1529, 1530, 1531, 1532, 1533, 1534, 1535, 1536, 1543,
+          1554</revremark>
       </revision>
       <revision>
         <revnumber>1.2</revnumber>
@@ -66,7 +83,8 @@
         <author>
           <personname>Dirk Stegemann</personname>
         </author>
-        <revremark>Change Request 1552, 1555, 1565, 1580, 1583, 1590, 1615, 1616, 1617, 1618, 1619. Added certificate-based client authentication</revremark>
+        <revremark>Change Request 1552, 1555, 1565, 1580, 1583, 1590, 1615, 1616, 1617, 1618, 1619.
+          Added certificate-based client authentication</revremark>
       </revision>
       <revision>
         <revnumber>1.3</revnumber>
@@ -114,7 +132,8 @@
         <author>
           <personname>Oksana Tyushkina, Rick Boer</personname>
         </author>
-        <revremark>Fix typo in commands names. Fix inconsistency in Security NoMatchingPrivateKey</revremark>
+        <revremark>Fix typo in commands names. Fix inconsistency in Security
+          NoMatchingPrivateKey</revremark>
       </revision>
       <revision>
         <revnumber>22.06</revnumber>
@@ -122,7 +141,8 @@
         <author>
           <personname>Hans Busch</personname>
         </author>
-        <revremark>Fix fault namespace prefix and remove requirement to accept missing MAC when passphrase is present.</revremark>
+        <revremark>Fix fault namespace prefix and remove requirement to accept missing MAC when
+          passphrase is present.</revremark>
       </revision>
       <revision>
         <revnumber>22.12</revnumber>
@@ -130,7 +150,8 @@
         <author>
           <personname>Hans Busch</personname>
         </author>
-        <revremark>Do not require to support multiple identical pathes. Remove CRL requirement on client authentication.</revremark>
+        <revremark>Do not require to support multiple identical pathes. Remove CRL requirement on
+          client authentication.</revremark>
       </revision>
       <revision>
         <revnumber>23.06</revnumber>
@@ -146,7 +167,8 @@
         <author>
           <personname>Ottavio Campana, Fredrik Svensson</personname>
         </author>
-        <revremark>Added support for ECC cryptography, JSON Web Tokens, Authorization Servers using OAuth2 and OpenID Connect.</revremark>
+        <revremark>Added support for ECC cryptography, JSON Web Tokens, Authorization Servers using
+          OAuth2 and OpenID Connect.</revremark>
       </revision>
       <revision>
         <revnumber>24.06</revnumber>
@@ -154,85 +176,156 @@
         <author>
           <personname>Sriram Bhetanabottla, Hans Busch</personname>
         </author>
-        <revremark>Improve readability of section on authorization server. Move JWT example to annex.</revremark>
+        <revremark>Improve readability of section on authorization server. Move JWT example to
+          annex.</revremark>
       </revision>
       <revision>
         <revnumber>24.12</revnumber>
         <date>Dec-2024</date>
         <author>
-          <personname>Fredrik Svensson, Sriram Bhetanabottla, Hans Busch, Jose Melancon, Sujith Raman, Kieran McCartan</personname>
+          <personname>Fredrik Svensson, Sriram Bhetanabottla, Hans Busch, Jose Melancon, Sujith
+            Raman, Kieran McCartan</personname>
         </author>
-        <revremark>Add media signing capabilities and operations. Clarify JWT and OAuth sections.  Add CertPathValidationPolicyId to AuthorizationServer &amp; StorageConfiguration. Recommend strong signature selection. Update CreateEccKeyPair and Curve name references. Add annex on TLS ciphers.</revremark>
+        <revremark>Add media signing capabilities and operations. Clarify JWT and OAuth sections.
+          Add CertPathValidationPolicyId to AuthorizationServer &amp; StorageConfiguration.
+          Recommend strong signature selection. Update CreateEccKeyPair and Curve name references.
+          Add annex on TLS ciphers.</revremark>
       </revision>
     </revhistory>
   </info>
   <chapter>
     <title>Scope</title>
-    <para>This document defines the web service interface for ONVIF security configuration features such as a keystore and a TLS server on an ONVIF device.</para>
-    <para>Web service usage is outside of the scope of this document. Please refer to the ONVIF core specification.</para>
+    <para>This document defines the web service interface for ONVIF security configuration features
+      such as a keystore and a TLS server on an ONVIF device.</para>
+    <para>Web service usage is outside of the scope of this document. Please refer to the ONVIF core
+      specification.</para>
   </chapter>
   <chapter xml:id="chapter_sqp_r1s_jwb">
     <title>Normative References</title>
-    <para>Basic Security Profile Version 1.1 Committee Specification 01, OASIS Standard, 22 October 2004</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://docs.oasis-open.org/ws-brsp/BasicSecurityProfile/v1.1/cs01/BasicSecurityProfile-v1.1-cs01.pdf">https://docs.oasis-open.org/ws-brsp/BasicSecurityProfile/v1.1/cs01/BasicSecurityProfile-v1.1-cs01.pdf</link>&gt;</para>
+    <para>Basic Security Profile Version 1.1 Committee Specification 01, OASIS Standard, 22 October
+      2004</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="https://docs.oasis-open.org/ws-brsp/BasicSecurityProfile/v1.1/cs01/BasicSecurityProfile-v1.1-cs01.pdf"
+        >https://docs.oasis-open.org/ws-brsp/BasicSecurityProfile/v1.1/cs01/BasicSecurityProfile-v1.1-cs01.pdf</link>&gt;</para>
     <para>IANA TLS Supported Groups, Elliptic curve groups</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8"/>&gt;</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8"
+      />&gt;</para>
     <para>IEEE 802.1X, Port-Based Network Access Control</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://standards.ieee.org/getieee802/download/802.1X-2004.pdf">http://standards.ieee.org/getieee802/download/802.1X-2004.pdf</link>&gt;</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://standards.ieee.org/getieee802/download/802.1X-2004.pdf"
+        >http://standards.ieee.org/getieee802/download/802.1X-2004.pdf</link>&gt;</para>
     <para>ONVIF Core Specification</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.onvif.org/specs/core/ONVIF-Core-Specification.pdf">http://www.onvif.org/specs/core/ONVIF-Core-Specification.pdf</link>&gt;</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.onvif.org/specs/core/ONVIF-Core-Specification.pdf"
+        >http://www.onvif.org/specs/core/ONVIF-Core-Specification.pdf</link>&gt;</para>
     <para>ONVIF Media Signing Specification</para>
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
         xlink:href="http://www.onvif.org/specs/core/ONVIF-Core-Specification.pdf"
         >http://www.onvif.org/specs/stream/ONVIF-MediaSigning-Specification.pdf</link>&gt;</para>
     <para>IETF RFC 2246 The TLS Protocol Version 1.0</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc2246.txt">http://www.ietf.org/rfc/rfc2246.txt</link>&gt;</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc2246.txt"
+      >http://www.ietf.org/rfc/rfc2246.txt</link>&gt;</para>
     <para>IETF RFC 2898 PKCS#5 Password-based Cryptography Specification v2.0</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc2898.txt">http://www.ietf.org/rfc/rfc2898.txt</link>&gt;</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc2898.txt"
+      >http://www.ietf.org/rfc/rfc2898.txt</link>&gt;</para>
     <para>IETF RFC 2986 PKCS #10: Certification RequestSyntaxSpecification Version 1.7</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc2986.txt">http://www.ietf.org/rfc/rfc2986.txt</link>&gt;</para>
-    <para>IETF RFC 3279 Algorithms and Identifiers for the Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc3279.txt">http://www.ietf.org/rfc/rfc3279.txt</link>&gt;</para>
-    <para>IETF RFC 3447 Public Key Cryptography Standards #1: RSA Cryptography Specifications Version 2.1</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc3447.txt">http://www.ietf.org/rfc/rfc3447.txt</link>&gt;</para>
-    <para>IETF RFC 4055 Additional Algorithms and Identifiers for RSA Cryptography for use in the Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc4055.txt">http://www.ietf.org/rfc/rfc4055.txt</link>&gt;</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc2986.txt"
+      >http://www.ietf.org/rfc/rfc2986.txt</link>&gt;</para>
+    <para>IETF RFC 3279 Algorithms and Identifiers for the Internet X.509 Public Key Infrastructure
+      Certificate and Certificate Revocation List (CRL) Profile</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc3279.txt"
+      >http://www.ietf.org/rfc/rfc3279.txt</link>&gt;</para>
+    <para>IETF RFC 3447 Public Key Cryptography Standards #1: RSA Cryptography Specifications
+      Version 2.1</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc3447.txt"
+      >http://www.ietf.org/rfc/rfc3447.txt</link>&gt;</para>
+    <para>IETF RFC 4055 Additional Algorithms and Identifiers for RSA Cryptography for use in the
+      Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL)
+      Profile</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc4055.txt"
+      >http://www.ietf.org/rfc/rfc4055.txt</link>&gt;</para>
     <para>IETF RFC 4346 The Transport Layer Security (TLS) Protocol Version 1.1</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc4346.txt">http://www.ietf.org/rfc/rfc4346.txt</link>&gt;</para>
-    <para>IETF RFC 5208 Public-Key Cryptography Standards (PKCS) #8: Private-Key Information Syntax Specification v1.2</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc5208.txt">http://www.ietf.org/rfc/rfc5208.txt</link>&gt;</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc4346.txt"
+      >http://www.ietf.org/rfc/rfc4346.txt</link>&gt;</para>
+    <para>IETF RFC 5208 Public-Key Cryptography Standards (PKCS) #8: Private-Key Information Syntax
+      Specification v1.2</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc5208.txt"
+      >http://www.ietf.org/rfc/rfc5208.txt</link>&gt;</para>
     <para>IETF RFC 5246 The Transport Layer Security (TLS) Protocol Version 1.2</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc5246.txt">http://www.ietf.org/rfc/rfc5246.txt</link>&gt;</para>
-    <para>IETF RFC 8422 Elliptic Curve Cryptography (ECC) Cipher Suites for Transport Layer Security (TLS) Versions 1.2 and Earlier</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.ietf.org/rfc/rfc8422.txt">https://www.ietf.org/rfc/rfc8422.txt</link>&gt;</para>
-    <para>IETF RFC 5280 Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc5280.txt">http://www.ietf.org/rfc/rfc5280.txt</link>&gt;</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc5246.txt"
+      >http://www.ietf.org/rfc/rfc5246.txt</link>&gt;</para>
+    <para>IETF RFC 8422 Elliptic Curve Cryptography (ECC) Cipher Suites for Transport Layer Security
+      (TLS) Versions 1.2 and Earlier</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="https://www.ietf.org/rfc/rfc8422.txt"
+        >https://www.ietf.org/rfc/rfc8422.txt</link>&gt;</para>
+    <para>IETF RFC 5280 Internet X.509 Public Key Infrastructure Certificate and Certificate
+      Revocation List (CRL) Profile</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc5280.txt"
+      >http://www.ietf.org/rfc/rfc5280.txt</link>&gt;</para>
     <para>IETF RFC 5958 Asymmetric Key Packages</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc5958.txt">http://www.ietf.org/rfc/rfc5958.txt</link>&gt;</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc5958.txt"
+      >http://www.ietf.org/rfc/rfc5958.txt</link>&gt;</para>
     <para>IETF RFC 5959 Algorithms for Asymmetric Key Package Content Type</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc5959.txt">http://www.ietf.org/rfc/rfc5959.txt</link>&gt;</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc5959.txt"
+      >http://www.ietf.org/rfc/rfc5959.txt</link>&gt;</para>
     <para>IETF RFC 6749 The OAuth 2.0 Authorization Framework</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc6749.txt">http://www.ietf.org/rfc/rfc6749.txt</link>&gt;</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc6749.txt"
+      >http://www.ietf.org/rfc/rfc6749.txt</link>&gt;</para>
     <para>IETF RFC 6750 The OAuth 2.0 Authorization Framework: Bearer Token Usage</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc6750.txt">http://www.ietf.org/rfc/rfc6750.txt</link>&gt;</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc6750.txt"
+      >http://www.ietf.org/rfc/rfc6750.txt</link>&gt;</para>
     <para>IETF RFC 7517 JSON Web Key (JWK)</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc7517.txt">http://www.ietf.org/rfc/rfc7517.txt</link>&gt;</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc7517.txt"
+      >http://www.ietf.org/rfc/rfc7517.txt</link>&gt;</para>
     <para>IETF RFC 7518 JSON Web Algorithms (JWA)</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc7518.txt">http://www.ietf.org/rfc/rfc7518.txt</link>&gt;</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc7518.txt"
+      >http://www.ietf.org/rfc/rfc7518.txt</link>&gt;</para>
     <para>IETF RFC 7519 JSON Web Token (JWT)</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc7519.txt">http://www.ietf.org/rfc/rfc7519.txt</link>&gt;</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc7519.txt"
+      >http://www.ietf.org/rfc/rfc7519.txt</link>&gt;</para>
     <para>IETF RFC 7643 System for Cross-domain Identity Management: Core Schema</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc7643.txt">http://www.ietf.org/rfc/rfc7643.txt</link>&gt;</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc7643.txt"
+      >http://www.ietf.org/rfc/rfc7643.txt</link>&gt;</para>
     <para>IETF RFC 8414 OAuth 2.0 Authorization Server Metadata</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc8414.txt">http://www.ietf.org/rfc/rfc8414.txt</link>&gt;</para>
-    <para>IETF RFC 8705 OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc8705.txt">http://www.ietf.org/rfc/rfc8705.txt</link>&gt;</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc8414.txt"
+      >http://www.ietf.org/rfc/rfc8414.txt</link>&gt;</para>
+    <para>IETF RFC 8705 OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access
+      Tokens</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc8705.txt"
+      >http://www.ietf.org/rfc/rfc8705.txt</link>&gt;</para>
     <para>Unified Modeling Language (UML) </para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.omg.org/spec/UML">http://www.omg.org/spec/UML</link>&gt;</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.omg.org/spec/UML">http://www.omg.org/spec/UML</link>&gt;</para>
     <para>OpenID Connect Core</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://openid.net/specs/openid-connect-core-1_0.html">https://openid.net/specs/openid-connect-core-1_0.html</link>&gt;</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="https://openid.net/specs/openid-connect-core-1_0.html"
+        >https://openid.net/specs/openid-connect-core-1_0.html</link>&gt;</para>
     <para>OpenID Connect Discovery</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://openid.net/specs/openid-connect-discovery-1_0.html">https://openid.net/specs/openid-connect-discovery-1_0.html</link>&gt;</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="https://openid.net/specs/openid-connect-discovery-1_0.html"
+        >https://openid.net/specs/openid-connect-discovery-1_0.html</link>&gt;</para>
     <para>PKCS#5 Password-based Encryption Standard v1.5, RSA Laboratories, 1993</para>
     <para>PKCS#12: Personal Information Exchange Syntax v1.0, RSA Laboratories, 1999</para>
   </chapter>
@@ -379,23 +472,33 @@
       <variablelist>
         <varlistentry>
           <term>CA</term>
-          <listitem><para>Certification Authority</para></listitem>
+          <listitem>
+            <para>Certification Authority</para>
+          </listitem>
         </varlistentry>
         <varlistentry>
           <term>CN</term>
-          <listitem><para>Common Name</para></listitem>
+          <listitem>
+            <para>Common Name</para>
+          </listitem>
         </varlistentry>
         <varlistentry>
           <term>CRL</term>
-          <listitem><para>Certificate Revocation List</para></listitem>
+          <listitem>
+            <para>Certificate Revocation List</para>
+          </listitem>
         </varlistentry>
         <varlistentry>
           <term>CSR</term>
-          <listitem><para>Certificate Signing Request (also called Certification Request)</para></listitem>
+          <listitem>
+            <para>Certificate Signing Request (also called Certification Request)</para>
+          </listitem>
         </varlistentry>
         <varlistentry>
           <term>EAP</term>
-          <listitem><para>Extensible Authentication Protocol</para></listitem>
+          <listitem>
+            <para>Extensible Authentication Protocol</para>
+          </listitem>
         </varlistentry>
         <varlistentry>
           <term>ECC</term>
@@ -405,59 +508,87 @@
         </varlistentry>
         <varlistentry>
           <term>HTTP</term>
-          <listitem><para>Hypertext Transfer Protocol</para></listitem>
+          <listitem>
+            <para>Hypertext Transfer Protocol</para>
+          </listitem>
         </varlistentry>
         <varlistentry>
           <term>IEEE</term>
-          <listitem><para>Institute of Electrical and Electronics Engineers</para></listitem>
+          <listitem>
+            <para>Institute of Electrical and Electronics Engineers</para>
+          </listitem>
         </varlistentry>
         <varlistentry>
           <term>JWS</term>
-          <listitem><para>JSON Web Signature</para></listitem>
+          <listitem>
+            <para>JSON Web Signature</para>
+          </listitem>
         </varlistentry>
         <varlistentry>
           <term>JWT</term>
-          <listitem><para>JSON Web Token</para></listitem>
+          <listitem>
+            <para>JSON Web Token</para>
+          </listitem>
         </varlistentry>
         <varlistentry>
           <term>MAC</term>
-          <listitem><para>Message Authentication Code</para></listitem>
+          <listitem>
+            <para>Message Authentication Code</para>
+          </listitem>
         </varlistentry>
         <varlistentry>
           <term>MD5</term>
-          <listitem><para>Message Digest Algorithm 5</para></listitem>
+          <listitem>
+            <para>Message Digest Algorithm 5</para>
+          </listitem>
         </varlistentry>
         <varlistentry>
           <term>MSCHAPv2</term>
-          <listitem><para>Microsoft’s Challenge Handshake Authentication Protocol version 2</para></listitem>
+          <listitem>
+            <para>Microsoft’s Challenge Handshake Authentication Protocol version 2</para>
+          </listitem>
         </varlistentry>
         <varlistentry>
           <term>PEAP</term>
-          <listitem><para>Protected EAP</para></listitem>
+          <listitem>
+            <para>Protected EAP</para>
+          </listitem>
         </varlistentry>
         <varlistentry>
           <term>SCTP</term>
-          <listitem><para>Stream Control Transmission Protocol</para></listitem>
+          <listitem>
+            <para>Stream Control Transmission Protocol</para>
+          </listitem>
         </varlistentry>
         <varlistentry>
           <term>SHA</term>
-          <listitem><para>Secure Hashing Algorithm</para></listitem>
+          <listitem>
+            <para>Secure Hashing Algorithm</para>
+          </listitem>
         </varlistentry>
         <varlistentry>
           <term>SSL</term>
-          <listitem><para>Secure Socket Layer</para></listitem>
+          <listitem>
+            <para>Secure Socket Layer</para>
+          </listitem>
         </varlistentry>
         <varlistentry>
           <term>TLS</term>
-          <listitem><para>Transport Layer Security</para></listitem>
+          <listitem>
+            <para>Transport Layer Security</para>
+          </listitem>
         </varlistentry>
         <varlistentry>
           <term>TTLS</term>
-          <listitem><para>Tunneled TLS</para></listitem>
+          <listitem>
+            <para>Tunneled TLS</para>
+          </listitem>
         </varlistentry>
         <varlistentry>
           <term>WS</term>
-          <listitem><para>Web Services</para></listitem>
+          <listitem>
+            <para>Web Services</para>
+          </listitem>
         </varlistentry>
       </variablelist>
     </section>
@@ -561,265 +692,311 @@
     </section>
     <section>
       <title>Certificate Path Verification</title>
-        <section>
-          <title>Certification Path Validation Algorithm Parameters</title>
-          <para>By default, a device shall use the values defined in <xref linkend="_Ref395170314"/> for the algorithm parameters defined in RFC 5280, Sect. 6.1.1.</para>
-          <table xml:id="_Ref395170314">
-            <title>Default parameter values for the certification path validation algorithm</title>
-            <tgroup cols="3">
-              <colspec colname="c1" colwidth="25*"/>
-              <colspec colname="c2" colwidth="14*"/>
-              <colspec colname="c3" colwidth="61*"/>
-              <thead>
-                <row>
-                  <entry>
-                    <para>Parameter</para>
-                  </entry>
-                  <entry>
-                    <para>Default </para>
-                  </entry>
-                  <entry>
-                    <para>Default Value Semantics</para>
-                  </entry>
-                </row>
-              </thead>
-              <tbody valign="top">
-                <row>
-                  <entry>
-                    <para>User-initial-policy-set</para>
-                  </entry>
-                  <entry>
-                    <para>Any-policy</para>
-                  </entry>
-                  <entry>
-                    <para>The device is not concerned about certificate policy.</para>
-                  </entry>
-                </row>
-                <row>
-                  <entry>
-                    <para>Initial-policy-mapping-inhibit</para>
-                  </entry>
-                  <entry>
-                    <para>0</para>
-                  </entry>
-                  <entry>
-                    <para>Policy mapping is not inhibited.</para>
-                  </entry>
-                </row>
-                <row>
-                  <entry>
-                    <para>Initial-explicit-policy</para>
-                  </entry>
-                  <entry>
-                    <para>0</para>
-                  </entry>
-                  <entry>
-                    <para>The prospective certification path does not have to be valid for at least one certificate policy in the user-initial-policy-set</para>
-                  </entry>
-                </row>
-                <row>
-                  <entry>
-                    <para>Initial-any-policy-inhibit</para>
-                  </entry>
-                  <entry>
-                    <para>0</para>
-                  </entry>
-                  <entry>
-                    <para>The any-policy identifier, if asserted in a certificate, does not have to be ignored</para>
-                  </entry>
-                </row>
-                <row>
-                  <entry>
-                    <para>Initial-permitted-subtrees</para>
-                  </entry>
-                  <entry>
-                    <para>(not specified)</para>
-                  </entry>
-                  <entry>
-                    <para>No restrictions on the subtree within which all subject names in every certificate in the prospective certification path must fall.</para>
-                  </entry>
-                </row>
-                <row>
-                  <entry>
-                    <para>Initial-excluded-subtrees</para>
-                  </entry>
-                  <entry>
-                    <para>(not specified)</para>
-                  </entry>
-                  <entry>
-                    <para>No restrictions on the subtree within which no subject names in any certificate in the prospective certification path may fall.</para>
-                  </entry>
-                </row>
-                <row>
-                  <entry>
-                    <para>CA-information-source-for-v1-and-v2</para>
-                  </entry>
-                  <entry>
-                    <para>None</para>
-                  </entry>
-                  <entry>
-                    <para>The device shall consider X.509 version 1 and version 2 certificates as non-CA certificates.</para>
-                  </entry>
-                </row>
-              </tbody>
-            </tgroup>
-          </table>
-        </section>
-        <section>
-          <title> Revocation Status Checking </title>
-          <para>By default, a device shall use the parameter values defined in <xref
+      <section>
+        <title>Certification Path Validation Algorithm Parameters</title>
+        <para>By default, a device shall use the values defined in <xref linkend="_Ref395170314"/>
+          for the algorithm parameters defined in RFC 5280, Sect. 6.1.1.</para>
+        <table xml:id="_Ref395170314">
+          <title>Default parameter values for the certification path validation algorithm</title>
+          <tgroup cols="3">
+            <colspec colname="c1" colwidth="25*"/>
+            <colspec colname="c2" colwidth="14*"/>
+            <colspec colname="c3" colwidth="61*"/>
+            <thead>
+              <row>
+                <entry>
+                  <para>Parameter</para>
+                </entry>
+                <entry>
+                  <para>Default </para>
+                </entry>
+                <entry>
+                  <para>Default Value Semantics</para>
+                </entry>
+              </row>
+            </thead>
+            <tbody valign="top">
+              <row>
+                <entry>
+                  <para>User-initial-policy-set</para>
+                </entry>
+                <entry>
+                  <para>Any-policy</para>
+                </entry>
+                <entry>
+                  <para>The device is not concerned about certificate policy.</para>
+                </entry>
+              </row>
+              <row>
+                <entry>
+                  <para>Initial-policy-mapping-inhibit</para>
+                </entry>
+                <entry>
+                  <para>0</para>
+                </entry>
+                <entry>
+                  <para>Policy mapping is not inhibited.</para>
+                </entry>
+              </row>
+              <row>
+                <entry>
+                  <para>Initial-explicit-policy</para>
+                </entry>
+                <entry>
+                  <para>0</para>
+                </entry>
+                <entry>
+                  <para>The prospective certification path does not have to be valid for at least
+                    one certificate policy in the user-initial-policy-set</para>
+                </entry>
+              </row>
+              <row>
+                <entry>
+                  <para>Initial-any-policy-inhibit</para>
+                </entry>
+                <entry>
+                  <para>0</para>
+                </entry>
+                <entry>
+                  <para>The any-policy identifier, if asserted in a certificate, does not have to be
+                    ignored</para>
+                </entry>
+              </row>
+              <row>
+                <entry>
+                  <para>Initial-permitted-subtrees</para>
+                </entry>
+                <entry>
+                  <para>(not specified)</para>
+                </entry>
+                <entry>
+                  <para>No restrictions on the subtree within which all subject names in every
+                    certificate in the prospective certification path must fall.</para>
+                </entry>
+              </row>
+              <row>
+                <entry>
+                  <para>Initial-excluded-subtrees</para>
+                </entry>
+                <entry>
+                  <para>(not specified)</para>
+                </entry>
+                <entry>
+                  <para>No restrictions on the subtree within which no subject names in any
+                    certificate in the prospective certification path may fall.</para>
+                </entry>
+              </row>
+              <row>
+                <entry>
+                  <para>CA-information-source-for-v1-and-v2</para>
+                </entry>
+                <entry>
+                  <para>None</para>
+                </entry>
+                <entry>
+                  <para>The device shall consider X.509 version 1 and version 2 certificates as
+                    non-CA certificates.</para>
+                </entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+      </section>
+      <section>
+        <title> Revocation Status Checking </title>
+        <para>By default, a device shall use the parameter values defined in <xref
             linkend="_Ref395170420"/> for the parameters specified in RFC 5280, section 6.3.1. For
           CRL processing see section 6.3.3 of RFC 5280.</para>
-          <table xml:id="_Ref395170420">
-            <title>Default parameter values for the revocation status checking algorithm</title>
-            <tgroup cols="3">
-              <colspec colname="c1" colwidth="33*"/>
-              <colspec colname="c2" colwidth="14*"/>
-              <colspec colname="c3" colwidth="53*"/>
-              <thead>
-                <row>
-                  <entry>
-                    <para>Parameter</para>
-                  </entry>
-                  <entry>
-                    <para>Default </para>
-                  </entry>
-                  <entry>
-                    <para>Default Value Semantics</para>
-                  </entry>
-                </row>
-              </thead>
-              <tbody valign="top">
-                <row>
-                  <entry>
-                    <para>Use-deltas</para>
-                  </entry>
-                  <entry>
-                    <para>False</para>
-                  </entry>
-                  <entry>
-                    <para>Delta CRLs, if available, are applied to CRLs.</para>
-                  </entry>
-                </row>
-                <row>
-                  <entry>
-                    <para>Relevant-reason-codes</para>
-                  </entry>
-                  <entry>
-                    <para>All-reasons</para>
-                  </entry>
-                  <entry>
-                    <para>The device considers a certificate revoked if it has been revoked for any reason defined in RFC 5280.</para>
-                  </entry>
-                </row>
-              </tbody>
-            </tgroup>
-          </table>
-          <para>By default, a device shall consider all trusted sources of revocation information that it has access to when determining the revocation status of a certificate. The device shall consider the certificate in question revoked if and only if at least one such source indicates that the certificate in question is revoked. If one such source is unavailable, the device shall behave as if this source had provided the reply UNDETERMINED.</para>
-          <para>A device shall consider at least the CRLs that are present in the keystore of the device.</para>
-          <para>By default, certificates that are considered revoked shall not be included in prospective certification paths.</para>
-        </section>
-        <section>
-          <title>Trust Anchors</title>
-          <para>The trust anchors assigned to the certification path validation policy shall be used as trust anchor input to the certification path validation algorithm specified in RFC 5280.</para>
-        </section>
-        <section>
-          <title>Certificate Repository for constructing Certification Paths</title>
-          <para>By default, the certification path validation shall consider all certificates in the
-          keystore on the device when constructing prospective certification paths.</para>
-        </section>
-        <section>
-          <title>Specific certification path validation parameters</title>
-          <para>
-            <xref linkend="_Ref395173040"/> defines additional certification path validation parameters.</para>
-          <table xml:id="_Ref395173040">
-            <title>Specific certification path validation parameters</title>
-            <tgroup cols="3">
-              <colspec colname="c1" colwidth="52*"/>
-              <colspec colname="c2" colwidth="12*"/>
-              <colspec colname="c3" colwidth="35*"/>
-              <thead>
-                <row>
-                  <entry>
-                    <para>Parameter</para>
-                  </entry>
-                  <entry>
-                    <para>Default </para>
-                  </entry>
-                  <entry>
-                    <para>Default Value Semantics</para>
-                  </entry>
-                </row>
-              </thead>
-              <tbody valign="top">
-                <row>
-                  <entry>
-                    <para>RequireTLSWWWClientAuthExtendedKeyUsage</para>
-                  </entry>
-                  <entry>
-                    <para>False</para>
-                  </entry>
-                  <entry>
-                    <para>If true, a TLS server shall only allow TLS clients to connect that present a client certificate containing the Require WWW client auth extended key usage extension as specified in RFC 5280, Sect. 4.2.1.12.</para>
-                  </entry>
-                </row>
-              </tbody>
-            </tgroup>
-          </table>
-        </section>
+        <table xml:id="_Ref395170420">
+          <title>Default parameter values for the revocation status checking algorithm</title>
+          <tgroup cols="3">
+            <colspec colname="c1" colwidth="33*"/>
+            <colspec colname="c2" colwidth="14*"/>
+            <colspec colname="c3" colwidth="53*"/>
+            <thead>
+              <row>
+                <entry>
+                  <para>Parameter</para>
+                </entry>
+                <entry>
+                  <para>Default </para>
+                </entry>
+                <entry>
+                  <para>Default Value Semantics</para>
+                </entry>
+              </row>
+            </thead>
+            <tbody valign="top">
+              <row>
+                <entry>
+                  <para>Use-deltas</para>
+                </entry>
+                <entry>
+                  <para>False</para>
+                </entry>
+                <entry>
+                  <para>Delta CRLs, if available, are applied to CRLs.</para>
+                </entry>
+              </row>
+              <row>
+                <entry>
+                  <para>Relevant-reason-codes</para>
+                </entry>
+                <entry>
+                  <para>All-reasons</para>
+                </entry>
+                <entry>
+                  <para>The device considers a certificate revoked if it has been revoked for any
+                    reason defined in RFC 5280.</para>
+                </entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+        <para>By default, a device shall consider all trusted sources of revocation information that
+          it has access to when determining the revocation status of a certificate. The device shall
+          consider the certificate in question revoked if and only if at least one such source
+          indicates that the certificate in question is revoked. If one such source is unavailable,
+          the device shall behave as if this source had provided the reply UNDETERMINED.</para>
+        <para>A device shall consider at least the CRLs that are present in the keystore of the
+          device.</para>
+        <para>By default, certificates that are considered revoked shall not be included in
+          prospective certification paths.</para>
       </section>
+      <section>
+        <title>Trust Anchors</title>
+        <para>The trust anchors assigned to the certification path validation policy shall be used
+          as trust anchor input to the certification path validation algorithm specified in RFC
+          5280.</para>
+      </section>
+      <section>
+        <title>Certificate Repository for constructing Certification Paths</title>
+        <para>By default, the certification path validation shall consider all certificates in the
+          keystore on the device when constructing prospective certification paths.</para>
+      </section>
+      <section>
+        <title>Specific certification path validation parameters</title>
+        <para>
+          <xref linkend="_Ref395173040"/> defines additional certification path validation
+          parameters.</para>
+        <table xml:id="_Ref395173040">
+          <title>Specific certification path validation parameters</title>
+          <tgroup cols="3">
+            <colspec colname="c1" colwidth="52*"/>
+            <colspec colname="c2" colwidth="12*"/>
+            <colspec colname="c3" colwidth="35*"/>
+            <thead>
+              <row>
+                <entry>
+                  <para>Parameter</para>
+                </entry>
+                <entry>
+                  <para>Default </para>
+                </entry>
+                <entry>
+                  <para>Default Value Semantics</para>
+                </entry>
+              </row>
+            </thead>
+            <tbody valign="top">
+              <row>
+                <entry>
+                  <para>RequireTLSWWWClientAuthExtendedKeyUsage</para>
+                </entry>
+                <entry>
+                  <para>False</para>
+                </entry>
+                <entry>
+                  <para>If true, a TLS server shall only allow TLS clients to connect that present a
+                    client certificate containing the Require WWW client auth extended key usage
+                    extension as specified in RFC 5280, Sect. 4.2.1.12.</para>
+                </entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+      </section>
+    </section>
     <section xml:id="_Ref395181339">
       <title>JWT-based client authorization</title>
       <section>
         <title>General</title>
-      <para>Unlike with HTTP Digest and WS-UsernameToken authentication, this specification defines how to associate clients with the different User Levels as defined in the ONVIF Core Specification. Devices are not expected to have the user credentials stored in their memory, instead they will verify that the user has been correctly authenticated by a trusted service based on OpenID Connect and authorize accessing different functions, based on the claims presented in the supplied JWT. JWTs can be presented as headers in case of HTTPS or RTSP, or they can be embedded in SOAP messages, in the form of binary security tokens. In case JWTs are embedded in binary security tokens, their content is base64url-encoded according to RFC 7519.</para>
-      <para>JWTs consists of three elements:</para>
-      <para>
-        <itemizedlist>
-          <listitem>
-            <para>JOSE header</para>
-          </listitem>
-          <listitem>
-            <para>Payload</para>
-          </listitem>
-          <listitem>
-            <para>Signature</para>
-          </listitem>
-        </itemizedlist>
-      </para>
-      <para>The JOSE header shall declare that the encoded object is a JSON Web Token by setting the <emphasis>typ</emphasis> parameter to <emphasis>JWT</emphasis>, and the JWT is a JWS that is signed using the algorithm identified by the <emphasis>alg</emphasis> claim with a value defined in RFC7518. Since the keystore does not support symmetric encryption, this specification only mandates asymmetric encryption.</para>
-      <para>The JWT payload shall include the following standard claims:</para>
-      <para>
-        <itemizedlist>
-          <listitem>
-            <para><emphasis>iss</emphasis>: Issuer, the URI of the server that generated the JWT.</para>
-          </listitem>
-          <listitem>
-            <para><emphasis>aud</emphasis>: Audience, a list of strings representing the recipients that the JWT is intended for. Each principal intended to process the JWT shall identify itself with a value in the audience claim. If the principal processing the claim does not identify itself with a value in the audience claim when this claim is present, then the JWT shall be rejected.</para>
-          </listitem>
-          <listitem>
-            <para><emphasis>exp</emphasis>: Expiration Time.</para>
-          </listitem>
-          <listitem>
-            <para><emphasis>nbf</emphasis>: Not before.</para>
-          </listitem>
-        </itemizedlist>
-      </para>
-      <para>For the <emphasis>exp</emphasis>, <emphasis>nbf</emphasis> claims, a device shall reject a token when the current time is not within the range of claims nbf and exp. It shall reject a token when at least one of the claims is missing.</para>
-      <para>The JWT payload shall include the <emphasis>roles</emphasis> claim, as defined within RFC 7643:</para>
-      <para>
-        <itemizedlist>
-          <listitem>
-            <para><emphasis>roles</emphasis>: Access class. One of the authenticated classes of the default access policy prefixed with the string <emphasis>onvif:</emphasis>, i.e. "onvif:Administrator", "onvif:Operator" or "onvif:User" as defined also within the ONVIF Core Specification. This access level will be used to authorize access to the required function.</para>
-          </listitem>
-        </itemizedlist>
-      </para>
-      <para>The signature is evaluated by applying ECDSA using secp256r1 and SHA-256 hashing to the base64url-encoded header and payload, concatenated by a '.'</para>
-      <programlisting>ECDSA-SHA256 (base64UrlEncode(header) + "." +
+        <para>Unlike with HTTP Digest and WS-UsernameToken authentication, this specification
+          defines how to associate clients with the different User Levels as defined in the ONVIF
+          Core Specification. Devices are not expected to have the user credentials stored in their
+          memory, instead they will verify that the user has been correctly authenticated by a
+          trusted service based on OpenID Connect and authorize accessing different functions, based
+          on the claims presented in the supplied JWT. JWTs can be presented as headers in case of
+          HTTPS or RTSP, or they can be embedded in SOAP messages, in the form of binary security
+          tokens. In case JWTs are embedded in binary security tokens, their content is
+          base64url-encoded according to RFC 7519.</para>
+        <para>JWTs consists of three elements:</para>
+        <para>
+          <itemizedlist>
+            <listitem>
+              <para>JOSE header</para>
+            </listitem>
+            <listitem>
+              <para>Payload</para>
+            </listitem>
+            <listitem>
+              <para>Signature</para>
+            </listitem>
+          </itemizedlist>
+        </para>
+        <para>The JOSE header shall declare that the encoded object is a JSON Web Token by setting
+          the <emphasis>typ</emphasis> parameter to <emphasis>JWT</emphasis>, and the JWT is a JWS
+          that is signed using the algorithm identified by the <emphasis>alg</emphasis> claim with a
+          value defined in RFC7518. Since the keystore does not support symmetric encryption, this
+          specification only mandates asymmetric encryption.</para>
+        <para>The JWT payload shall include the following standard claims:</para>
+        <para>
+          <itemizedlist>
+            <listitem>
+              <para><emphasis>iss</emphasis>: Issuer, the URI of the server that generated the
+                JWT.</para>
+            </listitem>
+            <listitem>
+              <para><emphasis>aud</emphasis>: Audience, a list of strings representing the
+                recipients that the JWT is intended for. Each principal intended to process the JWT
+                shall identify itself with a value in the audience claim. If the principal
+                processing the claim does not identify itself with a value in the audience claim
+                when this claim is present, then the JWT shall be rejected.</para>
+            </listitem>
+            <listitem>
+              <para><emphasis>exp</emphasis>: Expiration Time.</para>
+            </listitem>
+            <listitem>
+              <para><emphasis>nbf</emphasis>: Not before.</para>
+            </listitem>
+          </itemizedlist>
+        </para>
+        <para>For the <emphasis>exp</emphasis>, <emphasis>nbf</emphasis> claims, a device shall
+          reject a token when the current time is not within the range of claims nbf and exp. It
+          shall reject a token when at least one of the claims is missing.</para>
+        <para>The JWT payload shall include the <emphasis>roles</emphasis> claim, as defined within
+          RFC 7643:</para>
+        <para>
+          <itemizedlist>
+            <listitem>
+              <para><emphasis>roles</emphasis>: Access class. One of the authenticated classes of
+                the default access policy prefixed with the string <emphasis>onvif:</emphasis>, i.e.
+                "onvif:Administrator", "onvif:Operator" or "onvif:User" as defined also within the
+                ONVIF Core Specification. This access level will be used to authorize access to the
+                required function.</para>
+            </listitem>
+          </itemizedlist>
+        </para>
+        <para>The signature is evaluated by applying ECDSA using secp256r1 and SHA-256 hashing to
+          the base64url-encoded header and payload, concatenated by a '.'</para>
+        <programlisting>ECDSA-SHA256 (base64UrlEncode(header) + "." +
               base64UrlEncode(payload),
               secp256r1))</programlisting>
-      <para>The evaluated signature is further appended to the encoded header and payload with a '.' separator, to get the final JWT. Appendix <xref linkend="_Ref460769599"/> demonstrates the construction or a JWT.</para>
-      <para>The signature is used to protect the JWT data integrity and JWT source authenticity.</para>
+        <para>The evaluated signature is further appended to the encoded header and payload with a
+          '.' separator, to get the final JWT. Appendix <xref linkend="_Ref460769599"/> demonstrates
+          the construction or a JWT.</para>
+        <para>The signature is used to protect the JWT data integrity and JWT source
+          authenticity.</para>
       </section>
       <section>
         <title>Configuration</title>
@@ -827,39 +1004,57 @@
         <variablelist>
           <varlistentry>
             <term>Audiences</term>
-            <listitem><para>One or more audience strings. A device shall reject a token if none of the provided strings matches.</para></listitem>
+            <listitem>
+              <para>One or more audience strings. A device shall reject a token if none of the
+                provided strings matches.</para>
+            </listitem>
           </varlistentry>
           <varlistentry>
             <term>TrustedIssuer</term>
-            <listitem><para>Optional list of trusted issuer metadata URIs. A device shall reject a token if the list is
-                non-empty and the token does not match the information provided via one of the
-                issuer metadata URIs.</para></listitem>
+            <listitem>
+              <para>Optional list of trusted issuer metadata URIs. A device shall reject a token if
+                the list is non-empty and the token does not match the information provided via one
+                of the issuer metadata URIs.</para>
+            </listitem>
           </varlistentry>
           <varlistentry>
             <term>KeyID</term>
-            <listitem><para>Optional list of  keys. A device shall reject a token if this list is non-empty and none of
-                the provided keys can verify the signature.</para></listitem>
+            <listitem>
+              <para>Optional list of keys. A device shall reject a token if this list is non-empty
+                and none of the provided keys can verify the signature.</para>
+            </listitem>
           </varlistentry>
           <varlistentry>
             <term>ValidationPolicy</term>
-            <listitem><para>Optional cert path validation policies to verify trusted issuers. If this list is non-empty a
-                device shall only accept trusted issuers with matching TLS server
-                certificates.</para></listitem>
+            <listitem>
+              <para>Optional cert path validation policies to verify trusted issuers. If this list
+                is non-empty a device shall only accept trusted issuers with matching TLS server
+                certificates.</para>
+            </listitem>
           </varlistentry>
         </variablelist>
       </section>
       <section>
         <title>Usage of JWT-based client authentication over HTTP</title>
-        <para>Since authentication tokens contain sensitive information that could be easily used to perform replay attacks, JWT-based client authentication shall not be used over unencrypted HTTP connections.</para>
+        <para>Since authentication tokens contain sensitive information that could be easily used to
+          perform replay attacks, JWT-based client authentication shall not be used over unencrypted
+          HTTP connections.</para>
       </section>
       <section>
         <title>Usage of JWT-based client authentication over HTTPS</title>
-        <para>Usage JWT-based client authentication over HTTPS shall adhere to the Authorization Request header Field, as specified by RFC 6750. In case of authentication failure, ONVIF-compliant devices shall respond with the error codes specified by RFC 6750.</para>
+        <para>Usage JWT-based client authentication over HTTPS shall adhere to the Authorization
+          Request header Field, as specified by RFC 6750. In case of authentication failure,
+          ONVIF-compliant devices shall respond with the error codes specified by RFC 6750.</para>
       </section>
       <section>
         <title>Usage of JWT-based client authentication over SCTP</title>
-        <para>In scenarios where a SCTP channel is used to exchange commands and responses between the device and the client, it is not possible to embed a JWT within a header. In this case, the JWT can be embedded in the Security Token of the SOAP message, as defined in the WS-Security Basic Security Profile.</para>
-        <para>A client shall use both ValueType and EncodingType. The device shall reject any Binary Security Token not using both <emphasis>ValueType</emphasis> and <emphasis>EncodingType</emphasis>.</para>
+        <para>In scenarios where a SCTP channel is used to exchange commands and responses between
+          the device and the client, it is not possible to embed a JWT within a header. In this
+          case, the JWT can be embedded in the Security Token of the SOAP message, as defined in the
+          WS-Security Basic Security Profile.</para>
+        <para>A client shall use both ValueType and EncodingType. The device shall reject any Binary
+          Security Token not using both <emphasis>ValueType</emphasis> and
+            <emphasis>EncodingType</emphasis>.</para>
         <para>The EncodingType attribute shall have the value of</para>
         <programlisting>http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#BinarySecurityToken</programlisting>
         <para>The ValueType attribute shall have the value of</para>
@@ -867,19 +1062,30 @@
       </section>
       <section>
         <title>Usage of JWT-based client authentication over RTSP</title>
-        <para>Since authentication tokens contain sensitive information that could be easily used to perform replay attacks, JWT-based client authentication shall be used with RTSP connections only when HTTPS transport is selected.</para>
+        <para>Since authentication tokens contain sensitive information that could be easily used to
+          perform replay attacks, JWT-based client authentication shall be used with RTSP
+          connections only when HTTPS transport is selected.</para>
       </section>
       <section>
         <title>Usage of JWT-based client authentication over RTSPS</title>
-        <para>Since the RTSPS protocol is similar to HTTPS, JWT-based client authentication over RTSPS behaves in the same way as JWT-based client authentication over HTTPS.</para>
+        <para>Since the RTSPS protocol is similar to HTTPS, JWT-based client authentication over
+          RTSPS behaves in the same way as JWT-based client authentication over HTTPS.</para>
       </section>
     </section>
     <section>
       <title>IEEE 802.1X</title>
-      <para>IEEE 802.1X is an IEEE standard for port based network access control for the purpose of providing authentication and authorization of the devices attached to LAN ports. It allows access to the LAN port to devices that are configured for access, and prevents access to the LAN port to devices that are not correctly configured.</para>
-      <para>This specification recommends the adoption of IEEE 802.1X for port based authentication for wireless networks.</para>
-      <para>This specification defines a set of commands to configure and manage a device’s IEEE 802.1X configurations, both for wireless and hardwired network interfaces.  It assumes that IEEE 802.1X configuration and reconfiguration is performed outside of the IEEE 802.1X-secured network.</para>
-      <para>Many schema elements in this specification include Dot1X as shorthand for IEEE 802.1X.  This convention increases the readability of source code generated from the WSDL.</para>
+      <para>IEEE 802.1X is an IEEE standard for port based network access control for the purpose of
+        providing authentication and authorization of the devices attached to LAN ports. It allows
+        access to the LAN port to devices that are configured for access, and prevents access to the
+        LAN port to devices that are not correctly configured.</para>
+      <para>This specification recommends the adoption of IEEE 802.1X for port based authentication
+        for wireless networks.</para>
+      <para>This specification defines a set of commands to configure and manage a device’s IEEE
+        802.1X configurations, both for wireless and hardwired network interfaces. It assumes that
+        IEEE 802.1X configuration and reconfiguration is performed outside of the IEEE
+        802.1X-secured network.</para>
+      <para>Many schema elements in this specification include Dot1X as shorthand for IEEE 802.1X.
+        This convention increases the readability of source code generated from the WSDL.</para>
     </section>
     <section xml:id="section_b4m_rs4_rwb">
       <title>Authorization Servers</title>
@@ -990,14 +1196,23 @@
                 </entry>
               </row>
               <row>
-                <entry><para>KeyID</para></entry>
-                <entry><para>Key identifier for the <emphasis>private_key_jwt</emphasis> authentication
-                  method</para></entry>
+                <entry>
+                  <para>KeyID</para>
+                </entry>
+                <entry>
+                  <para>Key identifier for the <emphasis>private_key_jwt</emphasis> authentication
+                    method</para>
+                </entry>
               </row>
               <row>
-                <entry><para>CertificateID</para></entry>
-                <entry><para>Certificate identifier for the
-                  <emphasis>self_signed_tls_client_auth</emphasis> and <emphasis>tls_client_auth</emphasis> authentication methods.</para></entry>
+                <entry>
+                  <para>CertificateID</para>
+                </entry>
+                <entry>
+                  <para>Certificate identifier for the
+                      <emphasis>self_signed_tls_client_auth</emphasis> and
+                      <emphasis>tls_client_auth</emphasis> authentication methods.</para>
+                </entry>
               </row>
               <row>
                 <entry>
@@ -1024,8 +1239,8 @@
                   <para>CertPathValidationPolicyID</para>
                 </entry>
                 <entry>
-                  <para>The unique identifier of the certification path validation policy to be
-                    used for validating the server certificate</para>
+                  <para>The unique identifier of the certification path validation policy to be used
+                    for validating the server certificate</para>
                 </entry>
               </row>
             </tbody>
@@ -1166,7 +1381,8 @@
           <para>IEEE 802.1X</para>
         </listitem>
       </itemizedlist>
-      <para>The design and data model of the ONVIF Security Configuration Service is reflected in <xref linkend="_Ref350769587"/>.</para>
+      <para>The design and data model of the ONVIF Security Configuration Service is reflected in
+          <xref linkend="_Ref350769587"/>.</para>
       <figure xml:id="_Ref350769587">
         <title>ONVIF Security Configuration Service UML Class Diagram</title>
         <mediaobject>
@@ -1180,26 +1396,51 @@
       <title>Keystore</title>
       <section>
         <title>Elements of the Keystore</title>
-        <para>The keystore security feature handles the storage and management of passphrases, keys, and certificates on an ONVIF device.</para>
-        <para>The keystore specified in this document supports passphrases, keys, key pairs, RSA and ECC key pairs, which are particular types of key pairs, certificates, certification paths, certificate revocation lists, and certification path validation policies.</para>
-        <para>The boolean attribute <emphasis>externallyGenerated</emphasis> of a key shall be true if and only if the key was generated outside the device.</para>
-        <para>The boolean attribute <emphasis>securelyStored</emphasis> of a key shall be true if and only if the key is stored in a specially protected hardware component (e.g., a trusted platform module) inside the device.</para>
+        <para>The keystore security feature handles the storage and management of passphrases, keys,
+          and certificates on an ONVIF device.</para>
+        <para>The keystore specified in this document supports passphrases, keys, key pairs, RSA and
+          ECC key pairs, which are particular types of key pairs, certificates, certification paths,
+          certificate revocation lists, and certification path validation policies.</para>
+        <para>The boolean attribute <emphasis>externallyGenerated</emphasis> of a key shall be true
+          if and only if the key was generated outside the device.</para>
+        <para>The boolean attribute <emphasis>securelyStored</emphasis> of a key shall be true if
+          and only if the key is stored in a specially protected hardware component (e.g., a trusted
+          platform module) inside the device.</para>
       </section>
       <section>
         <title>Unique Identifiers</title>
-        <para>An ID is used to uniquely identify objects of a particular type in the keystore on a device, i.e., no two objects of the same type shall have the same ID at any time.</para>
-        <para>Passphrases in the keystore shall be uniquely identified by passphrase IDs, keys shall be uniquely identified by key IDs, certificates shall be uniquely identified by certificate IDs, certification paths in the keystore shall be uniquely identified by certification path IDs, certificate revocation lists shall be uniquely identified by certificate revocation list IDs, certification path validation policies shall be uniquely identified by certification path validation policy IDs, and IEEE 802.1X configurations shall be uniquely identified by IEEE 802.1X configuration IDs.</para>
-        <para>It shall be noted that while IDs within a specific type shall be unique, no requirement exists for the uniqueness of IDs across different types. For example, there may be a key and a certificate in the keystore that share the same ID.</para>
-        <para>Devices may assign the ID of a deleted identified object to another, subsequently generated object. However, devices should avoid re-using IDs as long as possible to avoid race conditions on the client side.</para>
-        <para>A client may supply an alias for passphrases, keys, certificates, certification paths, certificate revocation lists, certification path validation policies and IEEE 802.1X configurations upon creation, e.g., to facilitate recognizing the created object at a later time. The device shall treat such aliases as unstructured data.</para>
+        <para>An ID is used to uniquely identify objects of a particular type in the keystore on a
+          device, i.e., no two objects of the same type shall have the same ID at any time.</para>
+        <para>Passphrases in the keystore shall be uniquely identified by passphrase IDs, keys shall
+          be uniquely identified by key IDs, certificates shall be uniquely identified by
+          certificate IDs, certification paths in the keystore shall be uniquely identified by
+          certification path IDs, certificate revocation lists shall be uniquely identified by
+          certificate revocation list IDs, certification path validation policies shall be uniquely
+          identified by certification path validation policy IDs, and IEEE 802.1X configurations
+          shall be uniquely identified by IEEE 802.1X configuration IDs.</para>
+        <para>It shall be noted that while IDs within a specific type shall be unique, no
+          requirement exists for the uniqueness of IDs across different types. For example, there
+          may be a key and a certificate in the keystore that share the same ID.</para>
+        <para>Devices may assign the ID of a deleted identified object to another, subsequently
+          generated object. However, devices should avoid re-using IDs as long as possible to avoid
+          race conditions on the client side.</para>
+        <para>A client may supply an alias for passphrases, keys, certificates, certification paths,
+          certificate revocation lists, certification path validation policies and IEEE 802.1X
+          configurations upon creation, e.g., to facilitate recognizing the created object at a
+          later time. The device shall treat such aliases as unstructured data.</para>
       </section>
       <section>
         <title>Uniqueness of Objects in the Keystore</title>
-        <para>A device shall allow multiple copies of the same passphrase to be present in the keystore under different IDs simultaneously.</para>
-        <para>A device shall allow multiple copies of the same certificate revocation list to be present in the keystore under different IDs, respectively.</para>
-        <para>A device shall allow multiple copies of the same certification path validation policy to be present in the keystore under different IDs, respectively.</para>
-        <para>A device shall allow multiple copies of the same IEEE 802.1X configuration to be present in the keystore under different IDs simultaneously.</para>
-        <para>A device shall not allow multiple copies of the same key to be present in the keystore simultaneously.</para>
+        <para>A device shall allow multiple copies of the same passphrase to be present in the
+          keystore under different IDs simultaneously.</para>
+        <para>A device shall allow multiple copies of the same certificate revocation list to be
+          present in the keystore under different IDs, respectively.</para>
+        <para>A device shall allow multiple copies of the same certification path validation policy
+          to be present in the keystore under different IDs, respectively.</para>
+        <para>A device shall allow multiple copies of the same IEEE 802.1X configuration to be
+          present in the keystore under different IDs simultaneously.</para>
+        <para>A device shall not allow multiple copies of the same key to be present in the keystore
+          simultaneously.</para>
       </section>
       <section>
         <title>Referential Integrity</title>
@@ -1239,49 +1480,79 @@
             <para>Certification path validation policies and security features</para>
           </listitem>
         </itemizedlist>
-        <para>A device shall enforce the following referential integrity rules for delete operations:</para>
+        <para>A device shall enforce the following referential integrity rules for delete
+          operations:</para>
         <itemizedlist>
           <listitem>
-            <para>A key shall not be deleted if it is referenced by a certificate or a security feature.</para>
+            <para>A key shall not be deleted if it is referenced by a certificate or a security
+              feature.</para>
           </listitem>
           <listitem>
-            <para>A certificate shall not be deleted if it is referenced by a certification path, a certificate revocation list, a certification path validation policy, or a security feature.</para>
+            <para>A certificate shall not be deleted if it is referenced by a certification path, a
+              certificate revocation list, a certification path validation policy, or a security
+              feature.</para>
           </listitem>
           <listitem>
-            <para>A certification path shall not be deleted if it is referenced by an IEEE 802.1X configuration or a security feature.</para>
+            <para>A certification path shall not be deleted if it is referenced by an IEEE 802.1X
+              configuration or a security feature.</para>
           </listitem>
           <listitem>
-            <para>A passphrase shall not be deleted if it is referenced by an IEEE 802.1X configuration.</para>
+            <para>A passphrase shall not be deleted if it is referenced by an IEEE 802.1X
+              configuration.</para>
           </listitem>
           <listitem>
-            <para>A certification path validation policy shall not be deleted if it is referenced by a security feature.</para>
+            <para>A certification path validation policy shall not be deleted if it is referenced by
+              a security feature.</para>
           </listitem>
           <listitem>
-            <para>An IEEE 802.1X configuration shall not be deleted if it is referenced by a security feature.</para>
+            <para>An IEEE 802.1X configuration shall not be deleted if it is referenced by a
+              security feature.</para>
           </listitem>
         </itemizedlist>
-        <para>This integrity rule may be enforced by the following mechanism. Reference counters are maintained for keys, certificates, certification paths, passphrases, and IEEE 802.1X configurations. Each time a reference to an object of these types is added, e.g., by associating a certificate to a key pair or assigning a key pair or certificate to a security feature, the reference counter of the object is incremented. Conversely, if a reference to an object is deleted, the reference counter of the referenced object is decremented. Deleting a key, certificate, or certification path is only permitted if the corresponding reference counter is equal to zero.</para>
-        <para>A device shall enforce the following referential integrity rules for update operations:</para>
+        <para>This integrity rule may be enforced by the following mechanism. Reference counters are
+          maintained for keys, certificates, certification paths, passphrases, and IEEE 802.1X
+          configurations. Each time a reference to an object of these types is added, e.g., by
+          associating a certificate to a key pair or assigning a key pair or certificate to a
+          security feature, the reference counter of the object is incremented. Conversely, if a
+          reference to an object is deleted, the reference counter of the referenced object is
+          decremented. Deleting a key, certificate, or certification path is only permitted if the
+          corresponding reference counter is equal to zero.</para>
+        <para>A device shall enforce the following referential integrity rules for update
+          operations:</para>
         <itemizedlist>
           <listitem>
             <para>
-              <phrase>A key shall not be updated if it is referenced by a certificate or a security feature. However, </phrase>a private key may be added to an existing key pair if the private key matches the public key in the key pair. If a private key is about to be added to a key pair that already contains the private key to be added, the adding operation shall have no effect.</para>
+              <phrase>A key shall not be updated if it is referenced by a certificate or a security
+                feature. However, </phrase>a private key may be added to an existing key pair if the
+              private key matches the public key in the key pair. If a private key is about to be
+              added to a key pair that already contains the private key to be added, the adding
+              operation shall have no effect.</para>
           </listitem>
           <listitem>
-            <para>A certificate shall not be updated if it is referenced by a certification path, a certificate revocation list, a certification path validation policy, or a security feature.</para>
+            <para>A certificate shall not be updated if it is referenced by a certification path, a
+              certificate revocation list, a certification path validation policy, or a security
+              feature.</para>
           </listitem>
           <listitem>
-            <para>A certification path validation policy shall not be updated if it is referenced by a security feature.</para>
+            <para>A certification path validation policy shall not be updated if it is referenced by
+              a security feature.</para>
           </listitem>
         </itemizedlist>
-        <para>This specification omits APIs for modifying keys or certificates. If a key or certificate is to be updated, it has to be deleted and newly generated with the updated information. If other API exists that allows for modification of keys or certificates, special care shall be taken in order not to break the referential integrity rule.</para>
+        <para>This specification omits APIs for modifying keys or certificates. If a key or
+          certificate is to be updated, it has to be deleted and newly generated with the updated
+          information. If other API exists that allows for modification of keys or certificates,
+          special care shall be taken in order not to break the referential integrity rule.</para>
         <para>A device shall enforce the following invariants:</para>
         <itemizedlist>
           <listitem>
-            <para>The private key and the public key in an asymmetric key pair in the keystore shall always match, i.e., the asymmetric operation under the public key is the inverse of the corresponding operation under the private key.</para>
+            <para>The private key and the public key in an asymmetric key pair in the keystore shall
+              always match, i.e., the asymmetric operation under the public key is the inverse of
+              the corresponding operation under the private key.</para>
           </listitem>
           <listitem>
-            <para>The public key in a certificate in the keystore and the public key in an associated key pair in the keystore shall always be equal for all associated key pairs.</para>
+            <para>The public key in a certificate in the keystore and the public key in an
+              associated key pair in the keystore shall always be equal for all associated key
+              pairs.</para>
           </listitem>
         </itemizedlist>
       </section>
@@ -1295,11 +1566,14 @@
           </listitem>
           <listitem>
             <para>
-              <emphasis>generating</emphasis> (The key is being generated and not yet ready for use)</para>
+              <emphasis>generating</emphasis> (The key is being generated and not yet ready for
+              use)</para>
           </listitem>
           <listitem>
             <para>
-              <emphasis>corrupt</emphasis> (The key is corrupt and shall not be used, e.g., because it was not properly generated or a hardware fault corrupted a key that was ready to be used)</para>
+              <emphasis>corrupt</emphasis> (The key is corrupt and shall not be used, e.g., because
+              it was not properly generated or a hardware fault corrupted a key that was ready to be
+              used)</para>
           </listitem>
         </itemizedlist>
       </section>
@@ -1310,10 +1584,15 @@
           <section>
             <title>UploadPassphrase</title>
             <para>This operation uploads a passphrase to the keystore of the device.</para>
-            <para>Passphrases are uniquely identified using passphrase IDs. The device shall generate a new passphrase ID for the uploaded passphrase.</para>
-            <para>If the command was successful, the device shall return the ID of the uploaded passphrase.</para>
-            <para>If the device does not have enough storage capacity for storing the passphrase to be uploaded, the device shall produce a maximum number of passphrases reached fault and shall not upload the supplied passphrase.</para>
-            <para>If the device cannot process the passphrase to be uploaded, the device shall produce a BadPassphrase fault and shall not upload a passphrase.</para>
+            <para>Passphrases are uniquely identified using passphrase IDs. The device shall
+              generate a new passphrase ID for the uploaded passphrase.</para>
+            <para>If the command was successful, the device shall return the ID of the uploaded
+              passphrase.</para>
+            <para>If the device does not have enough storage capacity for storing the passphrase to
+              be uploaded, the device shall produce a maximum number of passphrases reached fault
+              and shall not upload the supplied passphrase.</para>
+            <para>If the device cannot process the passphrase to be uploaded, the device shall
+              produce a BadPassphrase fault and shall not upload a passphrase.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
@@ -1334,10 +1613,13 @@
               <varlistentry>
                 <term>faults</term>
                 <listitem>
-                  <para role="param">env:Receiver - ter:Action - ter:MaximumNumberOfPassphrasesReached</para>
-                  <para role="text"> The device does not have enough storage space to store the passphrase to be uploaded.</para>
+                  <para role="param">env:Receiver - ter:Action -
+                    ter:MaximumNumberOfPassphrasesReached</para>
+                  <para role="text"> The device does not have enough storage space to store the
+                    passphrase to be uploaded.</para>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:BadPassphrase</para>
-                  <para role="text"> The provided passphrase cannot be processed by the device.</para>
+                  <para role="text"> The provided passphrase cannot be processed by the
+                    device.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -1350,9 +1632,12 @@
           </section>
           <section>
             <title>GetAllPassphrases</title>
-            <para>This operation returns information about all passphrases that are stored in the keystore of the device.</para>
-            <para>This operation may be used, e.g., if a client lost track of which passphrases are present on the device.</para>
-            <para>If no passphrase is stored on the device, the device shall return an empty list.</para>
+            <para>This operation returns information about all passphrases that are stored in the
+              keystore of the device.</para>
+            <para>This operation may be used, e.g., if a client lost track of which passphrases are
+              present on the device.</para>
+            <para>If no passphrase is stored on the device, the device shall return an empty
+              list.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
@@ -1363,8 +1648,10 @@
               <varlistentry>
                 <term>response</term>
                 <listitem>
-                  <para role="param">PassphraseAttribute - optional, unbounded [tas:PassphraseAttribute]</para>
-                  <para role="text"> List of passphrase attributes.  Each attribute contains information about a passphrase in the keystore.</para>
+                  <para role="param">PassphraseAttribute - optional, unbounded
+                    [tas:PassphraseAttribute]</para>
+                  <para role="text"> List of passphrase attributes. Each attribute contains
+                    information about a passphrase in the keystore.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -1384,14 +1671,20 @@
           <section>
             <title>DeletePassphrase</title>
             <para>This operation deletes a passphrase from the keystore of the device.</para>
-            <para>Passphrases are uniquely identified using passphrase IDs. If no passphrase is stored under the requested passphrase ID in the keystore, a device shall produce an invalid passphrase ID fault. If there is a passphrase under the requested passphrase ID stored in the keystore and the passphrase could not be deleted, a device shall produce a passphrase deletion failed fault.</para>
-            <para>After a passphrase is successfully deleted, the device may assign its former ID to other passphrases.</para>
+            <para>Passphrases are uniquely identified using passphrase IDs. If no passphrase is
+              stored under the requested passphrase ID in the keystore, a device shall produce an
+              invalid passphrase ID fault. If there is a passphrase under the requested passphrase
+              ID stored in the keystore and the passphrase could not be deleted, a device shall
+              produce a passphrase deletion failed fault.</para>
+            <para>After a passphrase is successfully deleted, the device may assign its former ID to
+              other passphrases.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
                 <listitem>
                   <para role="param">PassphraseID - [tas:PassphraseID]</para>
-                  <para role="text"> The ID of the passphrase that is to be deleted from the keystore.</para>
+                  <para role="text"> The ID of the passphrase that is to be deleted from the
+                    keystore.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -1404,9 +1697,11 @@
                 <term>faults</term>
                 <listitem>
                   <para role="param">env:Receiver - ter:Action - ter:PassphraseDeletionFailed</para>
-                  <para role="text"> Deleting the passphrase with the requested PassphraseID failed.</para>
+                  <para role="text"> Deleting the passphrase with the requested PassphraseID
+                    failed.</para>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:PassphraseID</para>
-                  <para role="text"> No passphrase is stored under the requested PassphraseID.</para>
+                  <para role="text"> No passphrase is stored under the requested
+                    PassphraseID.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -1422,10 +1717,29 @@
           <title>Key Management</title>
           <section>
             <title>CreateRSAKeyPair</title>
-            <para>This operation triggers the asynchronous generation of an RSA key pair of a particular keylength (specified as the number of bits) as specified in RFC 3447, with a suitable key generation mechanism on the device. Keys, especially RSA key pairs, are uniquely identified using key IDs. </para>
-            <para>If the device does not have enough storage capacity for storing the key pair to be created, the maximum number of keys reached fault shall be produced and no key pair shall be generated. Otherwise, the operation generates a keyID for the new key and associates the <emphasis>generating</emphasis> status to it. Immediately after key generation has started, the device shall return the keyID to the client and continue to generate the key pair. The client may query the device with the GetKeyStatus operation (see Sect. <xref linkend="_Ref361388129"/>) whether the generation has finished. The client may also subscribe to Key Status events (see Sect. <xref linkend="_Ref353780603"/>) to be notified about key status changes.</para>
-            <para>The device also returns a best-effort estimate of how much time it requires to create the key pair.<footnote xml:id="__FN1__"><para>Implementors may estimate the key generation time for a fixed key length as the average elapsed time of a number of key generation operations for this key length.</para></footnote> A client may use this information as an indication how long to wait before querying the device whether key generation is completed.</para>
-            <para>After the key has been successfully created, the device shall assign it the <emphasis>ok</emphasis> status. If the key generation fails, the device shall assign the key the <emphasis>corrupt</emphasis> status.</para>
+            <para>This operation triggers the asynchronous generation of an RSA key pair of a
+              particular keylength (specified as the number of bits) as specified in RFC 3447, with
+              a suitable key generation mechanism on the device. Keys, especially RSA key pairs, are
+              uniquely identified using key IDs. </para>
+            <para>If the device does not have enough storage capacity for storing the key pair to be
+              created, the maximum number of keys reached fault shall be produced and no key pair
+              shall be generated. Otherwise, the operation generates a keyID for the new key and
+              associates the <emphasis>generating</emphasis> status to it. Immediately after key
+              generation has started, the device shall return the keyID to the client and continue
+              to generate the key pair. The client may query the device with the GetKeyStatus
+              operation (see Sect. <xref linkend="_Ref361388129"/>) whether the generation has
+              finished. The client may also subscribe to Key Status events (see Sect. <xref
+                linkend="_Ref353780603"/>) to be notified about key status changes.</para>
+            <para>The device also returns a best-effort estimate of how much time it requires to
+              create the key pair.<footnote xml:id="__FN1__">
+                <para>Implementors may estimate the key generation time for a fixed key length as
+                  the average elapsed time of a number of key generation operations for this key
+                  length.</para>
+              </footnote> A client may use this information as an indication how long to wait before
+              querying the device whether key generation is completed.</para>
+            <para>After the key has been successfully created, the device shall assign it the
+                <emphasis>ok</emphasis> status. If the key generation fails, the device shall assign
+              the key the <emphasis>corrupt</emphasis> status.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
@@ -1442,14 +1756,17 @@
                   <para role="param">KeyID - [tas:KeyID]</para>
                   <para role="text"> The key ID of the key pair being generated.</para>
                   <para role="param">EstimatedCreationTime - [xs:duration]</para>
-                  <para role="text"> Best-effort estimation of how long the key generation will take.</para>
+                  <para role="text"> Best-effort estimation of how long the key generation will
+                    take.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
                 <term>faults</term>
                 <listitem>
-                  <para role="param">env:Receiver - ter:Action - ter:MaximumNumberOfKeysReached</para>
-                  <para role="text"> The keystore does not have enough storage space to store the key pair that has to be generated.</para>
+                  <para role="param">env:Receiver - ter:Action -
+                    ter:MaximumNumberOfKeysReached</para>
+                  <para role="text"> The keystore does not have enough storage space to store the
+                    key pair that has to be generated.</para>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:KeyLength</para>
                   <para role="text"> The specified key length is not supported by the device.</para>
                 </listitem>
@@ -1464,16 +1781,37 @@
           </section>
           <section>
             <title>CreateECCKeyPair</title>
-            <para>This operation triggers the asynchronous generation of an ECC key pair using a particular elliptic curve as specified in RFC 8422, with a suitable key generation mechanism on the device. Keys, especially ECC key pairs, are uniquely identified using key IDs. </para>
-            <para>If the device does not have enough storage capacity for storing the key pair to be created, the maximum number of keys reached fault shall be produced and no key pair shall be generated. Otherwise, the operation generates a keyID for the new key and associates the <emphasis>generating</emphasis> status to it. Immediately after key generation has started, the device shall return the keyID to the client and continue to generate the key pair. The client may query the device with the GetKeyStatus operation (see Sect. <xref linkend="_Ref361388129"/>) whether the generation has finished. The client may also subscribe to Key Status events (see Sect. <xref linkend="_Ref353780603"/>) to be notified about key status changes.</para>
-            <para>The device also returns a best-effort estimate of how much time it requires to create the key pair.<footnote xml:id="__FN3__"><para>Implementors may estimate the key generation time for a fixed key length as the average elapsed time of a number of key generation operations for this key length.</para></footnote> A client may use this information as an indication how long to wait before querying the device whether key generation is completed.</para>
-            <para>After the key has been successfully created, the device shall assign it the <emphasis>ok</emphasis> status. If the key generation fails, the device shall assign the key the <emphasis>corrupt</emphasis> status.</para>
+            <para>This operation triggers the asynchronous generation of an ECC key pair using a
+              particular elliptic curve as specified in RFC 8422, with a suitable key generation
+              mechanism on the device. Keys, especially ECC key pairs, are uniquely identified using
+              key IDs. </para>
+            <para>If the device does not have enough storage capacity for storing the key pair to be
+              created, the maximum number of keys reached fault shall be produced and no key pair
+              shall be generated. Otherwise, the operation generates a keyID for the new key and
+              associates the <emphasis>generating</emphasis> status to it. Immediately after key
+              generation has started, the device shall return the keyID to the client and continue
+              to generate the key pair. The client may query the device with the GetKeyStatus
+              operation (see Sect. <xref linkend="_Ref361388129"/>) whether the generation has
+              finished. The client may also subscribe to Key Status events (see Sect. <xref
+                linkend="_Ref353780603"/>) to be notified about key status changes.</para>
+            <para>The device also returns a best-effort estimate of how much time it requires to
+              create the key pair.<footnote xml:id="__FN3__">
+                <para>Implementors may estimate the key generation time for a fixed key length as
+                  the average elapsed time of a number of key generation operations for this key
+                  length.</para>
+              </footnote> A client may use this information as an indication how long to wait before
+              querying the device whether key generation is completed.</para>
+            <para>After the key has been successfully created, the device shall assign it the
+                <emphasis>ok</emphasis> status. If the key generation fails, the device shall assign
+              the key the <emphasis>corrupt</emphasis> status.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
                 <listitem>
                   <para role="param">EllipticCurve - [xs:string]</para>
-                  <para role="text"> The name of the elliptic curve to be used for generating the ECC keypair. Supported curve names can be found in the IANA TLS Supported Groups section, under the <emphasis>Description</emphasis> field.</para>
+                  <para role="text"> The name of the elliptic curve to be used for generating the
+                    ECC keypair. Supported curve names can be found in the IANA TLS Supported Groups
+                    section, under the <emphasis>Description</emphasis> field.</para>
                   <para role="param">Alias - optional [xs:string] </para>
                   <para role="text">The client-defined alias of the key.</para>
                 </listitem>
@@ -1484,16 +1822,21 @@
                   <para role="param">KeyID - [tas:KeyID]</para>
                   <para role="text"> The key ID of the key pair being generated.</para>
                   <para role="param">EstimatedCreationTime - [xs:duration]</para>
-                  <para role="text"> Best-effort estimation of how long the key generation will take.</para>
+                  <para role="text"> Best-effort estimation of how long the key generation will
+                    take.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
                 <term>faults</term>
                 <listitem>
-                  <para role="param">env:Receiver - ter:Action - ter:MaximumNumberOfKeysReached</para>
-                  <para role="text"> The keystore does not have enough storage space to store the key pair that has to be generated.</para>
-                  <para role="param">env:Sender - ter:InvalidArgVal - ter:UnsupportedEllipticCurve</para>
-                  <para role="text"> The specified elliptic curve is not supported by the device.</para>
+                  <para role="param">env:Receiver - ter:Action -
+                    ter:MaximumNumberOfKeysReached</para>
+                  <para role="text"> The keystore does not have enough storage space to store the
+                    key pair that has to be generated.</para>
+                  <para role="param">env:Sender - ter:InvalidArgVal -
+                    ter:UnsupportedEllipticCurve</para>
+                  <para role="text"> The specified elliptic curve is not supported by the
+                    device.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -1506,25 +1849,51 @@
           </section>
           <section>
             <title>UploadKeyPairInPKCS8</title>
-            <para>This operation uploads a key pair in a PKCS#8 data structure as specified in [RFC 5958, RFC 5959]. </para>
+            <para>This operation uploads a key pair in a PKCS#8 data structure as specified in [RFC
+              5958, RFC 5959]. </para>
             <para>If a passphrase is either directly provided or as ID reference to a previously
               uploaded passphrase, the device shall assume that the KeyPair parameter contains an
               EncryptedPrivateKeyInfo ASN.1 structure that is encrypted with the given passphrase.
               In case neither a passphrase nor a passphrase ID is provided the device shall assume
               that the KeyPair parameter contains a OneAsymmetricKey ASN.1 structure which contains
               both the private key and the corresponding public key. </para>
-            <para>If the supplied key pair cannot be processed by the device, the device shall produce an UnsupportedPublicKeyAlgorithm fault and shall not store the uploaded key pair in the keystore.</para>
-            <para>Key pairs are uniquely identified using key IDs. If a key pair exists in the keystore with the public key equal to the public key in the request and this key pair does not contain a private key, the device shall add the supplied private key to the existing key pair and return the ID of this key pair.</para>
-            <para>If a key pair exists in the keystore with the public key equal to the public key in the request and this key pair contains a private key, the device shall leave the key pair unchanged and return the ID of this key pair.</para>
-            <para>If the existing key pair does not have status <emphasis>ok</emphasis>, the device shall produce an InvalidKeyStatus fault and shall not modify the existing key pair.</para>
-            <para>If no key pair exists in the keystore with the public key equal to the public key in the request, the device shall generate a new key pair with the supplied private key and the supplied public key, status <emphasis>ok</emphasis> and the externally generated attribute set to <emphasis>true</emphasis>. Furthermore, the device shall return the ID of this key pair.</para>
-            <para>If a new key pair is created, the device shall assign the supplied alias to it. Otherwise, the device shall ignore an eventually supplied alias.</para>
-            <para>If decryption of the EncryptedPrivateKeyInfo failed, the device shall produce a DecryptionFailed fault and shall not store the uploaded key pair in the keystore.</para>
-            <para>If the device does not have enough storage capacity for storing the key pair that eventually has to be created, the device shall generate a maximum number of keys reached fault. Furthermore the device shall not generate a key pair.</para>
-            <para>If no passphrase exists under the ID specified by EncryptionPassphraseID, the device shall produce an invalid passphrase ID fault and shall not store the uploaded key pair in the keystore.</para>
-            <para>If the supplied PKCS#8 data structure cannot be processed by the device, the device shall produce a BadPKCS8File fault and shall not store the uploaded key pair in the keystore.</para>
-            <para>If the public key in the uploaded key pair does not match the uploaded private key, the device shall produce a PublicPrivateKeyMismatch fault and shall not store the uploaded key pair in the keystore.</para>
-            <para>If the command was successful, the device shall return the ID of the key pair in the keystore that contains the supplied public and private key.</para>
+            <para>If the supplied key pair cannot be processed by the device, the device shall
+              produce an UnsupportedPublicKeyAlgorithm fault and shall not store the uploaded key
+              pair in the keystore.</para>
+            <para>Key pairs are uniquely identified using key IDs. If a key pair exists in the
+              keystore with the public key equal to the public key in the request and this key pair
+              does not contain a private key, the device shall add the supplied private key to the
+              existing key pair and return the ID of this key pair.</para>
+            <para>If a key pair exists in the keystore with the public key equal to the public key
+              in the request and this key pair contains a private key, the device shall leave the
+              key pair unchanged and return the ID of this key pair.</para>
+            <para>If the existing key pair does not have status <emphasis>ok</emphasis>, the device
+              shall produce an InvalidKeyStatus fault and shall not modify the existing key
+              pair.</para>
+            <para>If no key pair exists in the keystore with the public key equal to the public key
+              in the request, the device shall generate a new key pair with the supplied private key
+              and the supplied public key, status <emphasis>ok</emphasis> and the externally
+              generated attribute set to <emphasis>true</emphasis>. Furthermore, the device shall
+              return the ID of this key pair.</para>
+            <para>If a new key pair is created, the device shall assign the supplied alias to it.
+              Otherwise, the device shall ignore an eventually supplied alias.</para>
+            <para>If decryption of the EncryptedPrivateKeyInfo failed, the device shall produce a
+              DecryptionFailed fault and shall not store the uploaded key pair in the
+              keystore.</para>
+            <para>If the device does not have enough storage capacity for storing the key pair that
+              eventually has to be created, the device shall generate a maximum number of keys
+              reached fault. Furthermore the device shall not generate a key pair.</para>
+            <para>If no passphrase exists under the ID specified by EncryptionPassphraseID, the
+              device shall produce an invalid passphrase ID fault and shall not store the uploaded
+              key pair in the keystore.</para>
+            <para>If the supplied PKCS#8 data structure cannot be processed by the device, the
+              device shall produce a BadPKCS8File fault and shall not store the uploaded key pair in
+              the keystore.</para>
+            <para>If the public key in the uploaded key pair does not match the uploaded private
+              key, the device shall produce a PublicPrivateKeyMismatch fault and shall not store the
+              uploaded key pair in the keystore.</para>
+            <para>If the command was successful, the device shall return the ID of the key pair in
+              the keystore that contains the supplied public and private key.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
@@ -1534,9 +1903,11 @@
                   <para role="param">Alias - optional [xs:string]</para>
                   <para role="text"> The client-defined alias of the key pair.</para>
                   <para role="param">EncryptionPassphraseID - optional [tas:PassphraseID]</para>
-                  <para role="text"> The ID of the passphrase to use for decrypting the uploaded key pair.</para>
+                  <para role="text"> The ID of the passphrase to use for decrypting the uploaded key
+                    pair.</para>
                   <para role="param">EncryptionPassphrase - optional [xs:string]</para>
-                  <para role="text"> The passphrase to use for decrypting the uploaded key pair.</para>
+                  <para role="text"> The passphrase to use for decrypting the uploaded key
+                    pair.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -1549,20 +1920,29 @@
               <varlistentry>
                 <term>faults</term>
                 <listitem>
-                  <para role="param">env:Receiver - ter:Action - ter:MaximumNumberOfKeysReached</para>
-                  <para role="text"> The device does not have enough storage space to store the key pair to be uploaded.</para>
+                  <para role="param">env:Receiver - ter:Action -
+                    ter:MaximumNumberOfKeysReached</para>
+                  <para role="text"> The device does not have enough storage space to store the key
+                    pair to be uploaded.</para>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:PassphraseID</para>
-                  <para role="text"> No passphrase is stored under the requested PassphraseID.</para>
+                  <para role="text"> No passphrase is stored under the requested
+                    PassphraseID.</para>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:DecryptionFailed</para>
                   <para role="text"> The given date could not be decrypted.</para>
-                  <para role="param">env:Sender - ter:InvalidArgVal - ter:UnsupportedPublicKeyAlgorithm</para>
-                  <para role="text"> The public key algorithm of the supplied key pair is not supported by the device.</para>
+                  <para role="param">env:Sender - ter:InvalidArgVal -
+                    ter:UnsupportedPublicKeyAlgorithm</para>
+                  <para role="text"> The public key algorithm of the supplied key pair is not
+                    supported by the device.</para>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:InvalidKeyStatus</para>
-                  <para role="text"> The key with the requested KeyID has an inappropriate status.</para>
+                  <para role="text"> The key with the requested KeyID has an inappropriate
+                    status.</para>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:BadPKCS8File</para>
-                  <para role="text"> The PKCS#8 data structure cannot be processed by the device.</para>
-                  <para role="param">env:Sender - ter:InvalidArgVal - ter:PublicPrivateKeyMismatch</para>
-                  <para role="text"> The supplied private key does not match the supplied public key.</para>
+                  <para role="text"> The PKCS#8 data structure cannot be processed by the
+                    device.</para>
+                  <para role="param">env:Sender - ter:InvalidArgVal -
+                    ter:PublicPrivateKeyMismatch</para>
+                  <para role="text"> The supplied private key does not match the supplied public
+                    key.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -1575,9 +1955,12 @@
           </section>
           <section xml:id="_Ref361388129">
             <title>GetKeyStatus</title>
-            <para>This operation returns the status of a key as defined in Sect. <xref linkend="_Ref353728108"/>.</para>
+            <para>This operation returns the status of a key as defined in Sect. <xref
+                linkend="_Ref353728108"/>.</para>
             <para>An ONVIF conformant device shall support this command.</para>
-            <para>Keys are uniquely identified using key IDs. If no key is stored under the requested key ID in the keystore, an InvalidKeyID fault is produced. Otherwise, the status of the key is returned.</para>
+            <para>Keys are uniquely identified using key IDs. If no key is stored under the
+              requested key ID in the keystore, an InvalidKeyID fault is produced. Otherwise, the
+              status of the key is returned.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
@@ -1590,7 +1973,8 @@
                 <term>response</term>
                 <listitem>
                   <para role="param">KeyStatus - [xs:string]</para>
-                  <para role="text"> Status of the requested key.  The value should be one of the values in the tas:KeyStatus enumeration.</para>
+                  <para role="text"> Status of the requested key. The value should be one of the
+                    values in the tas:KeyStatus enumeration.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -1611,15 +1995,22 @@
           <section>
             <title>GetPrivateKeyStatus (deprecated)</title>
             <para>This operation returns whether a key pair contains a private key.</para>
-            <para>Keys are uniquely identified using key IDs. If no key is stored under the requested key ID in the keystore, an invalid key ID fault shall be produced. If a key is stored under the requested key ID in the keystore, but this key is not a key pair, an invalid key type fault shall be produced.</para>
-            <para>Otherwise, this operation returns <emphasis>true</emphasis> if the key pair identified by the key ID contains a private key, and <emphasis>false</emphasis> otherwise.</para>
-            <para>This command is deprecated. Use GetAllKeys (see Sect. <xref linkend="_Ref415492349"/>) instead.</para>
+            <para>Keys are uniquely identified using key IDs. If no key is stored under the
+              requested key ID in the keystore, an invalid key ID fault shall be produced. If a key
+              is stored under the requested key ID in the keystore, but this key is not a key pair,
+              an invalid key type fault shall be produced.</para>
+            <para>Otherwise, this operation returns <emphasis>true</emphasis> if the key pair
+              identified by the key ID contains a private key, and <emphasis>false</emphasis>
+              otherwise.</para>
+            <para>This command is deprecated. Use GetAllKeys (see Sect. <xref
+                linkend="_Ref415492349"/>) instead.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
                 <listitem>
                   <para role="param">KeyID - [tas:KeyID]</para>
-                  <para role="text"> The ID of the key pair for which to return whether it contains a private key.</para>
+                  <para role="text"> The ID of the key pair for which to return whether it contains
+                    a private key.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -1635,7 +2026,8 @@
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:KeyID</para>
                   <para role="text"> No key is stored under the requested KeyID.</para>
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:InvalidKeyType</para>
-                  <para role="text"> The key stored in the keystore under the requested KeyID is of an invalid type.</para>
+                  <para role="text"> The key stored in the keystore under the requested KeyID is of
+                    an invalid type.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -1648,8 +2040,10 @@
           </section>
           <section xml:id="_Ref415492349">
             <title>GetAllKeys</title>
-            <para>This operation returns information about all keys that are stored in the device’s keystore.</para>
-            <para>This operation may be used, e.g., if a client lost track of which keys are present on the device.</para>
+            <para>This operation returns information about all keys that are stored in the device’s
+              keystore.</para>
+            <para>This operation may be used, e.g., if a client lost track of which keys are present
+              on the device.</para>
             <para>If no key is stored on the device, an empty list is returned. An ONVIF conformant
               device shall support this command.</para>
             <variablelist role="op">
@@ -1663,7 +2057,8 @@
                 <term>response</term>
                 <listitem>
                   <para role="param">KeyAttribute - optional, unbounded [tas:KeyAttribute]</para>
-                  <para role="text"> List of key attributes.  Each attribute contains information about a key in the keystore.</para>
+                  <para role="text"> List of key attributes. Each attribute contains information
+                    about a key in the keystore.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -1684,14 +2079,23 @@
             <title>DeleteKey</title>
             <para>This operation deletes a key from the device’s keystore. An ONVIF conformant
               device shall support this command.</para>
-            <para>Keys are uniquely identified using key IDs. If no key is stored under the requested key ID in the keystore, a device shall produce an InvalidArgVal fault. If a reference exists for the specified key, a device shall produce the corresponding fault and shall not delete the key. If there is a key under the requested key ID stored in the keystore and the key could not be deleted, a device shall produce a KeyDeletion fault. If the key has the status <emphasis>generating</emphasis>, a device shall abort the generation of the key and delete from the keystore all data generated for this key.</para>
-            <para>After a key is successfully deleted, the device may assign its former ID to other keys.</para>
+            <para>Keys are uniquely identified using key IDs. If no key is stored under the
+              requested key ID in the keystore, a device shall produce an InvalidArgVal fault. If a
+              reference exists for the specified key, a device shall produce the corresponding fault
+              and shall not delete the key. If there is a key under the requested key ID stored in
+              the keystore and the key could not be deleted, a device shall produce a KeyDeletion
+              fault. If the key has the status <emphasis>generating</emphasis>, a device shall abort
+              the generation of the key and delete from the keystore all data generated for this
+              key.</para>
+            <para>After a key is successfully deleted, the device may assign its former ID to other
+              keys.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
                 <listitem>
                   <para role="param">KeyID - [tas:KeyID]</para>
-                  <para role="text"> The ID of the key that is to be deleted from the keystore.</para>
+                  <para role="text"> The ID of the key that is to be deleted from the
+                    keystore.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -1724,14 +2128,36 @@
           <title>Certificate Management</title>
           <section>
             <title>CreatePKCS10CSR</title>
-            <para>This operation generates a DER-encoded PKCS#10 v1.7 certification request (sometimes also called certificate signing request or CSR) as specified in RFC 2986 for a public key on the device. </para>
-            <para>The key pair that contains the public key for which a certification request shall be produced is specified by its key ID. If no key is stored under the requested KeyID or the key specified by the requested KeyID is not an asymmetric key pair, an invalid key ID fault shall be produced and no CSR shall be generated.</para>
-            <para>The subject parameter describes the entity that the public key belongs to. Additional attributes can be included in the attribute parameter.</para>
-            <para>Distinguished name attribute values shall be supplied either in UTF-8 or in hexadecimal form as specified in RFC 4514.</para>
-            <para>If the distinguished name attribute value is supplied in hexadecimal form, the device shall encode the attribute in the format given in the hexadecimal format.</para>
-            <para>If the distinguished name attribute value is supplied in UTF-8 and the attribute value has a uniquely defined encoding (e.g., CountryName is defined as PrintableString), the device shall encode the attribute as the defined encoding. Otherwise, the device shall encode the attribute value as UTF-8.</para>
-            <para>The signature algorithm parameter determines which signature algorithm shall be used for signing the certification request with the public key specified by the key ID parameter. If the specified signature algorithm is not supported by the device, an UnsupportedSignatureAlgorithm fault shall be produced and no CSR shall be generated. If the public key identified by the requested Key ID is an invalid input to the specified signature algorithm, a KeySignatureAlgorithmMismatch fault shall be produced and no CSR shall be generated. If the specified subject is invalid or incomplete, a Subject invalid fault shall be produced and no CSR shall be created. If an attribute is invalid or incomplete, an Attribute invalid fault shall be produced and no CSR shall be generated.</para>
-            <para>If the key pair does not have status <emphasis>ok</emphasis>, a device shall produce an InvalidKeyStatus fault and no CSR shall be generated.</para>
+            <para>This operation generates a DER-encoded PKCS#10 v1.7 certification request
+              (sometimes also called certificate signing request or CSR) as specified in RFC 2986
+              for a public key on the device. </para>
+            <para>The key pair that contains the public key for which a certification request shall
+              be produced is specified by its key ID. If no key is stored under the requested KeyID
+              or the key specified by the requested KeyID is not an asymmetric key pair, an invalid
+              key ID fault shall be produced and no CSR shall be generated.</para>
+            <para>The subject parameter describes the entity that the public key belongs to.
+              Additional attributes can be included in the attribute parameter.</para>
+            <para>Distinguished name attribute values shall be supplied either in UTF-8 or in
+              hexadecimal form as specified in RFC 4514.</para>
+            <para>If the distinguished name attribute value is supplied in hexadecimal form, the
+              device shall encode the attribute in the format given in the hexadecimal
+              format.</para>
+            <para>If the distinguished name attribute value is supplied in UTF-8 and the attribute
+              value has a uniquely defined encoding (e.g., CountryName is defined as
+              PrintableString), the device shall encode the attribute as the defined encoding.
+              Otherwise, the device shall encode the attribute value as UTF-8.</para>
+            <para>The signature algorithm parameter determines which signature algorithm shall be
+              used for signing the certification request with the public key specified by the key ID
+              parameter. If the specified signature algorithm is not supported by the device, an
+              UnsupportedSignatureAlgorithm fault shall be produced and no CSR shall be generated.
+              If the public key identified by the requested Key ID is an invalid input to the
+              specified signature algorithm, a KeySignatureAlgorithmMismatch fault shall be produced
+              and no CSR shall be generated. If the specified subject is invalid or incomplete, a
+              Subject invalid fault shall be produced and no CSR shall be created. If an attribute
+              is invalid or incomplete, an Attribute invalid fault shall be produced and no CSR
+              shall be generated.</para>
+            <para>If the key pair does not have status <emphasis>ok</emphasis>, a device shall
+              produce an InvalidKeyStatus fault and no CSR shall be generated.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
@@ -1741,7 +2167,8 @@
                   <para role="param">KeyID - [tas:KeyID]</para>
                   <para role="text"> The ID of the key for which the CSR shall be created.</para>
                   <para role="param">CSRAttribute - optional, unbounded [tas:CSRAttribute]</para>
-                  <para role="text"> List of CSR attributes.  Each attribute contains an attribute to be included in the CSR.</para>
+                  <para role="text"> List of CSR attributes. Each attribute contains an attribute to
+                    be included in the CSR.</para>
                   <para role="param">SignatureAlgorithm - [tas:AlgorithmIdentifier] </para>
                   <para role="text">The signature algorithm to be used to sign the CSR.</para>
                 </listitem>
@@ -1757,15 +2184,21 @@
                 <term>faults</term>
                 <listitem>
                   <para role="param">ter:Receiver - ter:Action - CSRCreationFailed</para>
-                  <para role="text"> The generation of the PKCS#10 certification request failed.</para>
+                  <para role="text"> The generation of the PKCS#10 certification request
+                    failed.</para>
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:KeyID</para>
                   <para role="text"> No key is stored under the requested KeyID.</para>
-                  <para role="param">ter:Sender - ter:InvalidArgVal - ter:UnsupportedSignatureAlgorithm</para>
-                  <para role="text"> The specified signature algorithm is not supported by the device.</para>
-                  <para role="param">ter:Sender - ter:InvalidArgVal - ter:KeySignatureAlgorithmMismatch</para>
-                  <para role="text"> The specified public key is an invalid input to the specified signature algorithm.</para>
+                  <para role="param">ter:Sender - ter:InvalidArgVal -
+                    ter:UnsupportedSignatureAlgorithm</para>
+                  <para role="text"> The specified signature algorithm is not supported by the
+                    device.</para>
+                  <para role="param">ter:Sender - ter:InvalidArgVal -
+                    ter:KeySignatureAlgorithmMismatch</para>
+                  <para role="text"> The specified public key is an invalid input to the specified
+                    signature algorithm.</para>
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:InvalidKeyStatus</para>
-                  <para role="text"> The key with the requested KeyID has an inappropriate status.</para>
+                  <para role="text"> The key with the requested KeyID has an inappropriate
+                    status.</para>
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:InvalidSubject</para>
                   <para role="text"> The specified subject is invalid or incomplete.</para>
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:InvalidAttribute</para>
@@ -1782,41 +2215,90 @@
           </section>
           <section>
             <title>CreateSelfSignedCertificate</title>
-            <para>This operation generates for a public key on the device a self-signed X.509 certificate that complies to RFC 5280. </para>
-            <para>The X509Version parameter specifies the version of X.509 that the generated certificate shall comply to. A device that supports this command shall support the generation of X.509v3 certificates as specified in RFC 5280 and may additionally be able to handle other X.509 certificate formats as indicated by the X.509Versions capability. If no X509Version is specified in the request, the device shall produce an X.509v3 certificate.</para>
-            <para>The key pair that contains the public key for which a self-signed certificate shall be produced is specified by its key pair ID. The subject parameter describes the entity that the public key belongs to.</para>
-            <para>If the key pair does not have status <emphasis>ok</emphasis>, a device shall produce an InvalidKeyStatus fault and no certificate shall be generated.</para>
-            <para>If the specified subject is invalid or incomplete, an InvalidSubject fault shall be produced and no certificate shall be created.</para>
-            <para>The notValidBefore parameter specifies at which point in time the validity period of the generated certificate shall begin. If this parameter is not specified in the request, the device shall use its current time or a time before its current time as starting point of the validity period. The notValidAfter parameter specifies at which point in time the validity period of the generated certificate shall end. If this parameter is not specified in the request, the device shall assign the GeneralizedTime value of 99991231235959Z as specified in RFC 5280 to the notValidAfter parameter. If the notValidBefore parameter is invalid, an invalid DateTime fault shall be produced and no certificate shall be generated. If the notValidAfter parameter is invalid, an invalid DateTime fault shall be produced and no certificate shall be generated.</para>
-            <para>The signature algorithm parameter determines which signature algorithm shall be used for signing the certification request with the public key specified by the key ID parameter.</para>
-            <para>The Extensions parameter specifies potential X509v3 extensions that shall be contained in the certificate. A device that supports this command shall support the extensions that are defined in RFC5280, Sect. 4.2 as mandatory for CAs that issue self-signed certificates.</para>
-            <para>Distinguished name attribute values shall be supplied either in UTF-8 or in hexadecimal form as specified in RFC 4514.</para>
-            <para>If the distinguished name attribute value is supplied in hexadecimal form, the device shall encode the attribute in the format given in the hexadecimal format.</para>
-            <para>If the distinguished name attribute value is supplied in UTF-8 and the attribute value has a uniquely defined encoding (e.g., CountryName is defined as PrintableString), the device shall encode the attribute as the defined encoding. Otherwise, the device shall encode the attribute value as UTF-8.</para>
-            <para>RFC 5280, Sect. 4.1.2.2 mandates that the certificate serial numbers be unique for each certificate issued by a given issuer (a CA). Since the subject is equal to the issuer in a self-signed certificate, the serial number shall be unique for each self-signed certificate that the device issues for a given subject.</para>
-            <para>The generated certificate shall not contain a unique identifier as specified in RFC 5280, Sect. 4.1.2.8. The device shall not mark the generated certificate as trusted.</para>
-            <para>Certificates are uniquely identified using certificate IDs. If the command was successful, the device generates a new ID for the generated certificate and returns this ID.</para>
-            <para>If the device does not have enough storage capacity for storing the certificate to be created, the maximum number of certificates reached fault shall be produced and no certificate shall be generated.</para>
+            <para>This operation generates for a public key on the device a self-signed X.509
+              certificate that complies to RFC 5280. </para>
+            <para>The X509Version parameter specifies the version of X.509 that the generated
+              certificate shall comply to. A device that supports this command shall support the
+              generation of X.509v3 certificates as specified in RFC 5280 and may additionally be
+              able to handle other X.509 certificate formats as indicated by the X.509Versions
+              capability. If no X509Version is specified in the request, the device shall produce an
+              X.509v3 certificate.</para>
+            <para>The key pair that contains the public key for which a self-signed certificate
+              shall be produced is specified by its key pair ID. The subject parameter describes the
+              entity that the public key belongs to.</para>
+            <para>If the key pair does not have status <emphasis>ok</emphasis>, a device shall
+              produce an InvalidKeyStatus fault and no certificate shall be generated.</para>
+            <para>If the specified subject is invalid or incomplete, an InvalidSubject fault shall
+              be produced and no certificate shall be created.</para>
+            <para>The notValidBefore parameter specifies at which point in time the validity period
+              of the generated certificate shall begin. If this parameter is not specified in the
+              request, the device shall use its current time or a time before its current time as
+              starting point of the validity period. The notValidAfter parameter specifies at which
+              point in time the validity period of the generated certificate shall end. If this
+              parameter is not specified in the request, the device shall assign the GeneralizedTime
+              value of 99991231235959Z as specified in RFC 5280 to the notValidAfter parameter. If
+              the notValidBefore parameter is invalid, an invalid DateTime fault shall be produced
+              and no certificate shall be generated. If the notValidAfter parameter is invalid, an
+              invalid DateTime fault shall be produced and no certificate shall be generated.</para>
+            <para>The signature algorithm parameter determines which signature algorithm shall be
+              used for signing the certification request with the public key specified by the key ID
+              parameter.</para>
+            <para>The Extensions parameter specifies potential X509v3 extensions that shall be
+              contained in the certificate. A device that supports this command shall support the
+              extensions that are defined in RFC5280, Sect. 4.2 as mandatory for CAs that issue
+              self-signed certificates.</para>
+            <para>Distinguished name attribute values shall be supplied either in UTF-8 or in
+              hexadecimal form as specified in RFC 4514.</para>
+            <para>If the distinguished name attribute value is supplied in hexadecimal form, the
+              device shall encode the attribute in the format given in the hexadecimal
+              format.</para>
+            <para>If the distinguished name attribute value is supplied in UTF-8 and the attribute
+              value has a uniquely defined encoding (e.g., CountryName is defined as
+              PrintableString), the device shall encode the attribute as the defined encoding.
+              Otherwise, the device shall encode the attribute value as UTF-8.</para>
+            <para>RFC 5280, Sect. 4.1.2.2 mandates that the certificate serial numbers be unique for
+              each certificate issued by a given issuer (a CA). Since the subject is equal to the
+              issuer in a self-signed certificate, the serial number shall be unique for each
+              self-signed certificate that the device issues for a given subject.</para>
+            <para>The generated certificate shall not contain a unique identifier as specified in
+              RFC 5280, Sect. 4.1.2.8. The device shall not mark the generated certificate as
+              trusted.</para>
+            <para>Certificates are uniquely identified using certificate IDs. If the command was
+              successful, the device generates a new ID for the generated certificate and returns
+              this ID.</para>
+            <para>If the device does not have enough storage capacity for storing the certificate to
+              be created, the maximum number of certificates reached fault shall be produced and no
+              certificate shall be generated.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
                 <listitem>
                   <para role="param">X509Version - optional [xs:positiveInteger]</para>
-                  <para role="text"> The X.509 version that the generated certificate shall comply to.</para>
+                  <para role="text"> The X.509 version that the generated certificate shall comply
+                    to.</para>
                   <para role="param">Subject - [tas:DistinguishedName]</para>
-                  <para role="text"> Distinguished name of the entity that the certificate shall belong to.</para>
+                  <para role="text"> Distinguished name of the entity that the certificate shall
+                    belong to.</para>
                   <para role="param">KeyID - [tas:KeyID]</para>
-                  <para role="text"> The ID of the key for which the certificate shall be created.</para>
+                  <para role="text"> The ID of the key for which the certificate shall be
+                    created.</para>
                   <para role="param">Alias - optional [xs:string]</para>
-                  <para role="text"> The client-defined alias of the certificate to be created.</para>
+                  <para role="text"> The client-defined alias of the certificate to be
+                    created.</para>
                   <para role="param">notValidBefore - optional [xs:dateTime]</para>
-                  <para role="text"> The X.509 not valid before information to be included in the certificate.  Defaults to a time equal to or before the device’s current time.</para>
+                  <para role="text"> The X.509 not valid before information to be included in the
+                    certificate. Defaults to a time equal to or before the device’s current
+                    time.</para>
                   <para role="param">notValidAfter - optional [xs:dateTime]</para>
-                  <para role="text"> The X.509 not valid after information to be included in the certificate.  Defaults to the time 99991231235959Z as specified in RFC 5280.</para>
+                  <para role="text"> The X.509 not valid after information to be included in the
+                    certificate. Defaults to the time 99991231235959Z as specified in RFC
+                    5280.</para>
                   <para role="param">SignatureAlgorithm - [tas:AlgorithmIdentifier]</para>
-                  <para role="text"> The signature algorithm to be used for signing the certificate.</para>
+                  <para role="text"> The signature algorithm to be used for signing the
+                    certificate.</para>
                   <para role="param">Extension - optional, unbounded [tas:X509v3Extension]</para>
-                  <para role="text"> List of X.509v3 extensions to be included in the certificate.</para>
+                  <para role="text"> List of X.509v3 extensions to be included in the
+                    certificate.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -1829,22 +2311,34 @@
               <varlistentry>
                 <term>faults</term>
                 <listitem>
-                  <para role="param">ter:Receiver - ter:Action - ter:CertificateCreationFailed</para>
+                  <para role="param">ter:Receiver - ter:Action -
+                    ter:CertificateCreationFailed</para>
                   <para role="text"> The generation of the self-signed certificate failed.</para>
-                  <para role="param">ter:Receiver - ter:Action - ter:MaximumNumberOfCertificatesReached</para>
-                  <para role="text"> The device does not have enough storage space to store the certificate to be created.</para>
-                  <para role="param">ter:Sender - ter:InvalidArgVal - ter:UnsupportedX509Version</para>
-                  <para role="text"> The specified X.509 version is not supported by the device.</para>
+                  <para role="param">ter:Receiver - ter:Action -
+                    ter:MaximumNumberOfCertificatesReached</para>
+                  <para role="text"> The device does not have enough storage space to store the
+                    certificate to be created.</para>
+                  <para role="param">ter:Sender - ter:InvalidArgVal -
+                    ter:UnsupportedX509Version</para>
+                  <para role="text"> The specified X.509 version is not supported by the
+                    device.</para>
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:KeyID</para>
                   <para role="text"> No key is stored under the requested KeyID.</para>
-                  <para role="param">ter:Sender - ter:InvalidArgVal - ter:UnsupportedSignatureAlgorithm</para>
-                  <para role="text">The specified signature algorithm is not supported by the device.</para>
-                  <para role="param">ter:Sender - ter:InvalidArgVal - ter:KeySignatureAlgorithmMismatch</para>
-                  <para role="text"> The specified public key is an invalid input to the specified signature algorithm.</para>
-                  <para role="param">ter:Sender - ter:InvalidArgVal - ter:X509VersionExtensionsMismatch</para>
-                  <para role="text"> The request contains extensions which are not supported by the X509Version in the request.</para>
+                  <para role="param">ter:Sender - ter:InvalidArgVal -
+                    ter:UnsupportedSignatureAlgorithm</para>
+                  <para role="text">The specified signature algorithm is not supported by the
+                    device.</para>
+                  <para role="param">ter:Sender - ter:InvalidArgVal -
+                    ter:KeySignatureAlgorithmMismatch</para>
+                  <para role="text"> The specified public key is an invalid input to the specified
+                    signature algorithm.</para>
+                  <para role="param">ter:Sender - ter:InvalidArgVal -
+                    ter:X509VersionExtensionsMismatch</para>
+                  <para role="text"> The request contains extensions which are not supported by the
+                    X509Version in the request.</para>
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:InvalidKeyStatus</para>
-                  <para role="text"> The key with the requested KeyID has an inappropriate status.</para>
+                  <para role="text"> The key with the requested KeyID has an inappropriate
+                    status.</para>
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:InvalidSubject</para>
                   <para role="text"> The specified subject is invalid or incomplete.</para>
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:InvalidDateTime</para>
@@ -1861,44 +2355,88 @@
           </section>
           <section>
             <title>UploadCertificate</title>
-            <para>This operation uploads an X.509 certificate as specified by RFC 5280 in DER encoding and the public key in the certificate to a device’s keystore. A device that supports this command shall be able to handle X.509v3 certificates as specified in RFC 5280 and may additionally be able to handle other X.509 certificate formats as indicated by the X.509Versions capability. </para>
-            <para>Certificates are uniquely identified using certificate IDs, and key pairs are uniquely identified using key IDs. The device shall generate a new certificate ID for the uploaded certificate.</para>
-            <para>Certain certificate usages, e.g. TLS server authentication, require the private key that corresponds to the public key in the certificate to be present in the keystore. In such cases, the client may indicate that it expects the device to produce a fault if the matching private key for the uploaded certificate is not present in the keystore by setting the PrivateKeyRequired argument in the upload request to <emphasis>true</emphasis>.</para>
+            <para>This operation uploads an X.509 certificate as specified by RFC 5280 in DER
+              encoding and the public key in the certificate to a device’s keystore. A device that
+              supports this command shall be able to handle X.509v3 certificates as specified in RFC
+              5280 and may additionally be able to handle other X.509 certificate formats as
+              indicated by the X.509Versions capability. </para>
+            <para>Certificates are uniquely identified using certificate IDs, and key pairs are
+              uniquely identified using key IDs. The device shall generate a new certificate ID for
+              the uploaded certificate.</para>
+            <para>Certain certificate usages, e.g. TLS server authentication, require the private
+              key that corresponds to the public key in the certificate to be present in the
+              keystore. In such cases, the client may indicate that it expects the device to produce
+              a fault if the matching private key for the uploaded certificate is not present in the
+              keystore by setting the PrivateKeyRequired argument in the upload request to
+                <emphasis>true</emphasis>.</para>
             <para>The uploaded certificate has to be linked to a key pair in the keystore.</para>
-            <para>If no private key is required for the public key in the certificate and a key pair exists in the keystore with a public key equal to the public key in the certificate, the uploaded certificate is linked to the key pair identified by the supplied key ID by adding a reference from the certificate to the key pair.</para>
-            <para>If no private key is required for the public key in the certificate and no key pair exists with the public key equal to the public key in the certificate, a new key pair with status <emphasis>ok </emphasis>is created with the public key from the certificate, and this key pair is linked to the uploaded certificate by adding a reference from the certificate to the key pair.</para>
-            <para>If a private key is required for the public key in the certificate, and a key pair exists in the keystore with a private key that matches the public key in the certificate, the uploaded certificate is linked to this key pair by adding a reference from the certificate to the key pair. If a private key is required for the public key and no such keypair exists in the keystore, then NoMatchingPrivateKey fault shall be produced and the certificate shall not be stored in the keystore.</para>
+            <para>If no private key is required for the public key in the certificate and a key pair
+              exists in the keystore with a public key equal to the public key in the certificate,
+              the uploaded certificate is linked to the key pair identified by the supplied key ID
+              by adding a reference from the certificate to the key pair.</para>
+            <para>If no private key is required for the public key in the certificate and no key
+              pair exists with the public key equal to the public key in the certificate, a new key
+              pair with status <emphasis>ok </emphasis>is created with the public key from the
+              certificate, and this key pair is linked to the uploaded certificate by adding a
+              reference from the certificate to the key pair.</para>
+            <para>If a private key is required for the public key in the certificate, and a key pair
+              exists in the keystore with a private key that matches the public key in the
+              certificate, the uploaded certificate is linked to this key pair by adding a reference
+              from the certificate to the key pair. If a private key is required for the public key
+              and no such keypair exists in the keystore, then NoMatchingPrivateKey fault shall be
+              produced and the certificate shall not be stored in the keystore.</para>
             <para>The device shall assign the supplied Alias to the uploaded certificate.</para>
-            <para>If a new key pair is generated, the device shall assign the supplied KeyAlias to it. Otherwise, the device shall ignore an eventually supplied KeyAlias.</para>
-            <para>How the link between the uploaded certificate and a key pair is established is illustrated in <xref linkend="_Ref338934863"/>.</para>
+            <para>If a new key pair is generated, the device shall assign the supplied KeyAlias to
+              it. Otherwise, the device shall ignore an eventually supplied KeyAlias.</para>
+            <para>How the link between the uploaded certificate and a key pair is established is
+              illustrated in <xref linkend="_Ref338934863"/>.</para>
             <para>An ONVIF compliant device shall support this command.</para>
             <figure xml:id="_Ref338934863">
-              <title>Link establishment between certificate and key pair for Upload Certificate</title>
+              <title>Link establishment between certificate and key pair for Upload
+                Certificate</title>
               <mediaobject>
                 <imageobject>
                   <imagedata fileref="media/Security/image3.png" contentwidth="159.70mm"/>
                 </imageobject>
               </mediaobject>
             </figure>
-            <para>If the key pair that the certificate shall be linked to does not have status <emphasis>ok</emphasis>, an InvalidKeyStatus fault is produced, and the uploaded certificate is not stored in the keystore.</para>
-            <para>If the signature algorithm that the signature of the supplied certificate is based on is not supported by the device, the device shall generate an UnsupportedSignatureAlgorithm fault and shall not store the uploaded certificate nor the contained public key in the keystore.</para>
-            <para>If the device cannot process the uploaded certificate, a BadCertificate fault is produced and neither the uploaded certificate nor the public key are stored in the device’s keystore. The BadCertificate fault shall not be produced based on the mere fact that the device’s current time lies outside the interval defined by the notBefore and notAfter fields as specified by RFC 5280, Sect. 4.1.</para>
+            <para>If the key pair that the certificate shall be linked to does not have status
+                <emphasis>ok</emphasis>, an InvalidKeyStatus fault is produced, and the uploaded
+              certificate is not stored in the keystore.</para>
+            <para>If the signature algorithm that the signature of the supplied certificate is based
+              on is not supported by the device, the device shall generate an
+              UnsupportedSignatureAlgorithm fault and shall not store the uploaded certificate nor
+              the contained public key in the keystore.</para>
+            <para>If the device cannot process the uploaded certificate, a BadCertificate fault is
+              produced and neither the uploaded certificate nor the public key are stored in the
+              device’s keystore. The BadCertificate fault shall not be produced based on the mere
+              fact that the device’s current time lies outside the interval defined by the notBefore
+              and notAfter fields as specified by RFC 5280, Sect. 4.1.</para>
             <para>The device shall not mark the uploaded certificate as trusted.</para>
-            <para>If the device does not have enough storage capacity for storing the certificate to be uploaded, the maximum number of certificates reached fault shall be produced and no certificate shall be uploaded.</para>
-            <para>If the device does not have enough storage capacity for storing the key pair that eventually has to be created, the device shall generate a maximum number of keys reached fault. Furthermore the device shall not generate a key pair and no certificate shall be stored.</para>
-            <para>If the command was successful, the device returns the ID of the uploaded certificate and the ID of the key pair that contains the public key in the certificate.</para>
+            <para>If the device does not have enough storage capacity for storing the certificate to
+              be uploaded, the maximum number of certificates reached fault shall be produced and no
+              certificate shall be uploaded.</para>
+            <para>If the device does not have enough storage capacity for storing the key pair that
+              eventually has to be created, the device shall generate a maximum number of keys
+              reached fault. Furthermore the device shall not generate a key pair and no certificate
+              shall be stored.</para>
+            <para>If the command was successful, the device returns the ID of the uploaded
+              certificate and the ID of the key pair that contains the public key in the
+              certificate.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
                 <listitem>
                   <para role="param">Certificate - [tas:Base64DERencodedASN1Value] </para>
-                  <para role="text">The base64-encoded DER representation of the X.509 certificate to be uploaded.</para>
+                  <para role="text">The base64-encoded DER representation of the X.509 certificate
+                    to be uploaded.</para>
                   <para role="param">Alias - optional [xs:string]</para>
                   <para role="text"> The client-defined alias of the certificate.</para>
                   <para role="param">KeyAlias - optional [xs:string]</para>
                   <para role="text"> The client-defined alias of the key pair.</para>
                   <para role="param">PrivateKeyRequired - optional [xs:boolean]</para>
-                  <para role="text"> Indicates if the device shall verify that a matching key pair with a private key exists in the keystore.</para>
+                  <para role="text"> Indicates if the device shall verify that a matching key pair
+                    with a private key exists in the keystore.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -1907,24 +2445,35 @@
                   <para role="param">CertificateID - [tas:CertificateID]</para>
                   <para role="text"> The ID of the uploaded certificate.</para>
                   <para role="param">KeyID - [tas:KeyID]</para>
-                  <para role="text"> The ID of the key that the uploaded certificate certifies.</para>
+                  <para role="text"> The ID of the key that the uploaded certificate
+                    certifies.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
                 <term>faults</term>
                 <listitem>
-                  <para role="param">ter:Receiver - ter:Action - ter:MaximumNumberOfCertificatesReached</para>
-                  <para role="text"> The device does not have enough storage space to store the certificate to be uploaded.</para>
-                  <para role="param">ter:Receiver - ter:Action - ter:MaximumNumberOfKeysReached</para>
-                  <para role="text"> The device does not have enough storage space to store the key pair to be uploaded.</para>
+                  <para role="param">ter:Receiver - ter:Action -
+                    ter:MaximumNumberOfCertificatesReached</para>
+                  <para role="text"> The device does not have enough storage space to store the
+                    certificate to be uploaded.</para>
+                  <para role="param">ter:Receiver - ter:Action -
+                    ter:MaximumNumberOfKeysReached</para>
+                  <para role="text"> The device does not have enough storage space to store the key
+                    pair to be uploaded.</para>
                   <para role="param">ter:Receiver - ter:Action - ter:NoMatchingPrivateKey </para>
-                  <para role="text">The keystore does not contain a key pair with a private key that matches the public key in the uploaded certificate.</para>
+                  <para role="text">The keystore does not contain a key pair with a private key that
+                    matches the public key in the uploaded certificate.</para>
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:BadCertificate </para>
-                  <para role="text">The supplied certificate file cannot be processed by the device.</para>
-                  <para role="param">ter:Sender - ter:InvalidArgVal - ter:UnsupportedPublicKeyAlgorithm</para>
-                  <para role="text"> The public key algorithm of the public key in the certificate is not supported by the device.</para>
-                  <para role="param">ter:Sender - ter:InvalidArgVal - ter:UnsupportedSignatureAlgorithm</para>
-                  <para role="text"> The specified signature algorithm is not supported by the device.</para>
+                  <para role="text">The supplied certificate file cannot be processed by the
+                    device.</para>
+                  <para role="param">ter:Sender - ter:InvalidArgVal -
+                    ter:UnsupportedPublicKeyAlgorithm</para>
+                  <para role="text"> The public key algorithm of the public key in the certificate
+                    is not supported by the device.</para>
+                  <para role="param">ter:Sender - ter:InvalidArgVal -
+                    ter:UnsupportedSignatureAlgorithm</para>
+                  <para role="text"> The specified signature algorithm is not supported by the
+                    device.</para>
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:InvalidKeyStatus</para>
                   <para role="text"> The key pair has an inappropriate status.</para>
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:Duplicate</para>
@@ -1941,77 +2490,170 @@
           </section>
           <section>
             <title>UploadCertificateWithPrivateKeyInPKCS12</title>
-            <para>This operation uploads a certification path consisting of X.509 certificates as specified by RFC 5280 in DER encoding along with a private key to a device’s keystore. Certificates and private key are supplied in the form of a PKCS#12 file as specified in PKCS#12.</para>
-            <para>The device shall support PKCS#12 files that contain the following safe bags:</para>
+            <para>This operation uploads a certification path consisting of X.509 certificates as
+              specified by RFC 5280 in DER encoding along with a private key to a device’s keystore.
+              Certificates and private key are supplied in the form of a PKCS#12 file as specified
+              in PKCS#12.</para>
+            <para>The device shall support PKCS#12 files that contain the following safe
+              bags:</para>
             <itemizedlist>
               <listitem>
                 <para>one or more instances of CertBag PKCS#12, Sect. 4.2.3</para>
               </listitem>
               <listitem>
-                <para>either exactly one instance of KeyBag PKCS#12, Sect. 4.3.1 or exactly one instance of PKCS8ShroudedKeyBag PKCS#12, Sect. 4.2.2.</para>
+                <para>either exactly one instance of KeyBag PKCS#12, Sect. 4.3.1 or exactly one
+                  instance of PKCS8ShroudedKeyBag PKCS#12, Sect. 4.2.2.</para>
               </listitem>
             </itemizedlist>
-            <para>If the IgnoreAdditionalCertificates parameter has the value <emphasis>true</emphasis>, the device shall behave as if the client had supplied only the first CertBag in the sequence of CertBag instances.</para>
-            <para>The device shall support PKCS#12 passphrase integrity mode for integrity protection of the PKCS#12 PFX as specified in PKCS#12, Sect. 4. The device shall support PKCS8ShroudedKeyBags that are encrypted with the same passphrase as the CertBag instances.</para>
-            <para>If an integrity passphrase ID is supplied, the device shall use the corresponding passphrase in the keystore to check the integrity of the supplied PKCS#12 PFX. If an integrity passphrase ID is supplied, but the supplied PKCS#12 PFX has no integrity protection, the device shall produce a BadPKCS12File fault and shall not store the uploaded certificates nor the uploaded key pair in the keystore.</para>
-            <para>If an encryption passphrase ID is supplied, the device shall use the corresponding passphrase in the keystore to decrypt the PKCS8ShroudedKeyBag and the CertBag instances.</para>
-            <para>If an EncryptionPassphraseID is supplied, but a CertBag is not encrypted, the device shall ignore the supplied EncryptionPassphraseID when processing this CertBag. If an EncryptionPassphraseID is supplied, but a KeyBag is provided instead of a PKCS8ShroudedKeyBag, the device shall ignore the supplied EncryptionPassphraseID when processing the KeyBag.</para>
-            <para>If a passphrase is supplied, the device shall ignore an eventually supplied integrity passphrase ID and an eventually supplied encryption passphrase ID, and the device shall use the supplied passphrase to check the integrity of the PKCS#12 PFX and to decrypt the PKCS8ShroudedKeyBag and the CertBag instances. If a passphrase is supplied, but a CertBag is not encrypted, the device shall ignore the supplied passphrase when processing this CertBag. If a passphrase is supplied, but a KeyBag is supplied instead of a PKCS8ShroudedKeyBag, the device shall ignore the supplied passphrase when processing the KeyBag.</para>
-            <para>If decryption of either the PKCS8ShroudedKeyBag or an encrypted CertBag failed, the device shall produce a DecryptionFailed fault and shall not store the uploaded certificates nor key pair in the keystore.</para>
-            <para>If the signature algorithm of a supplied certificate is not supported by the device, the device shall produce an UnsupportedSignatureAlgorithm fault and shall not upload a certificate nor key pair.</para>
-            <para>If the supplied key pair cannot be processed by the device, the device shall produce an UnsupportedPublicKeyAlgorithm fault and shall not store the uploaded key pair nor the uploaded certificates in the keystore.</para>
-            <para>Certificates are uniquely identified using certificate IDs. The device shall store the uploaded certificates in the keystore and generate a new certificate ID for each of the uploaded certificates.</para>
-            <para>Certification paths are uniquely identified using certification path IDs. The device shall create a certification path from the uploaded certificates. In this certification path, the certificates shall appear in the same order as in the PKCS#12 file. The device shall generate a new certification path ID for the created certification path and assign the eventually supplied CertificationPathAlias to the created certification path.</para>
-            <para>The signature of each certificate in the sequence of uploaded certificates except for the last one shall be verifiable with the public key contained in the next certificate in the sequence. If there is a certificate in the request other than the last certificate for which the signature cannot be verified with the public key in the next certificate, the device shall produce an invalid certification path fault and shall not store the uploaded certificates nor uploaded private key in the keystore.</para>
-            <para>If the device cannot process one of the uploaded certificates, it shall produce a BadCertificate fault and neither store the uploaded certificates nor private key in the keystore. The BadCertificate fault shall not be produced based on the mere fact that the device’s current time lies outside the interval defined by the notBefore and notAfter fields as specified by RFC 5280, Sect. 4.1.</para>
+            <para>If the IgnoreAdditionalCertificates parameter has the value
+                <emphasis>true</emphasis>, the device shall behave as if the client had supplied
+              only the first CertBag in the sequence of CertBag instances.</para>
+            <para>The device shall support PKCS#12 passphrase integrity mode for integrity
+              protection of the PKCS#12 PFX as specified in PKCS#12, Sect. 4. The device shall
+              support PKCS8ShroudedKeyBags that are encrypted with the same passphrase as the
+              CertBag instances.</para>
+            <para>If an integrity passphrase ID is supplied, the device shall use the corresponding
+              passphrase in the keystore to check the integrity of the supplied PKCS#12 PFX. If an
+              integrity passphrase ID is supplied, but the supplied PKCS#12 PFX has no integrity
+              protection, the device shall produce a BadPKCS12File fault and shall not store the
+              uploaded certificates nor the uploaded key pair in the keystore.</para>
+            <para>If an encryption passphrase ID is supplied, the device shall use the corresponding
+              passphrase in the keystore to decrypt the PKCS8ShroudedKeyBag and the CertBag
+              instances.</para>
+            <para>If an EncryptionPassphraseID is supplied, but a CertBag is not encrypted, the
+              device shall ignore the supplied EncryptionPassphraseID when processing this CertBag.
+              If an EncryptionPassphraseID is supplied, but a KeyBag is provided instead of a
+              PKCS8ShroudedKeyBag, the device shall ignore the supplied EncryptionPassphraseID when
+              processing the KeyBag.</para>
+            <para>If a passphrase is supplied, the device shall ignore an eventually supplied
+              integrity passphrase ID and an eventually supplied encryption passphrase ID, and the
+              device shall use the supplied passphrase to check the integrity of the PKCS#12 PFX and
+              to decrypt the PKCS8ShroudedKeyBag and the CertBag instances. If a passphrase is
+              supplied, but a CertBag is not encrypted, the device shall ignore the supplied
+              passphrase when processing this CertBag. If a passphrase is supplied, but a KeyBag is
+              supplied instead of a PKCS8ShroudedKeyBag, the device shall ignore the supplied
+              passphrase when processing the KeyBag.</para>
+            <para>If decryption of either the PKCS8ShroudedKeyBag or an encrypted CertBag failed,
+              the device shall produce a DecryptionFailed fault and shall not store the uploaded
+              certificates nor key pair in the keystore.</para>
+            <para>If the signature algorithm of a supplied certificate is not supported by the
+              device, the device shall produce an UnsupportedSignatureAlgorithm fault and shall not
+              upload a certificate nor key pair.</para>
+            <para>If the supplied key pair cannot be processed by the device, the device shall
+              produce an UnsupportedPublicKeyAlgorithm fault and shall not store the uploaded key
+              pair nor the uploaded certificates in the keystore.</para>
+            <para>Certificates are uniquely identified using certificate IDs. The device shall store
+              the uploaded certificates in the keystore and generate a new certificate ID for each
+              of the uploaded certificates.</para>
+            <para>Certification paths are uniquely identified using certification path IDs. The
+              device shall create a certification path from the uploaded certificates. In this
+              certification path, the certificates shall appear in the same order as in the PKCS#12
+              file. The device shall generate a new certification path ID for the created
+              certification path and assign the eventually supplied CertificationPathAlias to the
+              created certification path.</para>
+            <para>The signature of each certificate in the sequence of uploaded certificates except
+              for the last one shall be verifiable with the public key contained in the next
+              certificate in the sequence. If there is a certificate in the request other than the
+              last certificate for which the signature cannot be verified with the public key in the
+              next certificate, the device shall produce an invalid certification path fault and
+              shall not store the uploaded certificates nor uploaded private key in the
+              keystore.</para>
+            <para>If the device cannot process one of the uploaded certificates, it shall produce a
+              BadCertificate fault and neither store the uploaded certificates nor private key in
+              the keystore. The BadCertificate fault shall not be produced based on the mere fact
+              that the device’s current time lies outside the interval defined by the notBefore and
+              notAfter fields as specified by RFC 5280, Sect. 4.1.</para>
             <para>The device shall not mark the uploaded certificates as trusted.</para>
-            <para>The uploaded certificates have to be linked to key pairs in the keystore. Key pairs are uniquely identified using key IDs.</para>
-            <para>If a key pair exists in the keystore with the public key equal to the public key in a certificate in the request, the device shall link the uploaded certificate to the key pair in the keystore by adding a reference from the certificate to the key pair. If the key pair in the keystore does not contain a private key and the private key contained in the KeyBag or PKCS8ShroudedKeyBag that matches the public key in the key pair, the device shall add the private key contained in the KeyBag or PKCS8ShroudedKeyBag to the key pair.</para>
-            <para>If no key pair exists in the keystore with the public key equal to the public key in a certificate in the request, the device shall create a new key pair with status ok, externally generated attribute set to <emphasis>true</emphasis>, and the public and private keys from the request, and shall link this key pair to the uploaded certificate by adding a reference from the certificate to the key pair.</para>
-            <para>If a new key pair is created for the uploaded private key, the device shall assign the supplied KeyAlias to it. Otherwise, the device shall ignore an eventually supplied KeyAlias.</para>
-            <para>How the link between an uploaded certificate and a key pair is established is illustrated in <xref linkend="_Ref379899735"/>.</para>
+            <para>The uploaded certificates have to be linked to key pairs in the keystore. Key
+              pairs are uniquely identified using key IDs.</para>
+            <para>If a key pair exists in the keystore with the public key equal to the public key
+              in a certificate in the request, the device shall link the uploaded certificate to the
+              key pair in the keystore by adding a reference from the certificate to the key pair.
+              If the key pair in the keystore does not contain a private key and the private key
+              contained in the KeyBag or PKCS8ShroudedKeyBag that matches the public key in the key
+              pair, the device shall add the private key contained in the KeyBag or
+              PKCS8ShroudedKeyBag to the key pair.</para>
+            <para>If no key pair exists in the keystore with the public key equal to the public key
+              in a certificate in the request, the device shall create a new key pair with status
+              ok, externally generated attribute set to <emphasis>true</emphasis>, and the public
+              and private keys from the request, and shall link this key pair to the uploaded
+              certificate by adding a reference from the certificate to the key pair.</para>
+            <para>If a new key pair is created for the uploaded private key, the device shall assign
+              the supplied KeyAlias to it. Otherwise, the device shall ignore an eventually supplied
+              KeyAlias.</para>
+            <para>How the link between an uploaded certificate and a key pair is established is
+              illustrated in <xref linkend="_Ref379899735"/>.</para>
             <figure xml:id="_Ref379899735">
-              <title>Link establishment between certificates and key pair for Upload Certificate with Private Key in PKCS#12</title>
+              <title>Link establishment between certificates and key pair for Upload Certificate
+                with Private Key in PKCS#12</title>
               <mediaobject>
                 <imageobject>
                   <imagedata fileref="media/Security/image4.png" contentwidth="122.16mm"/>
                 </imageobject>
               </mediaobject>
             </figure>
-            <para>If the key pair that a certificate shall be linked to does not have status <emphasis>ok</emphasis>, the device shall produce an invalid key status fault and shall not store the uploaded certificates nor the uploaded key pair in the keystore.</para>
-            <para>If the device does not have enough storage capacity for storing the certificates to be uploaded, the device shall produce a maximum number of certificates reached fault and shall not store the uploaded certificates nor the uploaded key pair in the keystore.</para>
-            <para>If the device does not have enough storage capacity for storing the key pair that eventually has to be created, the device shall generate a maximum number of keys reached fault. Furthermore the device shall not store a key pair and shall not store the uploaded certificates in the keystore.</para>
-            <para>If the device does not have enough storage capacity for storing the certification path to be created, the device shall produce a maximum number of certification paths reached fault and shall not store the uploaded certificates nor the uploaded key pair in the keystore.</para>
-            <para>If no passphrase exists under the ID specified by IntegrityPassphraseID, the device shall produce an invalid passphrase ID fault and shall not store the uploaded certificates nor the uploaded key pair in the keystore.</para>
-            <para>If no passphrase exists under the ID specified by EncryptionPassphraseID, the device shall produce an invalid passphrase ID fault and shall not store the uploaded certificates nor the uploaded key pair in the keystore.</para>
-            <para>If the supplied PKCS#12 data structure cannot be processed by the device, the device shall produce a BadPKCS12File fault and shall not store the uploaded certificates nor the uploaded key pair in the keystore.</para>
-            <para>If the public key in the first uploaded certificate does not match the uploaded private key, the device shall produce a PublicPrivateKeyMismatch fault and shall not store the uploaded certificates nor the uploaded key pair in the keystore.</para>
-            <para>If the command was successful, the device shall return the ID of the created certification path and the ID of the key pair that contains the public key in the certificate.</para>
+            <para>If the key pair that a certificate shall be linked to does not have status
+                <emphasis>ok</emphasis>, the device shall produce an invalid key status fault and
+              shall not store the uploaded certificates nor the uploaded key pair in the
+              keystore.</para>
+            <para>If the device does not have enough storage capacity for storing the certificates
+              to be uploaded, the device shall produce a maximum number of certificates reached
+              fault and shall not store the uploaded certificates nor the uploaded key pair in the
+              keystore.</para>
+            <para>If the device does not have enough storage capacity for storing the key pair that
+              eventually has to be created, the device shall generate a maximum number of keys
+              reached fault. Furthermore the device shall not store a key pair and shall not store
+              the uploaded certificates in the keystore.</para>
+            <para>If the device does not have enough storage capacity for storing the certification
+              path to be created, the device shall produce a maximum number of certification paths
+              reached fault and shall not store the uploaded certificates nor the uploaded key pair
+              in the keystore.</para>
+            <para>If no passphrase exists under the ID specified by IntegrityPassphraseID, the
+              device shall produce an invalid passphrase ID fault and shall not store the uploaded
+              certificates nor the uploaded key pair in the keystore.</para>
+            <para>If no passphrase exists under the ID specified by EncryptionPassphraseID, the
+              device shall produce an invalid passphrase ID fault and shall not store the uploaded
+              certificates nor the uploaded key pair in the keystore.</para>
+            <para>If the supplied PKCS#12 data structure cannot be processed by the device, the
+              device shall produce a BadPKCS12File fault and shall not store the uploaded
+              certificates nor the uploaded key pair in the keystore.</para>
+            <para>If the public key in the first uploaded certificate does not match the uploaded
+              private key, the device shall produce a PublicPrivateKeyMismatch fault and shall not
+              store the uploaded certificates nor the uploaded key pair in the keystore.</para>
+            <para>If the command was successful, the device shall return the ID of the created
+              certification path and the ID of the key pair that contains the public key in the
+              certificate.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
                 <listitem>
                   <para role="param">CertWithPrivateKey - [tas:Base64DERencodedASN1Value]</para>
-                  <para role="text"> The certifcates and key pair to be uploaded in a PKCS#12 data structure.</para>
+                  <para role="text"> The certifcates and key pair to be uploaded in a PKCS#12 data
+                    structure.</para>
                   <para role="param">CertificationPathAlias - optional [xs:string] </para>
                   <para role="text">The client-defined alias of the certification path.</para>
                   <para role="param">KeyAlias - optional [xs:string]</para>
                   <para role="text"> The client-defined alias of the key pair.</para>
                   <para role="param">IgnoreAdditionalCertificates - optional [xs:boolean]</para>
-                  <para role="text"> True if and only if the device shall behave as if the client had only supplied the first certificate in the sequence of certificates.</para>
+                  <para role="text"> True if and only if the device shall behave as if the client
+                    had only supplied the first certificate in the sequence of certificates.</para>
                   <para role="param">IntegrityPassphraseID - optional [tas:PassphraseID]</para>
-                  <para role="text"> The ID of the passphrase to use for integrity checking of the uploaded PKCS#12 data structure.</para>
+                  <para role="text"> The ID of the passphrase to use for integrity checking of the
+                    uploaded PKCS#12 data structure.</para>
                   <para role="param">EncryptionPassphraseID - optional [tas:PassphraseID]</para>
-                  <para role="text"> The ID of the passphrase to use for decrypting the uploaded PKCS#12 data structure.</para>
+                  <para role="text"> The ID of the passphrase to use for decrypting the uploaded
+                    PKCS#12 data structure.</para>
                   <para role="param">Passphrase - optional [xs:string]</para>
-                  <para role="text"> The passphrase to use for integrity checking and decrypting the uploaded PKCS#12 data structure.</para>
+                  <para role="text"> The passphrase to use for integrity checking and decrypting the
+                    uploaded PKCS#12 data structure.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
                 <term>response</term>
                 <listitem>
                   <para role="param">CertificationPathID - [tas:CertificationPathID]</para>
-                  <para role="text"> The certification path ID of the uploaded certification path.</para>
+                  <para role="text"> The certification path ID of the uploaded certification
+                    path.</para>
                   <para role="param">KeyID - [tas:KeyID]</para>
                   <para role="text"> The key ID of the uploaded key pair.</para>
                 </listitem>
@@ -2021,31 +2663,48 @@
                 <listitem>
                   <para role="param">ter:Receiver - ter:Action - ter:</para>
                   <para role="text">
-                    <emphasis role="bold">MaximumNumberOfCertificatesReached</emphasis> The device does not have enough storage space to store the certificate to be uploaded.</para>
+                    <emphasis role="bold">MaximumNumberOfCertificatesReached</emphasis> The device
+                    does not have enough storage space to store the certificate to be
+                    uploaded.</para>
                   <para role="param">ter:Receiver - ter:Action - ter:</para>
                   <para role="text">
-                    <emphasis role="bold">MaximumNumberOfKeysReached</emphasis> The device does not have enough storage space to store the key pair that has to be generated.</para>
+                    <emphasis role="bold">MaximumNumberOfKeysReached</emphasis> The device does not
+                    have enough storage space to store the key pair that has to be generated.</para>
                   <para role="param">ter:Receiver - ter:Action - ter:</para>
                   <para role="text">
-                    <emphasis role="bold">MaximumNumberOfCertificationPathsReached</emphasis> The device does not have enough storage space to store the certification path to be uploaded.</para>
+                    <emphasis role="bold">MaximumNumberOfCertificationPathsReached</emphasis> The
+                    device does not have enough storage space to store the certification path to be
+                    uploaded.</para>
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:PassphraseID</para>
-                  <para role="text"> No passphrase is stored under the requested PassphraseID.</para>
+                  <para role="text"> No passphrase is stored under the requested
+                    PassphraseID.</para>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:DecryptionFailed</para>
                   <para role="text"> The given data could not be decrypted.</para>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:BadCertificate</para>
-                  <para role="text"> The supplied certificate file cannot be processed by the device.</para>
-                  <para role="param">env:Sender - ter:InvalidArgVal - ter:UnsupportedPublicKeyAlgorithm</para>
-                  <para role="text"> The public key algorithm of the public key in the certificate is not supported by the device.</para>
-                  <para role="param">env:Sender - ter:InvalidArgVal - ter:UnsupportedSignatureAlgorithm</para>
-                  <para role="text"> The signature algorithm that the signature of the supplied certificate is based on is not supported by the device.</para>
+                  <para role="text"> The supplied certificate file cannot be processed by the
+                    device.</para>
+                  <para role="param">env:Sender - ter:InvalidArgVal -
+                    ter:UnsupportedPublicKeyAlgorithm</para>
+                  <para role="text"> The public key algorithm of the public key in the certificate
+                    is not supported by the device.</para>
+                  <para role="param">env:Sender - ter:InvalidArgVal -
+                    ter:UnsupportedSignatureAlgorithm</para>
+                  <para role="text"> The signature algorithm that the signature of the supplied
+                    certificate is based on is not supported by the device.</para>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:InvalidKeyStatus</para>
-                  <para role="text"> The key with the requested KeyID has an inappropriate status.</para>
+                  <para role="text"> The key with the requested KeyID has an inappropriate
+                    status.</para>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:BadPKCS12File</para>
-                  <para role="text"> The PKCS#12 data structure cannot be processed by the device.</para>
-                  <para role="param">env:Sender - ter:InvalidArgVal - ter:PublicPrivateKeyMismatch</para>
-                  <para role="text"> The supplied private key does not match the supplied public key.</para>
-                  <para role="param">env:Sender - ter: InvalidArgVal - ter:InvalidCertificationPath</para>
-                  <para role="text"> At least one certificate in the certification path is not correctly signed with the public key in the next certificate in the path.</para>
+                  <para role="text"> The PKCS#12 data structure cannot be processed by the
+                    device.</para>
+                  <para role="param">env:Sender - ter:InvalidArgVal -
+                    ter:PublicPrivateKeyMismatch</para>
+                  <para role="text"> The supplied private key does not match the supplied public
+                    key.</para>
+                  <para role="param">env:Sender - ter: InvalidArgVal -
+                    ter:InvalidCertificationPath</para>
+                  <para role="text"> At least one certificate in the certification path is not
+                    correctly signed with the public key in the next certificate in the path.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -2059,9 +2718,12 @@
           <section>
             <title>GetCertificate</title>
             <para>This operation returns a specific certificate from the device’s keystore.</para>
-            <para>Certificates are uniquely identified using certificate IDs. If no certificate is stored under the requested certificate ID in the keystore, an InvalidArgVal fault is produced.</para>
+            <para>Certificates are uniquely identified using certificate IDs. If no certificate is
+              stored under the requested certificate ID in the keystore, an InvalidArgVal fault is
+              produced.</para>
             <para>The certificate shall be returned in DER encoding.</para>
-            <para>It shall be noted that this command does not return the private key that is associated with the public key in the certificate.</para>
+            <para>It shall be noted that this command does not return the private key that is
+              associated with the public key in the certificate.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
@@ -2081,7 +2743,8 @@
                 <term>faults</term>
                 <listitem>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:CertificateID</para>
-                  <para role="text"> No certificate is stored under the requested CertificateID.</para>
+                  <para role="text"> No certificate is stored under the requested
+                    CertificateID.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -2096,9 +2759,11 @@
             <title>GetAllCertificates</title>
             <para>This operation returns all certificates that are stored in the device’s keystore.
               An ONVIF compliant device shall support this command.</para>
-            <para>This operation may be used, e.g., if a client lost track of which certificates are present on the device.</para>
+            <para>This operation may be used, e.g., if a client lost track of which certificates are
+              present on the device.</para>
             <para>The certificates shall be returned in DER encoding.</para>
-            <para>If no certificate is stored in the device’s keystore, an empty list is returned.</para>
+            <para>If no certificate is stored in the device’s keystore, an empty list is
+              returned.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
@@ -2110,7 +2775,8 @@
                 <term>response</term>
                 <listitem>
                   <para role="param">Certificate - optional, unbounded [tas:X509Certificate]</para>
-                  <para role="text"> List of DER representation of certificates stored in the keystore.</para>
+                  <para role="text"> List of DER representation of certificates stored in the
+                    keystore.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -2131,10 +2797,17 @@
             <title>DeleteCertificate</title>
             <para>This operation deletes a certificate from the device’s keystore. An ONVIF
               compliant device shall support this command.</para>
-            <para>The operation shall not delete the public key that is contained in the certificate from the keystore.</para>
-            <para>Certificates are uniquely identified using certificate IDs. If no certificate is stored under the requested certificate ID in the keystore, an InvalidArgVal fault is produced. If there is a certificate under the requested certificate ID stored in the keystore and the certificate could not be deleted, a CertificateDeletion fault is produced.</para>
-            <para>If a reference exists for the specified certificate, the certificate shall not be deleted and the corresponding fault shall be produced.</para>
-            <para>After a certificate has been successfully deleted, the device may assign its former ID to other certificates.</para>
+            <para>The operation shall not delete the public key that is contained in the certificate
+              from the keystore.</para>
+            <para>Certificates are uniquely identified using certificate IDs. If no certificate is
+              stored under the requested certificate ID in the keystore, an InvalidArgVal fault is
+              produced. If there is a certificate under the requested certificate ID stored in the
+              keystore and the certificate could not be deleted, a CertificateDeletion fault is
+              produced.</para>
+            <para>If a reference exists for the specified certificate, the certificate shall not be
+              deleted and the corresponding fault shall be produced.</para>
+            <para>After a certificate has been successfully deleted, the device may assign its
+              former ID to other certificates.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
@@ -2152,10 +2825,13 @@
               <varlistentry>
                 <term>faults</term>
                 <listitem>
-                  <para role="param">ter:Receiver - ter:Action - ter:CertificateDeletionFailed</para>
-                  <para role="text"> Deleting the certificate with the requested CertificateID failed.</para>
+                  <para role="param">ter:Receiver - ter:Action -
+                    ter:CertificateDeletionFailed</para>
+                  <para role="text"> Deleting the certificate with the requested CertificateID
+                    failed.</para>
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:CertificateID</para>
-                  <para role="text"> No certificate is stored under the requested CertificateID.</para>
+                  <para role="text"> No certificate is stored under the requested
+                    CertificateID.</para>
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:ReferenceExists</para>
                   <para role="text"> A reference exists for the specified certificate.</para>
                 </listitem>
@@ -2170,16 +2846,29 @@
           </section>
           <section>
             <title>CreateCertificationPath</title>
-            <para>This operation creates a sequence of certificates that may be used, e.g., for certification path validation or for TLS server authentication.</para>
-            <para>Certification paths are uniquely identified using certification path IDs. Certificates are uniquely identified using certificate IDs. A certification path contains a sequence of certificate IDs.</para>
-            <para>If there is a certificate ID in the sequence of supplied certificate IDs for which no certificate exists in the device’s keystore, the corresponding fault shall be produced and no certification path shall be created.</para>
-            <para>The signature of each certificate in the certification path except for the last one shall be verifiable with the public key contained in the next certificate in the path. If there is a certificate ID in the request other than the last ID for which the corresponding certificate cannot be verified with the public key in the certificate identified by the next certificate ID, an InvalidCertificateChain fault shall be produced and no certification path shall be created.</para>
+            <para>This operation creates a sequence of certificates that may be used, e.g., for
+              certification path validation or for TLS server authentication.</para>
+            <para>Certification paths are uniquely identified using certification path IDs.
+              Certificates are uniquely identified using certificate IDs. A certification path
+              contains a sequence of certificate IDs.</para>
+            <para>If there is a certificate ID in the sequence of supplied certificate IDs for which
+              no certificate exists in the device’s keystore, the corresponding fault shall be
+              produced and no certification path shall be created.</para>
+            <para>The signature of each certificate in the certification path except for the last
+              one shall be verifiable with the public key contained in the next certificate in the
+              path. If there is a certificate ID in the request other than the last ID for which the
+              corresponding certificate cannot be verified with the public key in the certificate
+              identified by the next certificate ID, an InvalidCertificateChain fault shall be
+              produced and no certification path shall be created.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
                 <listitem>
                   <para role="param">CertificateIDs - [tas:CertificateIDs] </para>
-                  <para role="text">The IDs of the certificates to include in the certification path, where each certificate signature except for the last one in the path must be verifiable with the public key certified by the next certificate in the path.</para>
+                  <para role="text">The IDs of the certificates to include in the certification
+                    path, where each certificate signature except for the last one in the path must
+                    be verifiable with the public key certified by the next certificate in the
+                    path.</para>
                   <para role="param">Alias - optional [xs:string] </para>
                   <para role="text">The client-defined alias of the certification path.</para>
                 </listitem>
@@ -2194,12 +2883,16 @@
               <varlistentry>
                 <term>faults</term>
                 <listitem>
-                  <para role="param">env:Receiver - ter:Action - ter:MaximumNumberOfCertificationPathsReached</para>
-                  <para role="text"> The maximum number of certification paths that may be assigned to the TLS server simultaneously is reached.</para>
+                  <para role="param">env:Receiver - ter:Action -
+                    ter:MaximumNumberOfCertificationPathsReached</para>
+                  <para role="text"> The maximum number of certification paths that may be assigned
+                    to the TLS server simultaneously is reached.</para>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:CertificateID </para>
-                  <para role="text">No certificate is stored under the requested CertificateID.</para>
+                  <para role="text">No certificate is stored under the requested
+                    CertificateID.</para>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:InvalidCertificationPath </para>
-                  <para role="text">At least one certificate in the certification path is not correctly signed with the public key in the next certificate in the path.</para>
+                  <para role="text">At least one certificate in the certification path is not
+                    correctly signed with the public key in the next certificate in the path.</para>
                   <para role="param">env:Receiver - ter:Action - ter:CertificationPathCreationFailed </para>
                   <para role="text">Creating the certification path failed.</para>
                 </listitem>
@@ -2214,8 +2907,11 @@
           </section>
           <section>
             <title>GetCertificationPath</title>
-            <para>This operation returns a specific certification path from the device’s keystore.</para>
-            <para>Certification paths are uniquely identified using certification path IDs. If no certification path is stored under the requested ID in the keystore, an InvalidArgVal fault is produced.</para>
+            <para>This operation returns a specific certification path from the device’s
+              keystore.</para>
+            <para>Certification paths are uniquely identified using certification path IDs. If no
+              certification path is stored under the requested ID in the keystore, an InvalidArgVal
+              fault is produced.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
@@ -2228,14 +2924,16 @@
                 <term>response</term>
                 <listitem>
                   <para role="param">CertificationPath - [tas:CertificationPath] </para>
-                  <para role="text">The certification path that is stored under the given ID in the keystore.</para>
+                  <para role="text">The certification path that is stored under the given ID in the
+                    keystore.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
                 <term>faults</term>
                 <listitem>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:CertificationPathID </para>
-                  <para role="text">No certification path is stored under the requested certification path ID.</para>
+                  <para role="text">No certification path is stored under the requested
+                    certification path ID.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -2248,9 +2946,12 @@
           </section>
           <section>
             <title>GetAllCertificationPaths</title>
-            <para>This operation returns the IDs of all certification paths that are stored in the device’s keystore.</para>
-            <para>This operation may be used, e.g., if a client lost track of which certificates are present on the device.</para>
-            <para>If no certification path is stored on the device, an empty list is returned.</para>
+            <para>This operation returns the IDs of all certification paths that are stored in the
+              device’s keystore.</para>
+            <para>This operation may be used, e.g., if a client lost track of which certificates are
+              present on the device.</para>
+            <para>If no certification path is stored on the device, an empty list is
+              returned.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
@@ -2261,8 +2962,10 @@
               <varlistentry>
                 <term>response</term>
                 <listitem>
-                  <para role="param">CertificationPathID - optional, unbounded [tas:CertificationPathID]</para>
-                  <para role="text"> List of IDs of certification paths stored in the keystore.</para>
+                  <para role="param">CertificationPathID - optional, unbounded
+                    [tas:CertificationPathID]</para>
+                  <para role="text"> List of IDs of certification paths stored in the
+                    keystore.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -2290,7 +2993,10 @@
                   <para role="param">CertificationPathID - [tas:CertificationPathID] </para>
                   <para role="text">The ID of the certification path to modify.</para>
                   <para role="param">CertificateIDs - [tas:CertificateIDs] </para>
-                  <para role="text">The IDs of the certificates to include in the certification path, where each certificate signature except for the last one in the path must be verifiable with the public key certified by the next certificate in the path.</para>
+                  <para role="text">The IDs of the certificates to include in the certification
+                    path, where each certificate signature except for the last one in the path must
+                    be verifiable with the public key certified by the next certificate in the
+                    path.</para>
                   <para role="param">Alias - optional [xs:string] </para>
                   <para role="text">The client-defined alias of the certification path.</para>
                 </listitem>
@@ -2305,11 +3011,14 @@
                 <term>faults</term>
                 <listitem>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:CertificationPathID </para>
-                  <para role="text">No certification path is stored under the requested certification path ID.</para>
+                  <para role="text">No certification path is stored under the requested
+                    certification path ID.</para>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:CertificateID </para>
-                  <para role="text">No certificate is stored under the requested CertificateID.</para>
+                  <para role="text">No certificate is stored under the requested
+                    CertificateID.</para>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:InvalidCertificationPath </para>
-                  <para role="text">At least one certificate in the certification path is not correctly signed with the public key in the next certificate in the path.</para>
+                  <para role="text">At least one certificate in the certification path is not
+                    correctly signed with the public key in the next certificate in the path.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -2323,10 +3032,17 @@
           <section>
             <title>DeleteCertificationPath</title>
             <para>This operation deletes a certification path from the device’s keystore.</para>
-            <para>This operation shall not delete the certificates that are referenced by the certification path.</para>
-            <para>Certification paths are uniquely identified using certification path IDs. If no certification path is stored under the requested certification path ID in the keystore, an InvalidArgVal fault is produced. If there is a certification path under the requested certification path ID stored in the keystore and the certification path could not be deleted, a CertificationPathDeletion fault is produced.</para>
-            <para>If a reference exists for the specified certification path, the certification path shall not be deleted and the corresponding fault shall be produced.</para>
-            <para>After a certification path is successfully deleted, the device may assign its former ID to other certification paths.</para>
+            <para>This operation shall not delete the certificates that are referenced by the
+              certification path.</para>
+            <para>Certification paths are uniquely identified using certification path IDs. If no
+              certification path is stored under the requested certification path ID in the
+              keystore, an InvalidArgVal fault is produced. If there is a certification path under
+              the requested certification path ID stored in the keystore and the certification path
+              could not be deleted, a CertificationPathDeletion fault is produced.</para>
+            <para>If a reference exists for the specified certification path, the certification path
+              shall not be deleted and the corresponding fault shall be produced.</para>
+            <para>After a certification path is successfully deleted, the device may assign its
+              former ID to other certification paths.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
@@ -2344,10 +3060,13 @@
               <varlistentry>
                 <term>faults</term>
                 <listitem>
-                  <para role="param">ter:Receiver - ter:Action - ter:CertificationPathDeletionFailed</para>
-                  <para role="text"> Deleting the certification path with the requested certification path ID failed.</para>
+                  <para role="param">ter:Receiver - ter:Action -
+                    ter:CertificationPathDeletionFailed</para>
+                  <para role="text"> Deleting the certification path with the requested
+                    certification path ID failed.</para>
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:CertificationPathID</para>
-                  <para role="text"> No certification path is stored under the requested certification path ID.</para>
+                  <para role="text"> No certification path is stored under the requested
+                    certification path ID.</para>
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:ReferenceExists</para>
                   <para role="text"> A reference exists for the object that is to be deleted.</para>
                 </listitem>
@@ -2365,10 +3084,16 @@
           <title>CRL Management</title>
           <section>
             <title>UploadCRL</title>
-            <para>This operation uploads a certificate revocation list (CRL) as specified in RFC 5280 to the keystore on the device.</para>
-            <para>If the device does not have enough storage space to store the CRL to be uploaded, the device shall produce a MaximumNumberOfCRLsReached fault and shall not store the supplied CRL.</para>
-            <para>If the device is not able to process the supplied CRL, the device shall produce a BadCRL fault and shall not store the supplied CRL.</para>
-            <para>If the device does not support the signature algorithm that was used to sign the supplied CRL, the device shall produce an UnsupportedSignatureAlgorithm fault and shall not store the supplied CRL.</para>
+            <para>This operation uploads a certificate revocation list (CRL) as specified in RFC
+              5280 to the keystore on the device.</para>
+            <para>If the device does not have enough storage space to store the CRL to be uploaded,
+              the device shall produce a MaximumNumberOfCRLsReached fault and shall not store the
+              supplied CRL.</para>
+            <para>If the device is not able to process the supplied CRL, the device shall produce a
+              BadCRL fault and shall not store the supplied CRL.</para>
+            <para>If the device does not support the signature algorithm that was used to sign the
+              supplied CRL, the device shall produce an UnsupportedSignatureAlgorithm fault and
+              shall not store the supplied CRL.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
@@ -2378,8 +3103,7 @@
                   <para role="param">Alias - optional [xs:string] </para>
                   <para role="text">The alias to assign to the uploaded CRL.</para>
                   <para role="param">anyParameters - optional, unbounded [xs:any]</para>
-                  <para role="text">
-                  </para>
+                  <para role="text"> </para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -2392,13 +3116,17 @@
               <varlistentry>
                 <term>faults</term>
                 <listitem>
-                  <para role="param">env:Receiver - ter:Action - ter:MaximumNumberOfCRLsReached</para>
-                  <para role="text">The device does not have enough storage space to store the CRL to be uploaded.</para>
+                  <para role="param">env:Receiver - ter:Action -
+                    ter:MaximumNumberOfCRLsReached</para>
+                  <para role="text">The device does not have enough storage space to store the CRL
+                    to be uploaded.</para>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:BadCRL</para>
                   <para role="text">The supplied CRL cannot be processed by the device.</para>
-                  <para role="param">env:Sender - ter:InvalidArgVal - ter:UnsupportedSignatureAlgorithm </para>
+                  <para role="param">env:Sender - ter:InvalidArgVal -
+                    ter:UnsupportedSignatureAlgorithm </para>
                   <para role="text">
-                    <phrase>The specified signature algorithm is not supported by the device.</phrase>
+                    <phrase>The specified signature algorithm is not supported by the
+                      device.</phrase>
                   </para>
                 </listitem>
               </varlistentry>
@@ -2412,8 +3140,10 @@
           </section>
           <section>
             <title>GetCRL</title>
-            <para>This operation returns a specific certificate revocation list (CRL) from the keystore on the device.</para>
-            <para>Certification revocation lists are uniquely identified using CRLIDs. If no CRL is stored under the requested CRLID, the device shall produce a CRLID fault.</para>
+            <para>This operation returns a specific certificate revocation list (CRL) from the
+              keystore on the device.</para>
+            <para>Certification revocation lists are uniquely identified using CRLIDs. If no CRL is
+              stored under the requested CRLID, the device shall produce a CRLID fault.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
@@ -2448,8 +3178,10 @@
           </section>
           <section>
             <title>GetAllCRLs</title>
-            <para>This operation returns all certificate revocation lists (CRLs) that are stored in the keystore on the device.</para>
-            <para>If no certificate revocation list is stored in the device’s keystore, an empty list is returned.</para>
+            <para>This operation returns all certificate revocation lists (CRLs) that are stored in
+              the keystore on the device.</para>
+            <para>If no certificate revocation list is stored in the device’s keystore, an empty
+              list is returned.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
@@ -2461,7 +3193,8 @@
                 <term>response</term>
                 <listitem>
                   <para role="param">Crl - optional, unbounded [tas:CRL]</para>
-                  <para role="text"> A list of all CRLs that are stored in the keystore on the device.</para>
+                  <para role="text"> A list of all CRLs that are stored in the keystore on the
+                    device.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -2480,10 +3213,14 @@
           </section>
           <section>
             <title>DeleteCRL</title>
-            <para>This operation deletes a certificate revocation list (CRL) from the keystore on the device.</para>
-            <para>Certification revocation lists are uniquely identified using CRLIDs. If no CRL is stored under the requested CRLID, the device shall produce a CRLID fault.</para>
-            <para>If a reference exists for the specified CRL, the device shall produce a ReferenceExists fault and shall not delete the CRL.</para>
-            <para>After a CRL has been successfully deleted, a device may assign its former ID to other CRLs.</para>
+            <para>This operation deletes a certificate revocation list (CRL) from the keystore on
+              the device.</para>
+            <para>Certification revocation lists are uniquely identified using CRLIDs. If no CRL is
+              stored under the requested CRLID, the device shall produce a CRLID fault.</para>
+            <para>If a reference exists for the specified CRL, the device shall produce a
+              ReferenceExists fault and shall not delete the CRL.</para>
+            <para>After a CRL has been successfully deleted, a device may assign its former ID to
+              other CRLs.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
@@ -2522,41 +3259,59 @@
             <title>CreateCertPathValidationPolicy</title>
             <para>This operation creates a certification path validation policy. An ONVIF compliant
               device shall support this command.</para>
-            <para>Certification path validation policies are uniquely identified using certification path validation policy IDs. The device shall generate a new certification path validation policy ID for the created certification path validation policy.</para>
-            <para>If the device does not have enough storage capacity for storing the certification path validation policy to be created, the device shall produce a maximum number of certification path validation policies reached fault and shall not create a certification path validation policy.</para>
-            <para>If there is at least one trust anchor certificate ID in the request for which there exists no certificate in the device’s keystore, the device shall produce a CertificateID fault and shall not create a certification path validation policy.</para>
-            <para>If the device cannot process the supplied certification path validation parameters, the device shall produce a CertPathValidationParameters fault and shall not create a certification path validation policy.</para>
+            <para>Certification path validation policies are uniquely identified using certification
+              path validation policy IDs. The device shall generate a new certification path
+              validation policy ID for the created certification path validation policy.</para>
+            <para>If the device does not have enough storage capacity for storing the certification
+              path validation policy to be created, the device shall produce a maximum number of
+              certification path validation policies reached fault and shall not create a
+              certification path validation policy.</para>
+            <para>If there is at least one trust anchor certificate ID in the request for which
+              there exists no certificate in the device’s keystore, the device shall produce a
+              CertificateID fault and shall not create a certification path validation
+              policy.</para>
+            <para>If the device cannot process the supplied certification path validation
+              parameters, the device shall produce a CertPathValidationParameters fault and shall
+              not create a certification path validation policy.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
                 <listitem>
                   <para role="param">Alias - optional [xs:string] </para>
-                  <para role="text">The alias to assign to the created certification path validation policy.</para>
+                  <para role="text">The alias to assign to the created certification path validation
+                    policy.</para>
                   <para role="param">Parameters - [tas:CertPathValidationParameters] </para>
-                  <para role="text">The parameters of the certification path validation policy to be created.</para>
+                  <para role="text">The parameters of the certification path validation policy to be
+                    created.</para>
                   <para role="param">TrustAnchor - unbounded [tas:TrustAnchor] </para>
-                  <para role="text">The trust anchors of the certification path validation policy to be created.</para>
+                  <para role="text">The trust anchors of the certification path validation policy to
+                    be created.</para>
                   <para role="param">anyParameters - optional [xs:any]</para>
-                  <para role="text">
-                  </para>
+                  <para role="text"> </para>
                 </listitem>
               </varlistentry>
               <varlistentry>
                 <term>response</term>
                 <listitem>
                   <para role="param">CertPathValidationPolicyID - [tas:CertPathValidationPolicyID] </para>
-                  <para role="text">The ID of the created certification path validation policy.</para>
+                  <para role="text">The ID of the created certification path validation
+                    policy.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
                 <term>faults</term>
                 <listitem>
-                  <para role="param">env:Receiver - ter:Action - ter:MaximumNumberOfCertPathValidationPoliciesReached </para>
-                  <para role="text">The device does not have enough storage to store the certification path validation policy to be created.</para>
+                  <para role="param">env:Receiver - ter:Action -
+                    ter:MaximumNumberOfCertPathValidationPoliciesReached </para>
+                  <para role="text">The device does not have enough storage to store the
+                    certification path validation policy to be created.</para>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:CertificateID </para>
-                  <para role="text">No certificate is stored under the requested CertificateID.</para>
-                  <para role="param">env:Sender - ter:InvalidArgVal - ter:CertPathValidationParameters </para>
-                  <para role="text">The specified certification path validation parameters are invalid.</para>
+                  <para role="text">No certificate is stored under the requested
+                    CertificateID.</para>
+                  <para role="param">env:Sender - ter:InvalidArgVal -
+                    ter:CertPathValidationParameters </para>
+                  <para role="text">The specified certification path validation parameters are
+                    invalid.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -2571,27 +3326,33 @@
             <title>GetCertPathValidationPolicy</title>
             <para>This operation returns a certification path validation policy from the keystore on
               the device. An ONVIF compliant device shall support this command.</para>
-            <para>Certification path validation policies are uniquely identified using certification path validation policy IDs. If no certification path validation policy is stored under the requested certification path validation policy ID, the device shall produce a CertPathValidationPolicyID fault.</para>
+            <para>Certification path validation policies are uniquely identified using certification
+              path validation policy IDs. If no certification path validation policy is stored under
+              the requested certification path validation policy ID, the device shall produce a
+              CertPathValidationPolicyID fault.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
                 <listitem>
                   <para role="param">CertPathValidationPolicyID - [tas:CertPathValidationPolicyID] </para>
-                  <para role="text">The ID of the certification path validation policy to be created.</para>
+                  <para role="text">The ID of the certification path validation policy to be
+                    created.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
                 <term>response</term>
                 <listitem>
                   <para role="param">CertPathValidationPolicy - [tas:CertPathValidationPolicy] </para>
-                  <para role="text">The certification path validation policy that is stored under the requested ID.</para>
+                  <para role="text">The certification path validation policy that is stored under
+                    the requested ID.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
                 <term>faults</term>
                 <listitem>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:CertPathValidationPolicyID </para>
-                  <para role="text">No certification path validation policy is stored under the requested certification path validation policy ID.</para>
+                  <para role="text">No certification path validation policy is stored under the
+                    requested certification path validation policy ID.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -2607,7 +3368,8 @@
             <para>This operation returns all certification path validation policies that are stored
               in the keystore on the device. An ONVIF compliant device shall support this
               command.</para>
-            <para>If no certification path validation policy is stored in the device’s keystore, an empty list is returned.</para>
+            <para>If no certification path validation policy is stored in the device’s keystore, an
+              empty list is returned.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
@@ -2618,8 +3380,10 @@
               <varlistentry>
                 <term>response</term>
                 <listitem>
-                  <para role="param">CertPathValidationPolicy - optional, unbounded - [tas:CertPathValidationPolicy] </para>
-                  <para role="text">A list of all certification path validation policies that are stored in the keystore on the device.</para>
+                  <para role="param">CertPathValidationPolicy - optional, unbounded -
+                    [tas:CertPathValidationPolicy] </para>
+                  <para role="text">A list of all certification path validation policies that are
+                    stored in the keystore on the device.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -2647,7 +3411,8 @@
                 <term>request</term>
                 <listitem>
                   <para role="param">CertPathValidationPolicyID - [tas:CertPathValidationPolicyID] </para>
-                  <para role="text">The ID of the certification path validation policy to be modified.</para>
+                  <para role="text">The ID of the certification path validation policy to be
+                    modified.</para>
                   <para role="param">Parameters - [tas:CertPathValidationParameters] </para>
                   <para role="text">The parameters of the certification path validation
                     policy.</para>
@@ -2666,7 +3431,8 @@
                 <term>faults</term>
                 <listitem>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:CertPathValidationPolicyID </para>
-                  <para role="text">No certification path validation policy is stored under the requested certification path validation policy ID.</para>
+                  <para role="text">No certification path validation policy is stored under the
+                    requested certification path validation policy ID.</para>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:CertificateID </para>
                   <para role="text">No certificate is stored under the requested
                     CertificateID.</para>
@@ -2686,16 +3452,24 @@
           </section>
           <section>
             <title>DeleteCertPathValidationPolicy</title>
-            <para>This operation deletes a certification path validation policy from the keystore on the device.</para>
-            <para>Certification path validation policies are uniquely identified using certification path validation policy IDs. If no certification path validation policy is stored under the requested certification path validation policy ID, the device shall produce an CertPathValidationPolicyID fault.</para>
-            <para>If a reference exists for the requested certification path validation policy, the device shall produce a ReferenceExists fault and shall not delete the certification path validation policy.</para>
-            <para>After the certification path validation policy has been deleted, the device may assign its former ID to other certification path validation policies.</para>
+            <para>This operation deletes a certification path validation policy from the keystore on
+              the device.</para>
+            <para>Certification path validation policies are uniquely identified using certification
+              path validation policy IDs. If no certification path validation policy is stored under
+              the requested certification path validation policy ID, the device shall produce an
+              CertPathValidationPolicyID fault.</para>
+            <para>If a reference exists for the requested certification path validation policy, the
+              device shall produce a ReferenceExists fault and shall not delete the certification
+              path validation policy.</para>
+            <para>After the certification path validation policy has been deleted, the device may
+              assign its former ID to other certification path validation policies.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
                 <listitem>
                   <para role="param">CertPathValidationPolicyID - [tas:CertPathValidationPolicyID] </para>
-                  <para role="text">The ID of the certification path validation policy to be deleted.</para>
+                  <para role="text">The ID of the certification path validation policy to be
+                    deleted.</para>
                 </listitem>
               </varlistentry>
               <varlistentry>
@@ -2708,7 +3482,8 @@
                 <term>faults</term>
                 <listitem>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:CertPathValidationPolicyID </para>
-                  <para role="text">No certification path validation policy is stored under the requested certification path validation policy ID.</para>
+                  <para role="text">No certification path validation policy is stored under the
+                    requested certification path validation policy ID.</para>
                   <para role="param">ter:Sender - ter:InvalidArgVal - ter:ReferenceExists</para>
                   <para role="text"> A reference exists for the object that is to be deleted.</para>
                 </listitem>
@@ -2728,18 +3503,36 @@
       <title>TLS Server</title>
       <section>
         <title>Elements of the TLS Server</title>
-        <para>The TLS server security feature implements a TLS server as specified in RFC 2246 and subsequent specifications.</para>
-        <para>This specification defines how to manage the associations between certification paths and the TLS server. All other TLS server configuration actions are outside the scope of this specification. In particular, enabling and disabling the TLS server on the device shall be performed using the device management service specified in the ONVIF Core Specification.</para>
+        <para>The TLS server security feature implements a TLS server as specified in RFC 2246 and
+          subsequent specifications.</para>
+        <para>This specification defines how to manage the associations between certification paths
+          and the TLS server. All other TLS server configuration actions are outside the scope of
+          this specification. In particular, enabling and disabling the TLS server on the device
+          shall be performed using the device management service specified in the ONVIF Core
+          Specification.</para>
       </section>
       <section>
         <title>Authorization of TLS authenticated connections</title>
-        <para>If TLS client authentication is enabled, connections shall be authenticated as specified in RFC 2246, and the device shall before all validate the client TLS certificate. In case of invalid certificate the TLS connection shall be terminated and the device shall ignore any other credentials received on HTTP or WS layer.</para>
-        <para>Once a service request is authenticated on the TLS layer, the device shall decide based on its  access policy whether the requestor is authorized to receive the service. In order to authorize the requestor, additional information for the device is required.</para>
-        <para>If CnMapsToUser is true, the name of the user requiring access to the device shall be presented in the Common Name (CN) attribute of the certificate presented by the client to the device. The device shall validate the provided username against its set of credentials, and grant access to the requested function in case of success. If the user is not allowed to access the function, the device shall return a 403 Forbidden.</para>
-        <para>If CnMapsToUser is false, from this point forward the authorization procedure follows what is specified in the ONVIF Core Specification as part of the security service.</para>
-        <para>The authentication  and authorization process and falling back to the  ONVIF Core Specification is illustrated in <xref linkend="image5"/>.</para>
+        <para>If TLS client authentication is enabled, connections shall be authenticated as
+          specified in RFC 2246, and the device shall before all validate the client TLS
+          certificate. In case of invalid certificate the TLS connection shall be terminated and the
+          device shall ignore any other credentials received on HTTP or WS layer.</para>
+        <para>Once a service request is authenticated on the TLS layer, the device shall decide
+          based on its access policy whether the requestor is authorized to receive the service. In
+          order to authorize the requestor, additional information for the device is
+          required.</para>
+        <para>If CnMapsToUser is true, the name of the user requiring access to the device shall be
+          presented in the Common Name (CN) attribute of the certificate presented by the client to
+          the device. The device shall validate the provided username against its set of
+          credentials, and grant access to the requested function in case of success. If the user is
+          not allowed to access the function, the device shall return a 403 Forbidden.</para>
+        <para>If CnMapsToUser is false, from this point forward the authorization procedure follows
+          what is specified in the ONVIF Core Specification as part of the security service.</para>
+        <para>The authentication and authorization process and falling back to the ONVIF Core
+          Specification is illustrated in <xref linkend="image5"/>.</para>
         <figure xml:id="image5">
-          <title>Authentication and authorization flow chart and fallback mechanism to the ONVIF Core Specification.</title>
+          <title>Authentication and authorization flow chart and fallback mechanism to the ONVIF
+            Core Specification.</title>
           <mediaobject>
             <imageobject>
               <imagedata fileref="media/Security/image5.svg" contentwidth="160mm"/>
@@ -2751,13 +3544,36 @@
         <title>TLS Server Operations</title>
         <section>
           <title>AddServerCertificateAssignment</title>
-          <para>This operation assigns a key pair and certificate along with a certification path (certificate chain) to the TLS server on the device. The TLS server shall use this information for key exchange during the TLS handshake, particularly for constructing server certificate messages as specified in RFC 4346, RFC 2246.</para>
-          <para>Certification paths are identified by their certification path IDs in the keystore. The first certificate in the certification path shall be the TLS server certificate.</para>
-          <para>Since each certificate has exactly one associated key pair, a reference to the key pair that is associated with the server certificate is not supplied explicitly. Devices shall obtain the private key or results of operations under the private key by suitable internal interaction with the keystore.</para>
-          <para>If a device chooses to perform a TLS key exchange based on the supplied certification path,  it shall use the key pair that is associated with the server certificate for key exchange and transmit the certification path to TLS clients as-is, i.e., the device shall not check conformance of the certification path to RFC 4346, RFC 2246.</para>
-          <para>In order to use the server certificate during the TLS handshake, the corresponding private key is required. Therefore, if the key pair that is associated with the server certificate, i.e., the first certificate in the certification path, does not have an associated private key, the NoPrivateKey fault is produced and the certification path is not associated with the TLS server.</para>
-          <para>A TLS server may present different certification paths to different clients during the TLS handshake instead of presenting the same certification path to all clients. Therefore more than one certification path may be assigned to the TLS server. If the maximum number of certification paths that may be assigned to the TLS server simultaneously is reached, the device shall generate a MaximumNumberOfTLSCertificationPathsReached fault and the requested certification path shall not be assigned to the TLS server.</para>
-          <para>If the certification path identified by the supplied certification path ID is already assigned to the TLS server, this command shall have no effect.</para>
+          <para>This operation assigns a key pair and certificate along with a certification path
+            (certificate chain) to the TLS server on the device. The TLS server shall use this
+            information for key exchange during the TLS handshake, particularly for constructing
+            server certificate messages as specified in RFC 4346, RFC 2246.</para>
+          <para>Certification paths are identified by their certification path IDs in the keystore.
+            The first certificate in the certification path shall be the TLS server
+            certificate.</para>
+          <para>Since each certificate has exactly one associated key pair, a reference to the key
+            pair that is associated with the server certificate is not supplied explicitly. Devices
+            shall obtain the private key or results of operations under the private key by suitable
+            internal interaction with the keystore.</para>
+          <para>If a device chooses to perform a TLS key exchange based on the supplied
+            certification path, it shall use the key pair that is associated with the server
+            certificate for key exchange and transmit the certification path to TLS clients as-is,
+            i.e., the device shall not check conformance of the certification path to RFC 4346, RFC
+            2246.</para>
+          <para>In order to use the server certificate during the TLS handshake, the corresponding
+            private key is required. Therefore, if the key pair that is associated with the server
+            certificate, i.e., the first certificate in the certification path, does not have an
+            associated private key, the NoPrivateKey fault is produced and the certification path is
+            not associated with the TLS server.</para>
+          <para>A TLS server may present different certification paths to different clients during
+            the TLS handshake instead of presenting the same certification path to all clients.
+            Therefore more than one certification path may be assigned to the TLS server. If the
+            maximum number of certification paths that may be assigned to the TLS server
+            simultaneously is reached, the device shall generate a
+            MaximumNumberOfTLSCertificationPathsReached fault and the requested certification path
+            shall not be assigned to the TLS server.</para>
+          <para>If the certification path identified by the supplied certification path ID is
+            already assigned to the TLS server, this command shall have no effect.</para>
           <variablelist role="op">
             <varlistentry>
               <term>request</term>
@@ -2777,11 +3593,15 @@
               <term>faults</term>
               <listitem>
                 <para role="param">env:Sender - ter:InvalidArgVal - ter:CertificationPathID </para>
-                <para role="text">No certification path is stored in the keystore under the given certification path ID.</para>
+                <para role="text">No certification path is stored in the keystore under the given
+                  certification path ID.</para>
                 <para role="param">env:Sender - ter:InvalidArgVal - ter:NoPrivateKey </para>
-                <para role="text">The key pair that is associated with the first certificate in the certificate chain does not have an associated private key.</para>
-                <para role="param">env: Receiver - ter: Action - ter:MaximumNumberOfTLSCertificationPathsReached </para>
-                <para role="text">The maximum number of certification paths that may be assigned to the TLS server simultaneously is reached.</para>
+                <para role="text">The key pair that is associated with the first certificate in the
+                  certificate chain does not have an associated private key.</para>
+                <para role="param">env: Receiver - ter: Action -
+                  ter:MaximumNumberOfTLSCertificationPathsReached </para>
+                <para role="text">The maximum number of certification paths that may be assigned to
+                  the TLS server simultaneously is reached.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
@@ -2794,14 +3614,19 @@
         </section>
         <section>
           <title>RemoveServerCertificateAssignment</title>
-          <para>This operation removes a key pair and certificate assignment (including certification path) to the TLS server on the device.</para>
-          <para>Certification paths are identified using certification path IDs. If the supplied certification path ID is not associated with the TLS server, an InvalidArgVal fault is produced.</para>
-          <para>If the TLS server on the device is enabled, the device shall produce a ReferenceExists fault and shall not remove the server certificate assignment.</para>
+          <para>This operation removes a key pair and certificate assignment (including
+            certification path) to the TLS server on the device.</para>
+          <para>Certification paths are identified using certification path IDs. If the supplied
+            certification path ID is not associated with the TLS server, an InvalidArgVal fault is
+            produced.</para>
+          <para>If the TLS server on the device is enabled, the device shall produce a
+            ReferenceExists fault and shall not remove the server certificate assignment.</para>
           <variablelist role="op">
             <varlistentry>
               <term>request</term>
               <listitem>
-                <para role="param">CertificationPathID - [tas:CertificationPathID] The ID of the certification path to remove from the TLS server.</para>
+                <para role="param">CertificationPathID - [tas:CertificationPathID] The ID of the
+                  certification path to remove from the TLS server.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
@@ -2813,8 +3638,10 @@
             <varlistentry>
               <term>faults</term>
               <listitem>
-                <para role="param">env:Sender - ter:InvalidArgVal - ter:OldCertificationPathID</para>
-                <para role="text"> No certification path under the given certification path ID is associated with the TLS server.</para>
+                <para role="param">env:Sender - ter:InvalidArgVal -
+                  ter:OldCertificationPathID</para>
+                <para role="text"> No certification path under the given certification path ID is
+                  associated with the TLS server.</para>
                 <para role="param">env:Sender - ter:InvalidArgVal - ter:ReferenceExists</para>
                 <para role="text"> A reference exists for the object that is to be deleted.</para>
               </listitem>
@@ -2829,21 +3656,45 @@
         </section>
         <section>
           <title>ReplaceServerCertificateAssignment</title>
-          <para>This operation replaces an existing key pair and certificate assignment to the TLS server on the device by a new key pair and certificate assignment (including certification paths).</para>
-          <para>After the replacement, the TLS server shall use the new certificate and certification path exactly in those cases in which it would have used the old certificate and certification path. Therefore, especially in the case that several server certificates are assigned to the TLS server, clients that wish to replace an old certificate assignment by a new assignment should use this operation instead of a combination of the Add TLS Server Certificate Assignment and the Remove TLS Server Certificate Assignment operations.</para>
-          <para>Certification paths are identified using certification path IDs. If the supplied old certification path ID is not associated with the TLS server, or no certification path exists under the new certification path ID, the corresponding InvalidArgVal faults are produced and the associations are unchanged.</para>
-          <para>The first certificate in the new certification path shall be the TLS server certificate.</para>
-          <para>Since each certificate has exactly one associated key pair, a reference to the key pair that is associated with the new server certificate is not supplied explicitly. Devices shall obtain the private key or results of operations under the private key by suitable internal interaction with the keystore.</para>
-          <para>If a device chooses to perform a TLS key exchange based on the new certification path, it shall use the key pair that is associated with the server certificate for key exchange and transmit the certification path to TLS clients as-is, i.e., the device shall not check conformance of the certification path to RFC 4346, RFC 2246.</para>
-          <para>In order to use the server certificate during the TLS handshake, the corresponding private key is required. Therefore, if the key pair that is associated with the server certificate, i.e., the first certificate in the certification path, does not have an associated private key, the NoPrivateKey fault is produced and the certification path is not associated with the TLS server.</para>
+          <para>This operation replaces an existing key pair and certificate assignment to the TLS
+            server on the device by a new key pair and certificate assignment (including
+            certification paths).</para>
+          <para>After the replacement, the TLS server shall use the new certificate and
+            certification path exactly in those cases in which it would have used the old
+            certificate and certification path. Therefore, especially in the case that several
+            server certificates are assigned to the TLS server, clients that wish to replace an old
+            certificate assignment by a new assignment should use this operation instead of a
+            combination of the Add TLS Server Certificate Assignment and the Remove TLS Server
+            Certificate Assignment operations.</para>
+          <para>Certification paths are identified using certification path IDs. If the supplied old
+            certification path ID is not associated with the TLS server, or no certification path
+            exists under the new certification path ID, the corresponding InvalidArgVal faults are
+            produced and the associations are unchanged.</para>
+          <para>The first certificate in the new certification path shall be the TLS server
+            certificate.</para>
+          <para>Since each certificate has exactly one associated key pair, a reference to the key
+            pair that is associated with the new server certificate is not supplied explicitly.
+            Devices shall obtain the private key or results of operations under the private key by
+            suitable internal interaction with the keystore.</para>
+          <para>If a device chooses to perform a TLS key exchange based on the new certification
+            path, it shall use the key pair that is associated with the server certificate for key
+            exchange and transmit the certification path to TLS clients as-is, i.e., the device
+            shall not check conformance of the certification path to RFC 4346, RFC 2246.</para>
+          <para>In order to use the server certificate during the TLS handshake, the corresponding
+            private key is required. Therefore, if the key pair that is associated with the server
+            certificate, i.e., the first certificate in the certification path, does not have an
+            associated private key, the NoPrivateKey fault is produced and the certification path is
+            not associated with the TLS server.</para>
           <variablelist role="op">
             <varlistentry>
               <term>request</term>
               <listitem>
                 <para role="param">OldCertificationPathID - [tas:CertificationPathID] </para>
-                <para role="text">The ID of the certification path to remove from the TLS server.</para>
+                <para role="text">The ID of the certification path to remove from the TLS
+                  server.</para>
                 <para role="param">NewCertificationPathID - [tas:CertificationPathID] </para>
-                <para role="text">The ID of the certification path to assign to the TLS server.</para>
+                <para role="text">The ID of the certification path to assign to the TLS
+                  server.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
@@ -2856,9 +3707,11 @@
               <term>faults</term>
               <listitem>
                 <para role="param">env:Sender - ter:InvalidArgVal - ter:OldCertificationPathID </para>
-                <para role="text">No certification path under the given certification path ID is associated with the TLS server.</para>
+                <para role="text">No certification path under the given certification path ID is
+                  associated with the TLS server.</para>
                 <para role="param">env:Sender - ter:InvalidArgVal - ter:NewCertificationPathID </para>
-                <para role="text">No certification path is stored in the keystore under the given certification path ID.</para>
+                <para role="text">No certification path is stored in the keystore under the given
+                  certification path ID.</para>
                 <para role="param">env:Sender - ter:InvalidArgVal - ter:NoPrivateKey </para>
                 <para role="text">The key pair that is associated with the leaf certificate in the
                   certificate chain does not have an associated private key.</para>
@@ -2874,9 +3727,12 @@
         </section>
         <section>
           <title>GetAssignedServerCertificates</title>
-          <para>This operation returns the IDs of all certification paths that are assigned to the TLS server on the device.</para>
-          <para>This operation may be used, e.g., if a client lost track of the certification path assignments on the device.</para>
-          <para>If no certification path is assigned to the TLS server, an empty list is returned.</para>
+          <para>This operation returns the IDs of all certification paths that are assigned to the
+            TLS server on the device.</para>
+          <para>This operation may be used, e.g., if a client lost track of the certification path
+            assignments on the device.</para>
+          <para>If no certification path is assigned to the TLS server, an empty list is
+            returned.</para>
           <variablelist role="op">
             <varlistentry>
               <term>request</term>
@@ -2887,7 +3743,8 @@
             <varlistentry>
               <term>response</term>
               <listitem>
-                <para role="param">CertificationPathID - optional, unbounded [tas:CertificationPathID] </para>
+                <para role="param">CertificationPathID - optional, unbounded
+                  [tas:CertificationPathID] </para>
                 <para role="text">List of certification path IDs assigned to the TLS server.</para>
               </listitem>
             </varlistentry>
@@ -2907,16 +3764,23 @@
         </section>
         <section>
           <title>SetClientAuthenticationRequired</title>
-          <para>This operation activates or deactivates TLS client authentication for the TLS server on the device.</para>
-          <para>The TLS server on the device shall require client authentication if and only if clientAuthenticationRequired is set to <emphasis>true</emphasis>.</para>
-          <para>If TLS client authentication is requested to be enabled and no certification path validation policy is assigned to the TLS server, the device shall return an EnablingClientAuthenticationFailed fault and shall not enable TLS client authentication.</para>
-          <para>The device shall execute this command regardless of the TLS enabled/disabled state configured in the ONVIF Device Management Service.</para>
+          <para>This operation activates or deactivates TLS client authentication for the TLS server
+            on the device.</para>
+          <para>The TLS server on the device shall require client authentication if and only if
+            clientAuthenticationRequired is set to <emphasis>true</emphasis>.</para>
+          <para>If TLS client authentication is requested to be enabled and no certification path
+            validation policy is assigned to the TLS server, the device shall return an
+            EnablingClientAuthenticationFailed fault and shall not enable TLS client
+            authentication.</para>
+          <para>The device shall execute this command regardless of the TLS enabled/disabled state
+            configured in the ONVIF Device Management Service.</para>
           <variablelist role="op">
             <varlistentry>
               <term>request</term>
               <listitem>
                 <para role="param">clientAuthenticationRequired - [xs:boolean] </para>
-                <para role="text">Define whether TLS client authentication is active on the device.</para>
+                <para role="text">Define whether TLS client authentication is active on the
+                  device.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
@@ -2928,8 +3792,10 @@
             <varlistentry>
               <term>faults</term>
               <listitem>
-                <para role="param">env:Receiver - ter:ActionNotSupported - ter:EnablingClientAuthenticationFailed </para>
-                <para role="text">The device does not support TLS client authentication, or TLS client authentication is not configured appropriately.</para>
+                <para role="param">env:Receiver - ter:ActionNotSupported -
+                  ter:EnablingClientAuthenticationFailed </para>
+                <para role="text">The device does not support TLS client authentication, or TLS
+                  client authentication is not configured appropriately.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
@@ -2954,7 +3820,8 @@
               <term>response</term>
               <listitem>
                 <para role="param">clientAuthenticationRequired - [xs:boolean] </para>
-                <para role="text">Report whether TLS client authentication is active on the device.</para>
+                <para role="text">Report whether TLS client authentication is active on the
+                  device.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
@@ -2973,14 +3840,17 @@
         </section>
         <section>
           <title>SetCnMapsToUser</title>
-          <para>This operation enables or disables mapping of the Common Name present in the TLS client certificate to an existing user name in the device.</para>
-          <para>The TLS server on the device shall perform mapping if parameter clientAuthenticationRequired is set to <emphasis>true</emphasis>.</para>
+          <para>This operation enables or disables mapping of the Common Name present in the TLS
+            client certificate to an existing user name in the device.</para>
+          <para>The TLS server on the device shall perform mapping if parameter
+            clientAuthenticationRequired is set to <emphasis>true</emphasis>.</para>
           <variablelist role="op">
             <varlistentry>
               <term>request</term>
               <listitem>
                 <para role="param">cnMapsToUser - [xs:boolean]</para>
-                <para role="text">A request for the device to enable or disable Common Name Mapping to User.</para>
+                <para role="text">A request for the device to enable or disable Common Name Mapping
+                  to User.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
@@ -2993,7 +3863,8 @@
               <term>faults</term>
               <listitem>
                 <para role="param">env:Receiver - ter:ActionNotSupported - ter:CnMapsToUserFailed </para>
-                <para role="text">The device does not support TLS client authentication, or TLS client authentication is not configured appropriately.</para>
+                <para role="text">The device does not support TLS client authentication, or TLS
+                  client authentication is not configured appropriately.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
@@ -3037,9 +3908,19 @@
         </section>
         <section>
           <title>AddCertPathValidationPolicyAssignment</title>
-          <para>This operation assigns a certification path validation policy to the TLS server on the device. The TLS server shall enforce the policy when authenticating TLS clients and consider a client authentic if Certificaton Path Validation according to section 6 of RFC 5280 succeeds.</para>
-          <para>If no certification path validation policy is stored under the requested CertPathValidationPolicyID, the device shall produce a CertPathValidationPolicyID fault.</para>
-          <para>A TLS server may use different certification path validation policies to authenticate clients. Therefore more than one certification path validation policy may be assigned to the TLS server. If the maximum number of certification path validation policies that may be assigned to the TLS server simultaneously is reached, the device shall produce a MaximumNumberOfTLSCertPathValidationPoliciesReached fault and shall not assign the requested certification path validation policy to the TLS server.</para>
+          <para>This operation assigns a certification path validation policy to the TLS server on
+            the device. The TLS server shall enforce the policy when authenticating TLS clients and
+            consider a client authentic if Certificaton Path Validation according to section 6 of
+            RFC 5280 succeeds.</para>
+          <para>If no certification path validation policy is stored under the requested
+            CertPathValidationPolicyID, the device shall produce a CertPathValidationPolicyID
+            fault.</para>
+          <para>A TLS server may use different certification path validation policies to
+            authenticate clients. Therefore more than one certification path validation policy may
+            be assigned to the TLS server. If the maximum number of certification path validation
+            policies that may be assigned to the TLS server simultaneously is reached, the device
+            shall produce a MaximumNumberOfTLSCertPathValidationPoliciesReached fault and shall not
+            assign the requested certification path validation policy to the TLS server.</para>
           <variablelist role="op">
             <varlistentry>
               <term>request</term>
@@ -3061,8 +3942,10 @@
                 <para role="param">env:Sender - ter:InvalidArgVal - ter:CertPathValidationPolicyID </para>
                 <para role="text">No certification path validation policy is stored under the
                   requested CertPathValidationPolicyID.</para>
-                <para role="param">env:Receiver - ter:Action - ter:MaximumNumberOfTLSCertPathValidationPoliciesReached </para>
-                <para role="text">The maximum number of certification path validation policies that may be assigned to the TLS server simultaneously is reached.</para>
+                <para role="param">env:Receiver - ter:Action -
+                  ter:MaximumNumberOfTLSCertPathValidationPoliciesReached </para>
+                <para role="text">The maximum number of certification path validation policies that
+                  may be assigned to the TLS server simultaneously is reached.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
@@ -3075,14 +3958,18 @@
         </section>
         <section>
           <title>RemoveCertPathValidationPolicyAssignment</title>
-          <para>This operation removes a certification path validation policy assignment from the TLS server on the device.</para>
-          <para>If the certification path validation policy identified by the requested CertPathValidationPolicyID is not associated to the TLS server, the device shall produce a CertPathValidationPolicyID fault.</para>
+          <para>This operation removes a certification path validation policy assignment from the
+            TLS server on the device.</para>
+          <para>If the certification path validation policy identified by the requested
+            CertPathValidationPolicyID is not associated to the TLS server, the device shall produce
+            a CertPathValidationPolicyID fault.</para>
           <variablelist role="op">
             <varlistentry>
               <term>request</term>
               <listitem>
                 <para role="param">CertPathValidationPolicyID - [tas:CertPathValidationPolicyID] </para>
-                <para role="text">The ID of the certification path validation policy to remove from the TLS server.</para>
+                <para role="text">The ID of the certification path validation policy to remove from
+                  the TLS server.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
@@ -3095,7 +3982,8 @@
               <term>faults</term>
               <listitem>
                 <para role="param">env:Sender - ter:InvalidArgVal - ter:CertPathValidationPolicyID </para>
-                <para role="text">No certification path validation policy is stored under the requested CertPathValidationPolicyID.</para>
+                <para role="text">No certification path validation policy is stored under the
+                  requested CertPathValidationPolicyID.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
@@ -3108,17 +3996,28 @@
         </section>
         <section>
           <title>ReplaceCertPathValidationPolicyAssignment</title>
-          <para>This operation replaces a certification path validation policy assignment to the TLS server on the device with another certification path validation policy assignment.</para>
-          <para>If the certification path validation policy identified by the requested OldCertPathValidationPolicyID is not associated to the TLS server, the device shall produce an OldCertPathValidationPolicyID fault and shall not associate the certification path validation policy identified by the NewCertPathValidationPolicyID to the TLS server.</para>
-          <para>If no certification path validation policy exists under the requested NewCertPathValidationPolicyID in the device’s keystore, the device shall produce a NewCertPathValidationPolicyID fault and shall not remove the association of the old certification path validation policy to the TLS server.</para>
+          <para>This operation replaces a certification path validation policy assignment to the TLS
+            server on the device with another certification path validation policy
+            assignment.</para>
+          <para>If the certification path validation policy identified by the requested
+            OldCertPathValidationPolicyID is not associated to the TLS server, the device shall
+            produce an OldCertPathValidationPolicyID fault and shall not associate the certification
+            path validation policy identified by the NewCertPathValidationPolicyID to the TLS
+            server.</para>
+          <para>If no certification path validation policy exists under the requested
+            NewCertPathValidationPolicyID in the device’s keystore, the device shall produce a
+            NewCertPathValidationPolicyID fault and shall not remove the association of the old
+            certification path validation policy to the TLS server.</para>
           <variablelist role="op">
             <varlistentry>
               <term>request</term>
               <listitem>
                 <para role="param">OldCertPathValidationPolicyID - [tas:CertPathValidationPolicyID] </para>
-                <para role="text">The ID of the certification path validation policy to remove from the TLS server.</para>
+                <para role="text">The ID of the certification path validation policy to remove from
+                  the TLS server.</para>
                 <para role="param">NewCertPathValidationPolicyID - [tas:CertPathValidationPolicyID] </para>
-                <para role="text">The ID of the certification path validation policy to assign to the TLS server.</para>
+                <para role="text">The ID of the certification path validation policy to assign to
+                  the TLS server.</para>
                 <para role="param">RESPONSE:</para>
                 <para role="text">This message is empty.</para>
               </listitem>
@@ -3126,10 +4025,14 @@
             <varlistentry>
               <term>faults</term>
               <listitem>
-                <para role="param">env:Sender - ter:InvalidArgVal - ter:OldCertPathValidationPolicyID </para>
-                <para role="text">No certification path validation policy under the given OldCertPathValidationPolicyID is associated with the TLS server.</para>
-                <para role="param">env:Sender - ter:InvalidArgVal - ter:NewCertPathValidationPolicyID </para>
-                <para role="text">No certification path validation policy under the given NewCertPathValidationPolicyID is stored in the device’s keystore.</para>
+                <para role="param">env:Sender - ter:InvalidArgVal -
+                  ter:OldCertPathValidationPolicyID </para>
+                <para role="text">No certification path validation policy under the given
+                  OldCertPathValidationPolicyID is associated with the TLS server.</para>
+                <para role="param">env:Sender - ter:InvalidArgVal -
+                  ter:NewCertPathValidationPolicyID </para>
+                <para role="text">No certification path validation policy under the given
+                  NewCertPathValidationPolicyID is stored in the device’s keystore.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
@@ -3142,7 +4045,8 @@
         </section>
         <section>
           <title>GetAssignedCertPathValidationPolicies</title>
-          <para>This operation returns the IDs of all certification path validation policies that are assigned to the TLS server on the device.</para>
+          <para>This operation returns the IDs of all certification path validation policies that
+            are assigned to the TLS server on the device.</para>
           <variablelist role="op">
             <varlistentry>
               <term>request</term>
@@ -3153,8 +4057,10 @@
             <varlistentry>
               <term>response</term>
               <listitem>
-                <para role="param">CertPathValidationPolicyID - optional, unbounded [tas:CertPathValidationPolicyID] </para>
-                <para role="text">List of certification path validation policy IDs assigned to the TLS server.</para>
+                <para role="param">CertPathValidationPolicyID - optional, unbounded
+                  [tas:CertPathValidationPolicyID] </para>
+                <para role="text">List of certification path validation policy IDs assigned to the
+                  TLS server.</para>
               </listitem>
             </varlistentry>
             <varlistentry>
@@ -3173,12 +4079,27 @@
         </section>
         <section>
           <title>SetEnabledTLSVersions</title>
-          <para>This operation sets the version(s) of TLS which the device shall use. Valid values are taken from the TLSServerSupported capability.</para>
-          <para>A client initiates a TLS session by sending a ClientHello with the highest TLS version it supports. This suggests to the server that the client can accept any TLS version up to and including that version.</para>
-          <para>The server then chooses the TLS version to use. This is generally the highest TLS version the server supports that is within the range of the client. For example, if a ClientHello indicates TLS version 1.1, the server can proceed with TLS 1.0 or TLS 1.1.</para>
-          <para>In the event that an ONVIF installation wishes to disable certain version(s) of TLS, it may do so with this operation. For example, to disable TLS 1.0 on a device signaling support for TLS versions 1.0, 1.1, and 1.2, the enabled version list may be set to "1.1 1.2", omitting 1.0. If a client then attempts to connect with a ClientHello containing TLS 1.0, the server shall send a "protocol_version" alert message and close the connection. This handshake indicates to the client that TLS 1.0 is not supported by the server. The client must try again with a higher TLS version suggestion.</para>
-          <para>An empty version list is not permitted. Disabling all versions of TLS is not the intent of this operation. See AddServerCertificateAssignment and RemoveServerCertificateAssignment.</para>
-          <para>A device signalling support for TLS version enabling with the EnabledVersionsSupported capability shall support this command.</para>
+          <para>This operation sets the version(s) of TLS which the device shall use. Valid values
+            are taken from the TLSServerSupported capability.</para>
+          <para>A client initiates a TLS session by sending a ClientHello with the highest TLS
+            version it supports. This suggests to the server that the client can accept any TLS
+            version up to and including that version.</para>
+          <para>The server then chooses the TLS version to use. This is generally the highest TLS
+            version the server supports that is within the range of the client. For example, if a
+            ClientHello indicates TLS version 1.1, the server can proceed with TLS 1.0 or TLS
+            1.1.</para>
+          <para>In the event that an ONVIF installation wishes to disable certain version(s) of TLS,
+            it may do so with this operation. For example, to disable TLS 1.0 on a device signaling
+            support for TLS versions 1.0, 1.1, and 1.2, the enabled version list may be set to "1.1
+            1.2", omitting 1.0. If a client then attempts to connect with a ClientHello containing
+            TLS 1.0, the server shall send a "protocol_version" alert message and close the
+            connection. This handshake indicates to the client that TLS 1.0 is not supported by the
+            server. The client must try again with a higher TLS version suggestion.</para>
+          <para>An empty version list is not permitted. Disabling all versions of TLS is not the
+            intent of this operation. See AddServerCertificateAssignment and
+            RemoveServerCertificateAssignment.</para>
+          <para>A device signalling support for TLS version enabling with the
+            EnabledVersionsSupported capability shall support this command.</para>
           <variablelist role="op">
             <varlistentry>
               <term>request</term>
@@ -3212,7 +4133,9 @@
         </section>
         <section>
           <title>GetEnabledTLSVersions</title>
-          <para>This operation retrieves the version(s) of TLS which are currently enabled on the device. A device signalling support for TLS version enabling with the EnabledVersionsSupported capability shall support this command.</para>
+          <para>This operation retrieves the version(s) of TLS which are currently enabled on the
+            device. A device signalling support for TLS version enabling with the
+            EnabledVersionsSupported capability shall support this command.</para>
           <variablelist role="op">
             <varlistentry>
               <term>request</term>
@@ -3248,14 +4171,30 @@
       <section>
         <title>AddDot1XConfiguration</title>
         <para>This operation adds an IEEE 802.1X configuration to the device.</para>
-        <para>Configurations are uniquely identified using IEEE 802.1X configuration IDs. The device shall ignore Dot1XID in the request, if present, and shall generate a unique configuration ID for the added configuration.</para>
-        <para>If the command was successful, the device shall return the ID of the configuration.</para>
-        <para>If the device does not have capacity for the configuration, the device shall produce a MaximumNumberOfDot1XConfigurationsReached fault and shall not add the configuration.</para>
-        <para>If Identity is used as an anonymous identity for the corresponding authentication method, the device shall ignore an eventually supplied passphrase ID in the same Dot1XStage. Otherwise, if the device cannot process a passphrase ID included in the configuration to be added, the device shall produce a PassphraseID fault and shall not add the configuration.</para>
-        <para>If the device cannot process a certification path ID included in the configuration to be added, the device shall produce a CertificationPathID fault and shall not add the configuration.</para>
-        <para>If the device cannot process an authentication method included in the configuration to be added (e.g., unrecognized method or missing configuration parameter), the device shall produce a Dot1XMethod fault and shall not add the configuration.</para>
-        <para>If the device cannot process the authentication method combination in the configuration to be added, the device shall produce a Dot1XMethodCombination fault and shall not add the configuration.</para>
-        <para>A device signalling support for IEEE 802.1X configuration with the MaximumNumberOfDot1XConfigurations capability shall support this command.</para>
+        <para>Configurations are uniquely identified using IEEE 802.1X configuration IDs. The device
+          shall ignore Dot1XID in the request, if present, and shall generate a unique configuration
+          ID for the added configuration.</para>
+        <para>If the command was successful, the device shall return the ID of the
+          configuration.</para>
+        <para>If the device does not have capacity for the configuration, the device shall produce a
+          MaximumNumberOfDot1XConfigurationsReached fault and shall not add the
+          configuration.</para>
+        <para>If Identity is used as an anonymous identity for the corresponding authentication
+          method, the device shall ignore an eventually supplied passphrase ID in the same
+          Dot1XStage. Otherwise, if the device cannot process a passphrase ID included in the
+          configuration to be added, the device shall produce a PassphraseID fault and shall not add
+          the configuration.</para>
+        <para>If the device cannot process a certification path ID included in the configuration to
+          be added, the device shall produce a CertificationPathID fault and shall not add the
+          configuration.</para>
+        <para>If the device cannot process an authentication method included in the configuration to
+          be added (e.g., unrecognized method or missing configuration parameter), the device shall
+          produce a Dot1XMethod fault and shall not add the configuration.</para>
+        <para>If the device cannot process the authentication method combination in the
+          configuration to be added, the device shall produce a Dot1XMethodCombination fault and
+          shall not add the configuration.</para>
+        <para>A device signalling support for IEEE 802.1X configuration with the
+          MaximumNumberOfDot1XConfigurations capability shall support this command.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>
@@ -3276,16 +4215,21 @@
           <varlistentry>
             <term>faults</term>
             <listitem>
-              <para role="param">env:Receiver - ter:Action - ter:MaximumNumberOfDot1XConfigurationsReached </para>
-              <para role="text">The device already has the number of configurations specified by MaximumNumberOfDot1XConfigurations.</para>
+              <para role="param">env:Receiver - ter:Action -
+                ter:MaximumNumberOfDot1XConfigurationsReached </para>
+              <para role="text">The device already has the number of configurations specified by
+                MaximumNumberOfDot1XConfigurations.</para>
               <para role="param">env:Sender - ter:InvalidArgVal - ter:PassphraseID </para>
               <para role="text">A supplied passphrase ID cannot be processed by the device.</para>
               <para role="param">env:Sender - ter:InvalidArgVal - ter:CertificationPathID </para>
-              <para role="text">A supplied certification path ID cannot be processed by the device.</para>
+              <para role="text">A supplied certification path ID cannot be processed by the
+                device.</para>
               <para role="param">env:Sender - ter:InvalidArgVal - ter:Dot1XMethod </para>
-              <para role="text">A supplied IEEE 802.1X authentication method cannot be processed by the device.</para>
+              <para role="text">A supplied IEEE 802.1X authentication method cannot be processed by
+                the device.</para>
               <para role="param">env:Sender - ter:InvalidArgVal - ter:Dot1XMethodCombination </para>
-              <para role="text">The combination of IEEE 802.1X authentication methods cannot be processed by the device.</para>
+              <para role="text">The combination of IEEE 802.1X authentication methods cannot be
+                processed by the device.</para>
             </listitem>
           </varlistentry>
           <varlistentry>
@@ -3298,9 +4242,13 @@
       </section>
       <section>
         <title>GetAllDot1XConfigurations</title>
-        <para>This operation returns details of all IEEE 802.1X configurations that are on the device.  This operation may be used, e.g., if a client lost track of which IEEE 802.1X configurations are present on the device.</para>
-        <para>If no IEEE 802.1X configurations exist on the device, an empty list is returned.</para>
-        <para>A device signalling support for IEEE 802.1X configuration with the MaximumNumberOfDot1XConfigurations capability shall support this command.</para>
+        <para>This operation returns details of all IEEE 802.1X configurations that are on the
+          device. This operation may be used, e.g., if a client lost track of which IEEE 802.1X
+          configurations are present on the device.</para>
+        <para>If no IEEE 802.1X configurations exist on the device, an empty list is
+          returned.</para>
+        <para>A device signalling support for IEEE 802.1X configuration with the
+          MaximumNumberOfDot1XConfigurations capability shall support this command.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>
@@ -3331,9 +4279,12 @@
       </section>
       <section>
         <title>GetDot1XConfiguration</title>
-        <para>This operation returns details of a specific IEEE 802.1X configuration on the device.</para>
-        <para>If the device cannot process the provided IEEE 802.1X configuration ID, the device shall produce a Dot1XConfigurationID fault.</para>
-        <para>A device signalling support for IEEE 802.1X configuration with the MaximumNumberOfDot1XConfigurations capability shall support this command.</para>
+        <para>This operation returns details of a specific IEEE 802.1X configuration on the
+          device.</para>
+        <para>If the device cannot process the provided IEEE 802.1X configuration ID, the device
+          shall produce a Dot1XConfigurationID fault.</para>
+        <para>A device signalling support for IEEE 802.1X configuration with the
+          MaximumNumberOfDot1XConfigurations capability shall support this command.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>
@@ -3353,7 +4304,8 @@
             <term>faults</term>
             <listitem>
               <para role="param">env:Sender - ter:InvalidArgVal - ter:Dot1XConfigurationID </para>
-              <para role="text">The supplied IEEE 802.1X configuration ID cannot be processed by the device.</para>
+              <para role="text">The supplied IEEE 802.1X configuration ID cannot be processed by the
+                device.</para>
             </listitem>
           </varlistentry>
           <varlistentry>
@@ -3367,16 +4319,21 @@
       <section>
         <title>DeleteDot1XConfiguration</title>
         <para>This operation deletes an IEEE 802.1X configuration from the device.</para>
-        <para>If the device cannot process the provided IEEE 802.1X configuration ID, the device shall produce a Dot1XConfigurationID fault.</para>
-        <para>If a reference exists for the specified IEEE 802.1X configuration, the device shall produce a ReferenceExists fault and shall not delete the configuration.</para>
-        <para>After an IEEE 802.1X configuration has been successfully deleted, the device may assign its former ID to a new configuration.</para>
-        <para>A device signalling support for IEEE 802.1X configuration with the MaximumNumberOfDot1XConfigurations capability shall support this command.</para>
+        <para>If the device cannot process the provided IEEE 802.1X configuration ID, the device
+          shall produce a Dot1XConfigurationID fault.</para>
+        <para>If a reference exists for the specified IEEE 802.1X configuration, the device shall
+          produce a ReferenceExists fault and shall not delete the configuration.</para>
+        <para>After an IEEE 802.1X configuration has been successfully deleted, the device may
+          assign its former ID to a new configuration.</para>
+        <para>A device signalling support for IEEE 802.1X configuration with the
+          MaximumNumberOfDot1XConfigurations capability shall support this command.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>
             <listitem>
               <para role="param">Dot1XID - [tas:Dot1XID] </para>
-              <para role="text">The unique identifier of the 802.1X configuration to be deleted.</para>
+              <para role="text">The unique identifier of the 802.1X configuration to be
+                deleted.</para>
             </listitem>
           </varlistentry>
           <varlistentry>
@@ -3389,9 +4346,11 @@
             <term>faults</term>
             <listitem>
               <para role="param">env:Sender - ter:InvalidArgVal - ter:Dot1XConfigurationID </para>
-              <para role="text">The supplied IEEE 802.1X configuration ID cannot be processed by the device.</para>
+              <para role="text">The supplied IEEE 802.1X configuration ID cannot be processed by the
+                device.</para>
               <para role="param">env:Sender - ter:InvalidArgVal - ter:ReferenceExists </para>
-              <para role="text">A network interface reference exists for the specified IEEE 802.1X configuration.</para>
+              <para role="text">A network interface reference exists for the specified IEEE 802.1X
+                configuration.</para>
             </listitem>
           </varlistentry>
           <varlistentry>
@@ -3404,18 +4363,35 @@
       </section>
       <section>
         <title>SetNetworkInterfaceDot1XConfiguration</title>
-        <para>This operation binds an IEEE 802.1X configuration to a network interface on the device.  This operation shall either create a new binding or replace an existing binding.  On failure when an existing binding already exists, the existing binding shall remain.</para>
-        <para>The Device Management SetNetworkInterface operation provides a method of binding an IEEE 802.1X configuration to an IEEE 802.11 (wireless) interface, and that operation may still be used.  But there is no ability for SetNetworkInterface to bind an IEEE 802.1X configuration to a hardwired interface.  This operation is provided to bind an IEEE 802.1X configuration to either type of interface.</para>
-        <para>If SetNetworkInterfaceDot1XConfiguration is used to bind an IEEE 802.1X configuration to an IEEE 802.11 (wireless) interface, then the DeviceManagement GetNetworkInterfaces operation shall return the IEEE 802.1X configuration ID along with the rest of that interface’s configuration information.</para>
-        <para>If the device cannot process the provided network interface token, the device shall produce an InvalidNetworkInterface fault.</para>
-        <para>If the device cannot process the provided IEEE 802.1X configuration ID, the device shall produce a Dot1XConfigurationID fault.</para>
-        <para>A device signalling support for IEEE 802.1X configuration with the MaximumNumberOfDot1XConfigurations capability shall support this command.</para>
+        <para>This operation binds an IEEE 802.1X configuration to a network interface on the
+          device. This operation shall either create a new binding or replace an existing binding.
+          On failure when an existing binding already exists, the existing binding shall
+          remain.</para>
+        <para>The Device Management SetNetworkInterface operation provides a method of binding an
+          IEEE 802.1X configuration to an IEEE 802.11 (wireless) interface, and that operation may
+          still be used. But there is no ability for SetNetworkInterface to bind an IEEE 802.1X
+          configuration to a hardwired interface. This operation is provided to bind an IEEE 802.1X
+          configuration to either type of interface.</para>
+        <para>If SetNetworkInterfaceDot1XConfiguration is used to bind an IEEE 802.1X configuration
+          to an IEEE 802.11 (wireless) interface, then the DeviceManagement GetNetworkInterfaces
+          operation shall return the IEEE 802.1X configuration ID along with the rest of that
+          interface’s configuration information.</para>
+        <para>If the device cannot process the provided network interface token, the device shall
+          produce an InvalidNetworkInterface fault.</para>
+        <para>If the device cannot process the provided IEEE 802.1X configuration ID, the device
+          shall produce a Dot1XConfigurationID fault.</para>
+        <para>A device signalling support for IEEE 802.1X configuration with the
+          MaximumNumberOfDot1XConfigurations capability shall support this command.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>
             <listitem>
               <para role="param">token - [xs:string] </para>
-              <para role="text">The unique identifier of the Network Interface on which the 802.1X configuration is to be set. (NOTE: the network interface token is defined in devicemgmt.wsdl as tt:ReferenceToken, which is a derived type of xs:string.  To avoid importing all of common.xsd for this single type, the base type is used here.)</para>
+              <para role="text">The unique identifier of the Network Interface on which the 802.1X
+                configuration is to be set. (NOTE: the network interface token is defined in
+                devicemgmt.wsdl as tt:ReferenceToken, which is a derived type of xs:string. To avoid
+                importing all of common.xsd for this single type, the base type is used
+                here.)</para>
               <para role="param">Dot1XID - [tas:Dot1XID] </para>
               <para role="text">The unique identifier of the 802.1X configuration to be set.</para>
             </listitem>
@@ -3424,7 +4400,8 @@
             <term>response</term>
             <listitem>
               <para role="param">RebootNeeded - [xs:boolean] </para>
-              <para role="text">Indicates whether or not a reboot is required after configuration updates.</para>
+              <para role="text">Indicates whether or not a reboot is required after configuration
+                updates.</para>
             </listitem>
           </varlistentry>
           <varlistentry>
@@ -3433,7 +4410,8 @@
               <para role="param">env:Sender - ter:InvalidArgVal - ter:InvalidNetworkInterface </para>
               <para role="text">The supplied network interface token does not exist.</para>
               <para role="param">env:Sender - ter:InvalidArgVal - ter:Dot1XConfigurationID </para>
-              <para role="text">The supplied IEEE 802.1X configuration ID cannot be processed by the device.</para>
+              <para role="text">The supplied IEEE 802.1X configuration ID cannot be processed by the
+                device.</para>
             </listitem>
           </varlistentry>
           <varlistentry>
@@ -3446,23 +4424,35 @@
       </section>
       <section>
         <title>GetNetworkInterfaceDot1XConfiguration</title>
-        <para>This operation returns the IEEE 802.1X ID and configuration associated with a network interface on the device.  If there is no IEEE 802.1X configuration associated with the specified network interface, then the response shall be empty.</para>
-        <para>If the Device Management SetNetworkInterface operation was used to bind an IEEE 802.1X configuration to an IEEE 802.11 (wireless) interface, then this operation shall return the IEEE 802.1X configuration information as if the SetNetworkInterfaceDot1XConfiguration operation had been used.</para>
-        <para>If the device cannot process the provided network interface token, the device shall produce an InvalidNetworkInterface fault.</para>
-        <para>A device signalling support for IEEE 802.1X configuration with the MaximumNumberOfDot1XConfigurations capability shall support this command.</para>
+        <para>This operation returns the IEEE 802.1X ID and configuration associated with a network
+          interface on the device. If there is no IEEE 802.1X configuration associated with the
+          specified network interface, then the response shall be empty.</para>
+        <para>If the Device Management SetNetworkInterface operation was used to bind an IEEE 802.1X
+          configuration to an IEEE 802.11 (wireless) interface, then this operation shall return the
+          IEEE 802.1X configuration information as if the SetNetworkInterfaceDot1XConfiguration
+          operation had been used.</para>
+        <para>If the device cannot process the provided network interface token, the device shall
+          produce an InvalidNetworkInterface fault.</para>
+        <para>A device signalling support for IEEE 802.1X configuration with the
+          MaximumNumberOfDot1XConfigurations capability shall support this command.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>
             <listitem>
               <para role="param">token - [xs:string] </para>
-              <para role="text">The unique identifier of the Network Interface for which the 802.1X configuration is to be retrieved. (NOTE: the network interface token is defined in devicemgmt.wsdl as tt:ReferenceToken, which is a derived type of xs:string.  To avoid importing all of common.xsd for this single type, the base type is used here.)</para>
+              <para role="text">The unique identifier of the Network Interface for which the 802.1X
+                configuration is to be retrieved. (NOTE: the network interface token is defined in
+                devicemgmt.wsdl as tt:ReferenceToken, which is a derived type of xs:string. To avoid
+                importing all of common.xsd for this single type, the base type is used
+                here.)</para>
             </listitem>
           </varlistentry>
           <varlistentry>
             <term>response</term>
             <listitem>
               <para role="param">Dot1XID - optional [tas:Dot1XID] </para>
-              <para role="text">The unique identifier of 802.1X configuration assigned to the Network Interface.</para>
+              <para role="text">The unique identifier of 802.1X configuration assigned to the
+                Network Interface.</para>
             </listitem>
           </varlistentry>
           <varlistentry>
@@ -3482,24 +4472,41 @@
       </section>
       <section>
         <title>DeleteNetworkInterfaceDot1XConfiguration</title>
-        <para>This operation unbinds the IEEE 802.1X configuration associated with a network interface on the device.  If there is no IEEE 802.1X configuration associated with the specified network interface, then the operation does nothing.</para>
-        <para>The Device Management SetNetworkInterface operation provides a method of unbinding an IEEE 802.1X configuration from an IEEE 802.11 (wireless) interface by omitting the configuration ID, and that operation may still be used.  But there is no ability for SetNetworkInterface to unbind an IEEE 802.1X configuration from a hardwired interface.  This operation is provided to unbind an IEEE 802.1X configuration from either type of interface.</para>
-        <para>If the Device Management SetNetworkInterface operation was used to bind an IEEE 802.1X configuration to an IEEE 802.11 (wireless) interface, then this operation shall unbind the IEEE 802.1X configuration information as if the SetNetworkInterfaceDot1XConfiguration operation had been used.</para>
-        <para>If the device cannot process the provided network interface token, the device shall produce an InvalidNetworkInterface fault.</para>
-        <para>A device signalling support for IEEE 802.1X configuration with the MaximumNumberOfDot1XConfigurations capability shall support this command.</para>
+        <para>This operation unbinds the IEEE 802.1X configuration associated with a network
+          interface on the device. If there is no IEEE 802.1X configuration associated with the
+          specified network interface, then the operation does nothing.</para>
+        <para>The Device Management SetNetworkInterface operation provides a method of unbinding an
+          IEEE 802.1X configuration from an IEEE 802.11 (wireless) interface by omitting the
+          configuration ID, and that operation may still be used. But there is no ability for
+          SetNetworkInterface to unbind an IEEE 802.1X configuration from a hardwired interface.
+          This operation is provided to unbind an IEEE 802.1X configuration from either type of
+          interface.</para>
+        <para>If the Device Management SetNetworkInterface operation was used to bind an IEEE 802.1X
+          configuration to an IEEE 802.11 (wireless) interface, then this operation shall unbind the
+          IEEE 802.1X configuration information as if the SetNetworkInterfaceDot1XConfiguration
+          operation had been used.</para>
+        <para>If the device cannot process the provided network interface token, the device shall
+          produce an InvalidNetworkInterface fault.</para>
+        <para>A device signalling support for IEEE 802.1X configuration with the
+          MaximumNumberOfDot1XConfigurations capability shall support this command.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>
             <listitem>
               <para role="param">token - [xs:string] </para>
-              <para role="text">The unique identifier of the Network Interface for which the 802.1X configuration is to be deleted.  (NOTE: the network interface token is defined in devicemgmt.wsdl as tt:ReferenceToken, which is a derived type of xs:string.  To avoid importing all of common.xsd for this single type, the base type is used here.)</para>
+              <para role="text">The unique identifier of the Network Interface for which the 802.1X
+                configuration is to be deleted. (NOTE: the network interface token is defined in
+                devicemgmt.wsdl as tt:ReferenceToken, which is a derived type of xs:string. To avoid
+                importing all of common.xsd for this single type, the base type is used
+                here.)</para>
             </listitem>
           </varlistentry>
           <varlistentry>
             <term>response</term>
             <listitem>
               <para role="param">RebootNeeded - [xs:boolean] </para>
-              <para role="text">Indicates whether or not a reboot is required after configuration updates.</para>
+              <para role="text">Indicates whether or not a reboot is required after configuration
+                updates.</para>
             </listitem>
           </varlistentry>
           <varlistentry>
@@ -3523,11 +4530,11 @@
       <section xml:id="section_cfb_gy4_kwb">
         <title>Overview</title>
         <para>Signing of media that is generated by the device is described in the [Media Signing
-          Specification]. Media is signed using a private
-          key that is provisioned during factory production that is stored in a specially protected
-          hardware component (e.g., a trusted platform module). This private key is associated with
-          a certificate that holds the public key. In addition to the factory provisioned key one
-          additional private key can be used to sign media. </para>
+          Specification]. Media is signed using a private key that is provisioned during factory
+          production that is stored in a specially protected hardware component (e.g., a trusted
+          platform module). This private key is associated with a certificate that holds the public
+          key. In addition to the factory provisioned key one additional private key can be used to
+          sign media. </para>
       </section>
       <section xml:id="section_dfb_gy4_kwb">
         <title>AddMediaSigningCertificateAssignment</title>
@@ -3621,7 +4628,8 @@
           signing on the device. This operation will always return the factory provisioned
           certification path and can additionally return a certification path that has been added by
           AddMediaSigningCertificateAssignment.</para>
-        <para>A device shall support this command if the MediaSigningSupported capability is true.</para>
+        <para>A device shall support this command if the MediaSigningSupported capability is
+          true.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>
@@ -3655,7 +4663,9 @@
     </section>
     <section xml:id="section_hd2_5r4_rwb">
       <title>Autorization Server Configuration</title>
-      <para>This chapter describes configuration of external authorization servers. For an overview of this see <xref xmlns:xlink="http://www.w3.org/1999/xlink" linkend="section_b4m_rs4_rwb"/>.</para>
+      <para>This chapter describes configuration of external authorization servers. For an overview
+        of this see <xref xmlns:xlink="http://www.w3.org/1999/xlink" linkend="section_b4m_rs4_rwb"
+        />.</para>
       <section xml:id="section_c22_5r4_rwb">
         <title>GetAuthorizationServerConfigurations</title>
         <para>This operation retrieves an existing authorization server configuration, or all
@@ -3672,7 +4682,8 @@
           <varlistentry>
             <term>response</term>
             <listitem>
-              <para role="param">Configuration - optional, unbounded [tas:AuthorizationServerConfiguration]</para>
+              <para role="param">Configuration - optional, unbounded
+                [tas:AuthorizationServerConfiguration]</para>
               <para role="text">List of authorization server configurations.</para>
             </listitem>
           </varlistentry>
@@ -3716,7 +4727,8 @@
             <term>faults</term>
             <listitem>
               <para role="param">env:Receiver - ter:Action - ter:MaxAuthorizationServers</para>
-              <para role="text">The maximum number of configurations supported by the device has been reached.</para>
+              <para role="text">The maximum number of configurations supported by the device has
+                been reached.</para>
               <para role="param">env:Sender - ter:InvalidArgVal - ter:InvalidConfig</para>
               <para role="text">The configuration parameters are not possible to set.</para>
             </listitem>
@@ -3801,11 +4813,13 @@
     </section>
     <section>
       <title>JWT-based authentication</title>
-      <para>The following functions are defined to control the set of accepted <emphasis>aud</emphasis> claims. See also <xref linkend="_Ref395181339"/>.</para>
+      <para>The following functions are defined to control the set of accepted
+          <emphasis>aud</emphasis> claims. See also <xref linkend="_Ref395181339"/>.</para>
       <section>
         <title>GetJWTConfiguration</title>
         <para>This operation returns the parameters of the JWT authorization used by the device. A
-          device shall support this command if the capability JsonWebToken in the device service capabilities is set.</para>
+          device shall support this command if the capability JsonWebToken in the device service
+          capabilities is set.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>
@@ -3838,8 +4852,10 @@
       <section>
         <title>SetJWTConfiguration</title>
         <para>This operation sets the parameters of the JWT authorization used by the device. A
-          device shall support this command if the capability JsonWebToken in the device service capabilities is set.</para>
-        <para>JWT client authorization of the device is enabled when at least one key or trusted issuer URI is provided.</para>
+          device shall support this command if the capability JsonWebToken in the device service
+          capabilities is set.</para>
+        <para>JWT client authorization of the device is enabled when at least one key or trusted
+          issuer URI is provided.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>
@@ -3865,7 +4881,8 @@
               <para role="param">ter:Sender - ter:InvalidArgVal - ter:MaxIssuersExceeded</para>
               <para role="text">Too many trusted issuers provided.</para>
               <para role="param">env:Sender - ter:InvalidArgVal - ter:CertPathValidationPolicyID </para>
-              <para role="text">No certification path validation policy is stored under the requested certification path validation policy ID.</para>
+              <para role="text">No certification path validation policy is stored under the
+                requested certification path validation policy ID.</para>
             </listitem>
           </varlistentry>
           <varlistentry>
@@ -3875,14 +4892,18 @@
             </listitem>
           </varlistentry>
         </variablelist>
-        <para>A device shall support assignment of as many keys as its key store can hold. A device shall support at least two trusted issuers.</para>
+        <para>A device shall support assignment of as many keys as its key store can hold. A device
+          shall support at least two trusted issuers.</para>
       </section>
     </section>
     <section>
       <title>Capabilities</title>
       <section>
         <title>GetServiceCapabilities</title>
-        <para>The capabilities reflect optional functions and functionality of the different features in the security configuration service. The service capabilities consist of keystore capabilities and TLS server capabilities. The information is static and does not change during device operation.</para>
+        <para>The capabilities reflect optional functions and functionality of the different
+          features in the security configuration service. The service capabilities consist of
+          keystore capabilities and TLS server capabilities. The information is static and does not
+          change during device operation.</para>
         <para>A device shall support this command.</para>
         <variablelist role="op">
           <varlistentry>
@@ -3914,7 +4935,8 @@
       </section>
       <section>
         <title>Keystore Capabilities</title>
-        <para>The keystore capabilities reflect optional functions and functionality of the keystore on a device. The following capabilities are available: </para>
+        <para>The keystore capabilities reflect optional functions and functionality of the keystore
+          on a device. The following capabilities are available: </para>
         <table>
           <title>Keystore Capabilities</title>
           <tgroup cols="2">
@@ -3940,7 +4962,8 @@
                   <para>MaximumNumberOfPassphrases</para>
                 </entry>
                 <entry>
-                  <para>Indicates the maximum number of passphrases that the device is able to store simultaneously.</para>
+                  <para>Indicates the maximum number of passphrases that the device is able to store
+                    simultaneously.</para>
                 </entry>
               </row>
               <row>
@@ -3948,7 +4971,8 @@
                   <para>MaximumNumberOfKeys</para>
                 </entry>
                 <entry>
-                  <para>Indicates the maximum number of keys that the device is able store simultaneously.</para>
+                  <para>Indicates the maximum number of keys that the device is able store
+                    simultaneously.</para>
                 </entry>
               </row>
               <row>
@@ -3956,7 +4980,8 @@
                   <para>MaximumNumberOfCertificates</para>
                 </entry>
                 <entry>
-                  <para>Indicates the maximum number of certificates that the device is able to store simultaneously.</para>
+                  <para>Indicates the maximum number of certificates that the device is able to
+                    store simultaneously.</para>
                 </entry>
               </row>
               <row>
@@ -3964,7 +4989,8 @@
                   <para>MaximumNumberOfCertificationPaths</para>
                 </entry>
                 <entry>
-                  <para>Indicates the maximum number of certificate paths that the device is able to store simultaneously.</para>
+                  <para>Indicates the maximum number of certificate paths that the device is able to
+                    store simultaneously.</para>
                 </entry>
               </row>
               <row>
@@ -3974,18 +5000,10 @@
               </row>
               <row>
                 <entry>
-                  <para>RSAKeyPairGeneration</para>
+                  <para>KeyPairGeneration</para>
                 </entry>
                 <entry>
-                  <para>Indicates support for on-board RSA key pair generation.</para>
-                </entry>
-              </row>
-              <row>
-                <entry>
-                  <para>ECCKeyPairGeneration</para>
-                </entry>
-                <entry>
-                  <para>Indicates support for on-board ECC key pair generation.</para>
+                  <para>List of supported allgorithm for on-board key pair generation.</para>
                 </entry>
               </row>
               <row>
@@ -4006,26 +5024,11 @@
               </row>
               <row>
                 <entry>
-                  <para>PKCS8RSAKeyPairUpload</para>
-                </entry>
-                <entry>
-                  <para>Indicates support for uploading an RSA key pair in a PKCS#8 data structure.</para>
-                </entry>
-              </row>
-              <row>
-                <entry>
                   <para>PKCS8</para>
                 </entry>
                 <entry>
-                  <para>Indicates support for uploading supported key pair in a PKCS#8 data structure.</para>
-                </entry>
-              </row>
-              <row>
-                <entry>
-                  <para>PKCS12CertificateWithRSAPrivateKeyUpload</para>
-                </entry>
-                <entry>
-                  <para>Indicates support for uploading a certificate along with an RSA private key in a PKCS#12 data structure.</para>
+                  <para>Indicates support for uploading supported key pair in a PKCS#8 data
+                    structure.</para>
                 </entry>
               </row>
               <row>
@@ -4033,15 +5036,8 @@
                   <para>PKCS12</para>
                 </entry>
                 <entry>
-                  <para>Indicates support for uploading a certificate along with a private key in a PKCS#12 data structure.</para>
-                </entry>
-              </row>
-              <row>
-                <entry>
-                  <para>PKCS10ExternalCertificationWithRSA</para>
-                </entry>
-                <entry>
-                  <para>Indicates support for creating PKCS#10 requests for RSA keys and uploading the certificate obtained from a CA.</para>
+                  <para>Indicates support for uploading a certificate along with a private key in a
+                    PKCS#12 data structure.</para>
                 </entry>
               </row>
               <row>
@@ -4049,15 +5045,8 @@
                   <para>PKCS10</para>
                 </entry>
                 <entry>
-                  <para>Indicates support for creating PKCS#10 requests for asymetric key pair and uploading the certificate obtained from a CA.</para>
-                </entry>
-              </row>
-              <row>
-                <entry>
-                  <para>SelfSignedCertificateCreationWithRSA</para>
-                </entry>
-                <entry>
-                  <para>Indicates support for creating self-signed certificates for RSA keys.</para>
+                  <para>Indicates support for creating PKCS#10 requests for asymetric key pair and
+                    uploading the certificate obtained from a CA.</para>
                 </entry>
               </row>
               <row>
@@ -4081,7 +5070,8 @@
                   <para>PasswordBasedEncryptionAlgorithms</para>
                 </entry>
                 <entry>
-                  <para>Indicates which password-based encryption algorithms are supported by the device.</para>
+                  <para>Indicates which password-based encryption algorithms are supported by the
+                    device.</para>
                 </entry>
               </row>
               <row>
@@ -4089,7 +5079,8 @@
                   <para>PasswordBasedMACAlgorithms</para>
                 </entry>
                 <entry>
-                  <para>Indicates which password-based MAC algorithms are supported by the device.</para>
+                  <para>Indicates which password-based MAC algorithms are supported by the
+                    device.</para>
                 </entry>
               </row>
               <row>
@@ -4097,7 +5088,12 @@
                   <para>X.509Versions</para>
                 </entry>
                 <entry>
-                  <para>Indicates which X.509 versions are supported by the device.<footnote xml:id="__FN2__"><para>If a device supports X.509v3 certificates, this fact shall also be signalled by this capability.</para></footnote> X.509 versions shall be encoded as version numbers, e.g., 1, 2, 3.</para>
+                  <para>Indicates which X.509 versions are supported by the device.<footnote
+                      xml:id="__FN2__">
+                      <para>If a device supports X.509v3 certificates, this fact shall also be
+                        signalled by this capability.</para>
+                    </footnote> X.509 versions shall be encoded as version numbers, e.g., 1, 2,
+                    3.</para>
                 </entry>
               </row>
               <row>
@@ -4105,7 +5101,8 @@
                   <para>MaximumNumberOfCRLs</para>
                 </entry>
                 <entry>
-                  <para>Indicates the maximum number of CRLs that the device is able to store simultaneously.</para>
+                  <para>Indicates the maximum number of CRLs that the device is able to store
+                    simultaneously.</para>
                 </entry>
               </row>
               <row>
@@ -4113,7 +5110,8 @@
                   <para>MaximumNumberOfCertificationPathValidationPolicies</para>
                 </entry>
                 <entry>
-                  <para>Indicates the maximum number of certification path validation policies that the device is able to store simultaneously.</para>
+                  <para>Indicates the maximum number of certification path validation policies that
+                    the device is able to store simultaneously.</para>
                 </entry>
               </row>
               <row>
@@ -4121,7 +5119,8 @@
                   <para>EnforceTLSWebClientAuthExtKeyUsage</para>
                 </entry>
                 <entry>
-                  <para>Indicates whether a device supports checking for the TLS WWW client auth extended key usage extension while validating certification paths.</para>
+                  <para>Indicates whether a device supports checking for the TLS WWW client auth
+                    extended key usage extension while validating certification paths.</para>
                 </entry>
               </row>
               <row>
@@ -4129,13 +5128,18 @@
                   <para>NoPrivateKeySharing</para>
                 </entry>
                 <entry>
-                  <para>Indicates the device requires that each certificate with private key has its own unique key.</para>
+                  <para>Indicates the device requires that each certificate with private key has its
+                    own unique key.</para>
                 </entry>
               </row>
               <row>
-                <entry><para>SetCertPath</para></entry>
-                <entry><para>The device supports modification of certificate path and certificate
-                  validation path.</para></entry>
+                <entry>
+                  <para>SetCertPath</para>
+                </entry>
+                <entry>
+                  <para>The device supports modification of certificate path and certificate
+                    validation path.</para>
+                </entry>
               </row>
             </tbody>
           </tgroup>
@@ -4143,7 +5147,9 @@
       </section>
       <section>
         <title>TLS Server Capabilities</title>
-        <para>The TLS server capabilities reflect optional functions and functionality of the TLS server. The information is static and does not change during device operation. The following capabilities are available: </para>
+        <para>The TLS server capabilities reflect optional functions and functionality of the TLS
+          server. The information is static and does not change during device operation. The
+          following capabilities are available: </para>
         <table>
           <title>TLS Server Capabilities</title>
           <tgroup cols="2">
@@ -4155,7 +5161,8 @@
                   <para>TLSServerSupported</para>
                 </entry>
                 <entry>
-                  <para>Indicates which TLS server versions are supported by the device. Server versions shall be encoded as version numbers, e.g., “1.0 1.1 1.2”.</para>
+                  <para>Indicates which TLS server versions are supported by the device. Server
+                    versions shall be encoded as version numbers, e.g., “1.0 1.1 1.2”.</para>
                 </entry>
               </row>
               <row>
@@ -4163,7 +5170,8 @@
                   <para>MaximumNumberOfTLSCertificationPaths</para>
                 </entry>
                 <entry>
-                  <para>Indicates the maximum number of certification paths that may be assigned to the TLS server simultaneously.</para>
+                  <para>Indicates the maximum number of certification paths that may be assigned to
+                    the TLS server simultaneously.</para>
                 </entry>
               </row>
               <row>
@@ -4171,7 +5179,8 @@
                   <para>TLSClientAuthSupported</para>
                 </entry>
                 <entry>
-                  <para>Indicates whether the device supports TLS client authentication as defined in this specification.</para>
+                  <para>Indicates whether the device supports TLS client authentication as defined
+                    in this specification.</para>
                 </entry>
               </row>
               <row>
@@ -4179,7 +5188,8 @@
                   <para>CnMapsToUserSupported</para>
                 </entry>
                 <entry>
-                  <para>Indicates whether the device supports TLS client authorization using common name to local user mapping as defined in this specification</para>
+                  <para>Indicates whether the device supports TLS client authorization using common
+                    name to local user mapping as defined in this specification</para>
                 </entry>
               </row>
               <row>
@@ -4187,7 +5197,8 @@
                   <para>MaximumNumberOfTLSCertificationPathValidationPolicies</para>
                 </entry>
                 <entry>
-                  <para>Indicates the maximum number of certification path validation policies that may be assigned to the TLS server simultaneously</para>
+                  <para>Indicates the maximum number of certification path validation policies that
+                    may be assigned to the TLS server simultaneously</para>
                 </entry>
               </row>
               <row>
@@ -4195,7 +5206,8 @@
                   <para>EnabledVersionsSupported</para>
                 </entry>
                 <entry>
-                  <para>Indicates whether the device supports enabling and disabling specific TLS versions.</para>
+                  <para>Indicates whether the device supports enabling and disabling specific TLS
+                    versions.</para>
                 </entry>
               </row>
             </tbody>
@@ -4204,7 +5216,9 @@
       </section>
       <section>
         <title>IEEE 802.1X Capabilities</title>
-        <para>The IEEE 802.1X configuration capabilities reflect optional functions and functionality of IEEE 802.1X configuration on a device. The following additional capabilites are defined: </para>
+        <para>The IEEE 802.1X configuration capabilities reflect optional functions and
+          functionality of IEEE 802.1X configuration on a device. The following additional
+          capabilites are defined: </para>
         <table>
           <title>Additional IEEE 802.1X Configuration Capabilities</title>
           <tgroup cols="2">
@@ -4226,7 +5240,8 @@
                   <para>MaximumNumberOfDot1XConfigurations</para>
                 </entry>
                 <entry>
-                  <para>Indicates the maximum number of IEEE 802.1X configurations that the device is able to configure simultaneously.</para>
+                  <para>Indicates the maximum number of IEEE 802.1X configurations that the device
+                    is able to configure simultaneously.</para>
                 </entry>
               </row>
               <row>
@@ -4234,7 +5249,8 @@
                   <para>Dot1XMethods</para>
                 </entry>
                 <entry>
-                  <para>A list of authentication method outer/inner (phase1/phase2) combinations supported by the device.</para>
+                  <para>A list of authentication method outer/inner (phase1/phase2) combinations
+                    supported by the device.</para>
                 </entry>
               </row>
             </tbody>
@@ -4309,8 +5325,8 @@
                   <para>MaxConfigurations</para>
                 </entry>
                 <entry>
-                  <para>Indicates the maximum number of  authorization server configurations that
-                    the device is able to configure simultaneously.</para>
+                  <para>Indicates the maximum number of authorization server configurations that the
+                    device is able to configure simultaneously.</para>
                 </entry>
               </row>
               <row>
@@ -4319,13 +5335,15 @@
                 </entry>
                 <entry>
                   <para>A list of authorization server configuration types that is supported by the
-                    device, see <xref xmlns:xlink="http://www.w3.org/1999/xlink" linkend="table_ry3_fbr_swb"/> for possible values.</para>
+                    device, see <xref xmlns:xlink="http://www.w3.org/1999/xlink"
+                      linkend="table_ry3_fbr_swb"/> for possible values.</para>
                 </entry>
               </row>
               <row>
                 <entry>ClientAuthenticationMethodsSupported</entry>
-                <entry>A list of authentication methods that is supported by the device, see <xref xmlns:xlink="http://www.w3.org/1999/xlink" linkend="table_smg_rzq_swb"/> for possible values.
-                </entry>
+                <entry>A list of authentication methods that is supported by the device, see <xref
+                    xmlns:xlink="http://www.w3.org/1999/xlink" linkend="table_smg_rzq_swb"/> for
+                  possible values. </entry>
               </row>
             </tbody>
           </tgroup>
@@ -4334,7 +5352,9 @@
       <section>
         <title>Capability-implied Requirements</title>
         <para>
-          <xref linkend="_Ref406569780"/> summarizes for each capability the minimum requirements that a device signaling this capability shall satisfy; it should not be seen as a recommendation.</para>
+          <xref linkend="_Ref406569780"/> summarizes for each capability the minimum requirements
+          that a device signaling this capability shall satisfy; it should not be seen as a
+          recommendation.</para>
         <table xml:id="_Ref406569780">
           <title>Requirements implied by Capabilities</title>
           <tgroup cols="2">
@@ -4368,7 +5388,9 @@
                       <para>DeletePassphrase</para>
                     </listitem>
                   </itemizedlist>
-                  <para>If greater than zero, the device shall support passphrases that consist of characters from the ASCII character set and that have a length of up to 40 characters.</para>
+                  <para>If greater than zero, the device shall support passphrases that consist of
+                    characters from the ASCII character set and that have a length of up to 40
+                    characters.</para>
                 </entry>
               </row>
               <row>
@@ -4400,15 +5422,16 @@
                   <para>KeyPairGeneration</para>
                 </entry>
                 <entry>
-                  <para>If true, then either the list of supported RSA key length is not empty and
-                    the device supports the command:</para>
+                  <para>If it contains RSA, then the list of supported RSA key length shall not be
+                    empty and the device shall support the command:</para>
                   <itemizedlist>
                     <listitem>
                       <para>CreateRSAKeyPair</para>
                     </listitem>
                   </itemizedlist>
-                  <para>or the list of supported elliptic curves indicated by the EllipticCurves
-                    capability is not empty and the device supports the commands:</para>
+                  <para>If it contains ECC, then the list of supported elliptic curves indicated by
+                    the EllipticCurves capability shall not be empty and the device shall support
+                    the commands:</para>
                   <itemizedlist>
                     <listitem>
                       <para>CreateECCKeyPair</para>
@@ -4431,7 +5454,8 @@
                   <para>If true, the list of supported password-based encryption algorithms as
                     indicated by the PasswordBasedEncryptionAlgorithms capability shall contain at
                     least the algorithm <phrase>pbeWithSHAAnd3-KeyTripleDES-CBC</phrase>.</para>
-                  <para>If true, at least one capability between EllipticCurves and RSAKeyLenghts shall be specified.</para>
+                  <para>If true, at least one capability between EllipticCurves and RSAKeyLenghts
+                    shall be specified.</para>
                 </entry>
               </row>
               <row>
@@ -4470,7 +5494,8 @@
                   <para>If true, the list of supported password-based MAC algorithms as indicated by
                     the PasswordBasedMACAlgorithms capability shall include the baseline specified
                     in table Key Derivation Functions of the ONVIF Security Baseline.</para>
-                  <para>If true, the list of supported X.509 versions as indicated by the X.509Versions capability shall contain at least the value 3.</para>
+                  <para>If true, the list of supported X.509 versions as indicated by the
+                    X.509Versions capability shall contain at least the value 3.</para>
                 </entry>
               </row>
               <row>
@@ -4493,29 +5518,12 @@
                       <para>DeleteCertificate</para>
                     </listitem>
                     <listitem>
-                      <para>Uploading the certificate created for the CSR as well as the certificate of the created certificate’s signer with the UploadCertificate command.</para>
+                      <para>Uploading the certificate created for the CSR as well as the certificate
+                        of the created certificate’s signer with the UploadCertificate
+                        command.</para>
                     </listitem>
                   </itemizedlist>
-                  <para>If true, MaximumNumberOfCertificates&gt;=2 and MaximumNumberOfCertificationPaths&gt;0 shall hold.</para>
-                  <para>If true, MaximumNumberOfKeys&gt;=2 shall hold.</para>
-                  <para>If true and the capability RSAKeyLenghts is not empty the following condition shall be fulfilled:</para>
-                  <itemizedlist>
-                    <listitem>
-                      <para>The capability RSAKeyPairGeneration shall be specified .</para>
-                    </listitem>
-                  </itemizedlist>
-                  <para>If true and the capability EllipticCurves is provided, the following conditions shall be fulfilled:</para>
-                  <itemizedlist>
-                    <listitem>
-                      <para>The capability ECCKeyPairGeneration shall be specified.</para>
-                    </listitem>
-                    <listitem>
-                      <para>The list of supported signature algorithms as indicated by the
-                        SignatureAlgorithms capability shall contain at least the algorithm defined
-                        in the security baseline.</para>
-                    </listitem>
-                  </itemizedlist>
-                  
+                  <para>If true, the capability KeyPairGeneration shall not be empty.</para>
                 </entry>
               </row>
               <row>
@@ -4538,28 +5546,11 @@
                       <para>DeleteCertificate</para>
                     </listitem>
                   </itemizedlist>
-                  <para>If true, MaximumNumberOfCertificates&gt; 0 shall hold.</para>
                   <para>If true, the following operations shall be supported:</para>
                   <itemizedlist>
                     <listitem>
-                      <para>Key pair generation as signaled by the RSAKeyPairGeneration or ECCKeyPairGeneration capability or key pair upload as signaled by the PKCS8 capability or key pair upload as signaled by the PKCS12CertificateWithRSAPrivateKeyUpload capability</para>
-                    </listitem>
-                  </itemizedlist>
-                  <para>If true and the capability RSAKeyLenghts is not empty the following conditions shall be fulfilled:</para>
-                  <itemizedlist>
-                    <listitem>
-                      <para>The capability RSAKeyPairGeneration shall be specified .</para>
-                    </listitem>
-                    <listitem>
-                      <para>The list of supported signature algorithms as indicated by the
-                        SignatureAlgorithms capability shall contain the RSA baseline defined in
-                        table signature algorithms of the ONVIF Security Baseline.</para>
-                    </listitem>
-                  </itemizedlist>
-                  <para>If true and the capability EllipticCurves is provided, the following condition shall be fulfilled:</para>
-                  <itemizedlist>
-                    <listitem>
-                      <para>The capability ECCKeyPairGeneration shall be specified.</para>
+                      <para>Key pair generation as signaled by the KeyPairGeneration or key pair
+                        upload as signaled by PKCS8 or PKCS12 capability.</para>
                     </listitem>
                   </itemizedlist>
                 </entry>
@@ -4569,7 +5560,8 @@
                   <para>TLSServerSupported</para>
                 </entry>
                 <entry>
-                  <para>If not empty, PKCS10ExternalCertificationWithRSA or SelfSignedCertificateCreationWithRSA or PKCS10 or SelfSignedCertificateCreation shall be true.</para>
+                  <para>If not empty, PKCS10, PKCS12 or SelfSignedCertificateCreation shall be
+                    true.</para>
                   <para>If not empty, the following commands shall be supported:</para>
                   <itemizedlist>
                     <listitem>
@@ -4597,7 +5589,7 @@
                       <para>GetAssignedServerCertificates</para>
                     </listitem>
                   </itemizedlist>
-                  <para>If not empty, MaximumNumberOfCertificationPaths&gt;=2 and MaximumNumberOfTLSCertificationPaths&gt;0 shall hold.</para>
+                  <para>If not empty, MaximumNumberOfTLSCertificationPaths&gt;0 shall hold.</para>
                 </entry>
               </row>
               <row>
@@ -4622,8 +5614,13 @@
                 </entry>
                 <entry>
                   <para>
-                    <phrase>If X.509v3 is supported, the device shall support the distinguished name attribute types </phrase>
-                    <emphasis>country</emphasis>, <emphasis>organization</emphasis>, <emphasis>organizational unit</emphasis>, <emphasis>distinguished name qualifier</emphasis>, <emphasis>state or province name</emphasis>, <emphasis>common name</emphasis>, and <emphasis>serial number</emphasis>.</para>
+                    <phrase>If X.509v3 is supported, the device shall support the distinguished name
+                      attribute types </phrase>
+                    <emphasis>country</emphasis>, <emphasis>organization</emphasis>,
+                      <emphasis>organizational unit</emphasis>, <emphasis>distinguished name
+                      qualifier</emphasis>, <emphasis>state or province name</emphasis>,
+                      <emphasis>common name</emphasis>, and <emphasis>serial
+                    number</emphasis>.</para>
                 </entry>
               </row>
               <row>
@@ -4724,7 +5721,8 @@
                       <para>DeleteNetworkInterfaceDot1XConfiguration</para>
                     </listitem>
                   </itemizedlist>
-                  <para>If greater than zero, the Dot1XMethods capability shall be present and shall contain at least the EAP-PEAP MSCHAPv2 method.</para>
+                  <para>If greater than zero, the Dot1XMethods capability shall be present and shall
+                    contain at least the EAP-PEAP MSCHAPv2 method.</para>
                 </entry>
               </row>
               <row>
@@ -4732,7 +5730,8 @@
                   <para>Dot1XMethods</para>
                 </entry>
                 <entry>
-                  <para>If not empty, shall contain at least the “EAP-PEAP/MSCHAPv2” method, and MaximumNumberOfDot1XConfigurations shall be greater than zero.</para>
+                  <para>If not empty, shall contain at least the “EAP-PEAP/MSCHAPv2” method, and
+                    MaximumNumberOfDot1XConfigurations shall be greater than zero.</para>
                 </entry>
               </row>
               <row>
@@ -4754,7 +5753,10 @@
               </row>
               <row>
                 <entry>EllipticCurves</entry>
-                <entry><para>The list of supported elliptic curves. </para><para>If the entry is non-empty it shall contain at least the baseline </para></entry>
+                <entry>
+                  <para>The list of supported elliptic curves. </para>
+                  <para>If the entry is non-empty it shall contain at least the baseline </para>
+                </entry>
               </row>
             </tbody>
           </tgroup>
@@ -4765,7 +5767,9 @@
       <title>Events</title>
       <section xml:id="_Ref353780603">
         <title>Key Status</title>
-        <para>A device that indicates support for key handling via the MaximumNumberOfKeys capability shall provide information about key status changes through key status events.</para>
+        <para>A device that indicates support for key handling via the MaximumNumberOfKeys
+          capability shall provide information about key status changes through key status
+          events.</para>
         <para>A device shall include optional item OldStatus unless NewStatus is generating.</para>
         <programlisting><![CDATA[Topic: tns1:Advancedsecurity/Keystore/KeyStatus
 <tt:MessageDescription>
@@ -4790,46 +5794,87 @@
     <para>This section is informative.</para>
     <itemizedlist>
       <listitem>
-        <para>Faults and their types shall not disclose sensitive information to an attacker that he could not obtain otherwise.</para>
+        <para>Faults and their types shall not disclose sensitive information to an attacker that he
+          could not obtain otherwise.</para>
       </listitem>
       <listitem>
         <para>Secure up to date signature algorithm should be implemented by devices and clients.
           Devices signal the supported algorithm via their capabilities and clients should select
           the algorithm with highest security strength supported by both parties. See ONVIF Security
-          Baseline for algorithm to be supported.  </para>
+          Baseline for algorithm to be supported. </para>
       </listitem>
       <listitem>
-        <para>Operations with arguments that need protection against eavesdropping or manipulation shall only be executed over sufficiently protected communication channels. </para>
+        <para>Operations with arguments that need protection against eavesdropping or manipulation
+          shall only be executed over sufficiently protected communication channels. </para>
       </listitem>
       <listitem>
-        <para>It is good practice not to use the same key for different purposes. In order to prevent the device from using the same key for different purposes unnoticedly, this specification mandates that all keys in the keystore be distinct.</para>
+        <para>It is good practice not to use the same key for different purposes. In order to
+          prevent the device from using the same key for different purposes unnoticedly, this
+          specification mandates that all keys in the keystore be distinct.</para>
       </listitem>
       <listitem>
-        <para>Private keys must be protected against disclosure to unauthorized parties. If a private key is uploaded in an encrypted PKCS#8 or PKCS#12 structure, the passphrase that is used to encrypt the structure must be uploaded to the device over a communication channel that is protected against eavesdropping in order to preserve the confidentiality of the private key. Moreover, the confidentiality of the uploaded private key depends on the strength of the encryption passphrase. It is therefore strongly recommended to use random passwords with sufficient length.</para>
+        <para>Private keys must be protected against disclosure to unauthorized parties. If a
+          private key is uploaded in an encrypted PKCS#8 or PKCS#12 structure, the passphrase that
+          is used to encrypt the structure must be uploaded to the device over a communication
+          channel that is protected against eavesdropping in order to preserve the confidentiality
+          of the private key. Moreover, the confidentiality of the uploaded private key depends on
+          the strength of the encryption passphrase. It is therefore strongly recommended to use
+          random passwords with sufficient length.</para>
       </listitem>
       <listitem>
-        <para>In general, externally generated keys must be regarded less trustworthy than keys that are generated by the device because the probability of being disclosed to an attacker is higher for an externally generated key than for an internally generated key. A client may determine whether a key was generated by the device from the <emphasis>externallyGenerated</emphasis> attribute of the key.</para>
+        <para>In general, externally generated keys must be regarded less trustworthy than keys that
+          are generated by the device because the probability of being disclosed to an attacker is
+          higher for an externally generated key than for an internally generated key. A client may
+          determine whether a key was generated by the device from the
+            <emphasis>externallyGenerated</emphasis> attribute of the key.</para>
       </listitem>
       <listitem>
-        <para>While new specifications should be based on PKCS#5 v2.0 or higher, adoption of this standard is still limited. Therefore, this specification intends to balance security and interoperability by mandating cryptographic algorithms based on PKCS#5 v1.5 as interoperability baseline while strongly encouraging the use of PKCS#5 v2.0 or higher. Future versions of this specification or specifications referring to this specification may mandate additional cryptographic algorithms.</para>
+        <para>While new specifications should be based on PKCS#5 v2.0 or higher, adoption of this
+          standard is still limited. Therefore, this specification intends to balance security and
+          interoperability by mandating cryptographic algorithms based on PKCS#5 v1.5 as
+          interoperability baseline while strongly encouraging the use of PKCS#5 v2.0 or higher.
+          Future versions of this specification or specifications referring to this specification
+          may mandate additional cryptographic algorithms.</para>
       </listitem>
       <listitem>
-        <para>Although PKCS#8 RFC 5208 is widely used for exchanging cryptographic keys, this specification is based on the successor standard RFC 5958, particularly in order to incorporate both private key and public key in the same data structure.</para>
+        <para>Although PKCS#8 RFC 5208 is widely used for exchanging cryptographic keys, this
+          specification is based on the successor standard RFC 5958, particularly in order to
+          incorporate both private key and public key in the same data structure.</para>
       </listitem>
       <listitem>
-        <para>The default certification path validation policy is designed as a permissive interoperability baseline based on the certification path validation algorithm defined in RFC 5280. </para>
+        <para>The default certification path validation policy is designed as a permissive
+          interoperability baseline based on the certification path validation algorithm defined in
+          RFC 5280. </para>
       </listitem>
       <listitem>
-        <para>CRLs can be expected to be available from virtually any CA as a source of revocation information. The benefit of OCSP RFC 6960 as a means to obtain revocation information is increasingly under question, since a man-in-the-middle attacker blocking OCSP traffic combined with a permissive validator that silently accepts certificates for which no revocation is available limits the effective security gain of using OCSP. Therefore, this specification mandates support for CRLs as interoperability baseline and leaves other revocation information sources to future versions.</para>
+        <para>CRLs can be expected to be available from virtually any CA as a source of revocation
+          information. The benefit of OCSP RFC 6960 as a means to obtain revocation information is
+          increasingly under question, since a man-in-the-middle attacker blocking OCSP traffic
+          combined with a permissive validator that silently accepts certificates for which no
+          revocation is available limits the effective security gain of using OCSP. Therefore, this
+          specification mandates support for CRLs as interoperability baseline and leaves other
+          revocation information sources to future versions.</para>
       </listitem>
       <listitem>
-        <para>Devices may be required to use different trust anchors for different security features. Therefore, trust in a certificate is indicated as part of a certification path validation policy rather than globally, e.g., with an attribute of the X509Certificate data type. </para>
+        <para>Devices may be required to use different trust anchors for different security
+          features. Therefore, trust in a certificate is indicated as part of a certification path
+          validation policy rather than globally, e.g., with an attribute of the X509Certificate
+          data type. </para>
       </listitem>
       <listitem>
-        <para>RFC 5280, Sect. 6.1.4 (k) mandates that every certificate in a certification path except for the end entity certificate must be verified to be a CA certificate. For X.509 version 3 certificates, this is verified through the CA attribute in the basic constraints extension. For X.509 version 1 and 2 certificates, this information must be supplied by out-of-band mechanisms. Within the scope of this specification, the only means to obtain this information is the trust anchor information contained in the certification path validation algorithm. </para>
+        <para>RFC 5280, Sect. 6.1.4 (k) mandates that every certificate in a certification path
+          except for the end entity certificate must be verified to be a CA certificate. For X.509
+          version 3 certificates, this is verified through the CA attribute in the basic constraints
+          extension. For X.509 version 1 and 2 certificates, this information must be supplied by
+          out-of-band mechanisms. Within the scope of this specification, the only means to obtain
+          this information is the trust anchor information contained in the certification path
+          validation algorithm. </para>
       </listitem>
       <listitem>
-        <para>When configuring IEEE 802.1X, it is usually necessary to upload a password to the device’s keystore.  This should be done either on a private network (e.g., using a direct network connection between a laptop and a device) or using TLS (SSL) on the device to encrypt client / device traffic.</para>
+        <para>When configuring IEEE 802.1X, it is usually necessary to upload a password to the
+          device’s keystore. This should be done either on a private network (e.g., using a direct
+          network connection between a laptop and a device) or using TLS (SSL) on the device to
+          encrypt client / device traffic.</para>
       </listitem>
     </itemizedlist>
   </chapter>
@@ -4838,28 +5883,77 @@
     <para>This section is informative.</para>
     <section>
       <title>General Design Goals</title>
-      <para>The Security Configuration Service is designed for modularity and extensibility. Therefore, each security feature is encapsulated in a separate port type within the service. Later revisions of this specification may add port types to enhance the Security Configuration Service by additional security features.</para>
-      <para>Within a security feature, capabilities indicate support for sub-features and configuration options. Later revisions of this specification may add additional sub-features to existing features and identify them by additional capabilities.</para>
-      <para>Port types and capabilities enable devices to support well-defined subsets of this specification and to communicate this information to clients effectively.</para>
+      <para>The Security Configuration Service is designed for modularity and extensibility.
+        Therefore, each security feature is encapsulated in a separate port type within the service.
+        Later revisions of this specification may add port types to enhance the Security
+        Configuration Service by additional security features.</para>
+      <para>Within a security feature, capabilities indicate support for sub-features and
+        configuration options. Later revisions of this specification may add additional sub-features
+        to existing features and identify them by additional capabilities.</para>
+      <para>Port types and capabilities enable devices to support well-defined subsets of this
+        specification and to communicate this information to clients effectively.</para>
     </section>
     <section>
       <title>Keystore</title>
-      <para>The keystore design assumes that passphrases are chosen by clients. Therefore, an operation for retrieving passphrases from a device is deliberately omitted. If client loses a previously uploaded passphrase, the client should create a new passphrase, upload the new passphrase to the device, and delete the old passphrase from the device.</para>
-      <para>This specification deliberately deviates from the terminology in PKCS#8 and PKCS#12 by using the term ‘passphrase’ instead of ‘password’ in order to avoid confusion with the password that is assigned to ONVIF device users and the corresponding API in the ONVIF Device Management Service.</para>
-      <para>The keystore design is based on the rationale that an RSA key pair is a special type of key pair and a key pair is a special type of key. Therefore, key-related operations in the keystore deliberately refer to the most generic possible type in this hierarchy. For example, the DeleteKey operation (see Sect. <xref linkend="_Ref363540841"/>) refers to a key instead of a key pair or even an RSAKeyPair because it is applicable to all keys. On the other hand, the GetPrivateKeyStatus command refers to a key pair instead of a key, since this command is not meaningful for a key that is not a key pair, e.g., a symmetric key.</para>
-      <para>While this revision of the keystore specification only supports RSA key pairs as key pairs, later revisions of this specification may add other types of key pairs or symmetric keys as special types of keys.</para>
-      <para>Some interactions with the keystore, e.g., retrieving the private key for a public key that is contained in a certificate, are required device-internally, but need not be accessible to clients and may even, as in the above example, imply a security risk when made available outside the device. Such operations are therefore deliberately omitted from this specification.</para>
-      <para>The certificate-based client authentication specification intends to balance security concerns, interoperability, and implementation effort in order to facilitate adoption. Therefore, the certification path validation algorithm defined in RFC 5280 serves as interoperability baseline. The parameter values in the default certification path validation policy have been selected such that widely used implementations of the certification path validation algorithm can be used in their default configurations as much as permitted by the objective to provide an acceptable security baseline.</para>
-      <para>At the same time, more fine grained customization of the default certification path validation behavior in future versions of this specification is enabled by an extensible CertValidationPolicyParameters data type and capabilities that indicate which configuration options a device supports. As an example, checking for the TLS WWW client authentication key usage extension in client certificates is included in this specification, which can be implemented with moderate effort on the device side (e.g., with the OpenSSL option –purpose sslclient). Customization options for other parameters of the certification path validation algorithm are deliberately left to future versions of this specification in order to limit the required initial implementation effort.</para>
-      <para>In order to facilitate future extensions of this specification, the number of certification path validation policies that may be assigned to the TLS server simultaneously is not limited, but the certification path validation behavior is unspecified if more than one policy is assigned to the TLS server at the same time. Therefore, devices implementing this specification should limit the number of simultaneously assigned policies to one.</para>
+      <para>The keystore design assumes that passphrases are chosen by clients. Therefore, an
+        operation for retrieving passphrases from a device is deliberately omitted. If client loses
+        a previously uploaded passphrase, the client should create a new passphrase, upload the new
+        passphrase to the device, and delete the old passphrase from the device.</para>
+      <para>This specification deliberately deviates from the terminology in PKCS#8 and PKCS#12 by
+        using the term ‘passphrase’ instead of ‘password’ in order to avoid confusion with the
+        password that is assigned to ONVIF device users and the corresponding API in the ONVIF
+        Device Management Service.</para>
+      <para>The keystore design is based on the rationale that an RSA key pair is a special type of
+        key pair and a key pair is a special type of key. Therefore, key-related operations in the
+        keystore deliberately refer to the most generic possible type in this hierarchy. For
+        example, the DeleteKey operation (see Sect. <xref linkend="_Ref363540841"/>) refers to a key
+        instead of a key pair or even an RSAKeyPair because it is applicable to all keys. On the
+        other hand, the GetPrivateKeyStatus command refers to a key pair instead of a key, since
+        this command is not meaningful for a key that is not a key pair, e.g., a symmetric
+        key.</para>
+      <para>While this revision of the keystore specification only supports RSA key pairs as key
+        pairs, later revisions of this specification may add other types of key pairs or symmetric
+        keys as special types of keys.</para>
+      <para>Some interactions with the keystore, e.g., retrieving the private key for a public key
+        that is contained in a certificate, are required device-internally, but need not be
+        accessible to clients and may even, as in the above example, imply a security risk when made
+        available outside the device. Such operations are therefore deliberately omitted from this
+        specification.</para>
+      <para>The certificate-based client authentication specification intends to balance security
+        concerns, interoperability, and implementation effort in order to facilitate adoption.
+        Therefore, the certification path validation algorithm defined in RFC 5280 serves as
+        interoperability baseline. The parameter values in the default certification path validation
+        policy have been selected such that widely used implementations of the certification path
+        validation algorithm can be used in their default configurations as much as permitted by the
+        objective to provide an acceptable security baseline.</para>
+      <para>At the same time, more fine grained customization of the default certification path
+        validation behavior in future versions of this specification is enabled by an extensible
+        CertValidationPolicyParameters data type and capabilities that indicate which configuration
+        options a device supports. As an example, checking for the TLS WWW client authentication key
+        usage extension in client certificates is included in this specification, which can be
+        implemented with moderate effort on the device side (e.g., with the OpenSSL option –purpose
+        sslclient). Customization options for other parameters of the certification path validation
+        algorithm are deliberately left to future versions of this specification in order to limit
+        the required initial implementation effort.</para>
+      <para>In order to facilitate future extensions of this specification, the number of
+        certification path validation policies that may be assigned to the TLS server simultaneously
+        is not limited, but the certification path validation behavior is unspecified if more than
+        one policy is assigned to the TLS server at the same time. Therefore, devices implementing
+        this specification should limit the number of simultaneously assigned policies to
+        one.</para>
     </section>
     <section>
       <title>TLS Server</title>
-      <para>This revision of the Security Configuration Service Specification allows to manage assignments of certification paths to the TLS server on a device. It is permitted that a TLS server presents different certification paths to different clients, therefore more than one certification path may be assigned simultaneously to the TLS server to use as a server certificate.</para>
-      <para>All other configuration of the TLS server on a device is outside the scope of this specification revision and may be addressed by later revisions of this document.</para>
+      <para>This revision of the Security Configuration Service Specification allows to manage
+        assignments of certification paths to the TLS server on a device. It is permitted that a TLS
+        server presents different certification paths to different clients, therefore more than one
+        certification path may be assigned simultaneously to the TLS server to use as a server
+        certificate.</para>
+      <para>All other configuration of the TLS server on a device is outside the scope of this
+        specification revision and may be addressed by later revisions of this document.</para>
     </section>
   </chapter>
-  <appendix xml:id= "q5l_q5m_51c">
+  <appendix xml:id="q5l_q5m_51c">
     <title>JWT Content example</title>
     <para>Here is an example of JWT components to be encoded into a JWT Token</para>
     <programlisting><![CDATA[{
@@ -4881,14 +5975,15 @@ RJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c</programlisting>
   <appendix xml:id="_Ref460769599">
     <title>JWT over SCTP example</title>
     <para>A JWT, whose content example is shown in <xref xmlns:xlink="http://www.w3.org/1999/xlink"
-        linkend="q5l_q5m_51c"/>, can be used in the WS-Security header of the SOAP request. To conform
-        to the BinarySecurityToken format, the JWT itself must be base64-encoded before being embedded
-        in the request:</para>
+        linkend="q5l_q5m_51c"/>, can be used in the WS-Security header of the SOAP request. To
+      conform to the BinarySecurityToken format, the JWT itself must be base64-encoded before being
+      embedded in the request:</para>
     <programlisting><![CDATA[ZZXlKMGVYQWlPaUpLVjFRaUxDSmhiR2NpT2lKRlV6STFOaUo5LmV5SnBjM01pT2lKelpYSjJaWEl1Y0dGMGFDNW
 piMjBpTENKdVltWWlPakUyTnpBME9ESTRNREFzSW1WNGNDSTZNVFkzTURVM01qZ3dNQ3dpWVhWa0lqb2lkR0Z5
 WjJWMExtRjFaR2xsYm1ObElpd2ljbTlzWlhNaU9sc2liMjUyYVdZNlQzQmxjbUYwYjNJaVhYMC5TZmxLeHdSSl
 NNZUtLRjJRVDRmd3BNZUpmMzZQT2s2eUpWX2FkUXNzdzVj]]></programlisting>
-    <para>This encoded token can then be added to the SOAP request in a BinarySecurityToken element.</para>
+    <para>This encoded token can then be added to the SOAP request in a BinarySecurityToken
+      element.</para>
     <programlisting><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
 <env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"
               xmlns:enc="http://www.w3.org/2003/05/soap-encoding"
@@ -4914,9 +6009,11 @@ pTTWVLS0YyUVQ0ZndwTWVKZjM2UE9rNnlKVl9hZFFzc3c1Yw==
   <env:Body>
 </env:Envelope>]]></programlisting>
   </appendix>
-  <appendix xml:id= "hq4_s5m_51c">
+  <appendix xml:id="hq4_s5m_51c">
     <title>JWT over HTTPS example</title>
-    <para>The following exchange between client and device over HTTPS demonstrates a device supporting MD5 and SHA-256 for digest authentication as well as JWT-based client authentication.</para>
+    <para>The following exchange between client and device over HTTPS demonstrates a device
+      supporting MD5 and SHA-256 for digest authentication as well as JWT-based client
+      authentication.</para>
     <para>Unauthenticated request from the client:</para>
     <programlisting><![CDATA[POST /onvif/device_service HTTP/1.1
 Host: 10.XX.XX.XX
@@ -4964,9 +6061,11 @@ WWW-Authenticate: Digest algorithm=SHA-256, realm="Silvan_http_digest", qop="aut
 nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"
 X-Frame-Options: SAMEORIGIN]]></programlisting>
   </appendix>
-  <appendix xml:id= "b14_55m_51c">
+  <appendix xml:id="b14_55m_51c">
     <title>JWT over RTSPS example</title>
-    <para>The following exchange between client and device over RTSPS demonstrates a device supporting MD5 and SHA-256 for digest authentication as well as JWT-based client authentication.</para>
+    <para>The following exchange between client and device over RTSPS demonstrates a device
+      supporting MD5 and SHA-256 for digest authentication as well as JWT-based client
+      authentication.</para>
     <para>Unauthenticated request from the client:</para>
     <programlisting><![CDATA[DESCRIBE rtsp://10.XX.XX.XX/stream RTSP/1.0
 CSeq: 1
@@ -4991,8 +6090,6 @@ CSeq: 2
 User-Agent: ./onvifClient
 Accept: application/sdp]]></programlisting>
   </appendix>
-
-
   <appendix role="revhistory">
     <title>Revision History</title>
     <para/>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -4,12 +4,12 @@
   <info>
     <title>Security Service Specification</title>
     <titleabbrev>Security Configuration</titleabbrev>
-    <releaseinfo>24.12</releaseinfo>
+    <releaseinfo>25.12 Draft</releaseinfo>
     <author>
       <orgname>ONVIF™</orgname>
       <uri>www.onvif.org</uri>
     </author>
-    <pubdate>December 2024</pubdate>
+    <pubdate>December 2025</pubdate>
     <mediaobject>
       <imageobject>
         <imagedata fileref="media/logo.png" contentwidth="60mm"/>
@@ -20,9 +20,24 @@
       <holder>ONVIF™ All rights reserved.</holder>
     </copyright>
     <legalnotice>
-      <para>Recipients of this document may copy, distribute, publish, or display this document so long as this copyright notice, license and disclaimer are retained with all copies of the document. No license is granted to modify this document.</para>
-      <para>THIS DOCUMENT IS PROVIDED "AS IS," AND THE CORPORATION AND ITS MEMBERS AND THEIR AFFILIATES, MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THIS DOCUMENT ARE SUITABLE FOR ANY PURPOSE; OR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.</para>
-      <para>IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, PUNITIVE OR CONSEQUENTIAL DAMAGES, ARISING OUT OF OR RELATING TO ANY USE OR DISTRIBUTION OF THIS DOCUMENT, WHETHER OR NOT (1) THE CORPORATION, MEMBERS OR THEIR AFFILIATES HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES, OR (2) SUCH DAMAGES WERE REASONABLY FORESEEABLE, AND ARISING OUT OF OR RELATING TO ANY USE OR DISTRIBUTION OF THIS DOCUMENT.  THE FOREGOING DISCLAIMER AND LIMITATION ON LIABILITY DO NOT APPLY TO, INVALIDATE, OR LIMIT REPRESENTATIONS AND WARRANTIES MADE BY THE MEMBERS AND THEIR RESPECTIVE AFFILIATES TO THE CORPORATION AND OTHER MEMBERS IN CERTAIN WRITTEN POLICIES OF THE CORPORATION.</para>
+      <para>Recipients of this document may copy, distribute, publish, or display this document so
+        long as this copyright notice, license and disclaimer are retained with all copies of the
+        document. No license is granted to modify this document.</para>
+      <para>THIS DOCUMENT IS PROVIDED "AS IS," AND THE CORPORATION AND ITS MEMBERS AND THEIR
+        AFFILIATES, MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+        LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+        NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THIS DOCUMENT ARE SUITABLE FOR ANY PURPOSE;
+        OR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY PATENTS, COPYRIGHTS,
+        TRADEMARKS OR OTHER RIGHTS.</para>
+      <para>IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FOR ANY
+        DIRECT, INDIRECT, SPECIAL, INCIDENTAL, PUNITIVE OR CONSEQUENTIAL DAMAGES, ARISING OUT OF OR
+        RELATING TO ANY USE OR DISTRIBUTION OF THIS DOCUMENT, WHETHER OR NOT (1) THE CORPORATION,
+        MEMBERS OR THEIR AFFILIATES HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES, OR (2)
+        SUCH DAMAGES WERE REASONABLY FORESEEABLE, AND ARISING OUT OF OR RELATING TO ANY USE OR
+        DISTRIBUTION OF THIS DOCUMENT.  THE FOREGOING DISCLAIMER AND LIMITATION ON LIABILITY DO NOT
+        APPLY TO, INVALIDATE, OR LIMIT REPRESENTATIONS AND WARRANTIES MADE BY THE MEMBERS AND THEIR
+        RESPECTIVE AFFILIATES TO THE CORPORATION AND OTHER MEMBERS IN CERTAIN WRITTEN POLICIES OF
+        THE CORPORATION.</para>
     </legalnotice>
     <revhistory>
       <revision>
@@ -50,7 +65,8 @@
         <author>
           <personname>Dirk Stegemann, Stefan Andersson</personname>
         </author>
-        <revremark>Change Request 1268, 1276, 1349, 1350, 1351, 1352, 1376, 1377, 1378, 1379, 1380, 1381, 1382, 1390</revremark>
+        <revremark>Change Request 1268, 1276, 1349, 1350, 1351, 1352, 1376, 1377, 1378, 1379, 1380,
+          1381, 1382, 1390</revremark>
       </revision>
       <revision>
         <revnumber>1.1</revnumber>
@@ -58,7 +74,8 @@
         <author>
           <personname>Dirk Stegemann</personname>
         </author>
-        <revremark>Change Request 1528, 1529, 1530, 1531, 1532, 1533, 1534, 1535, 1536, 1543, 1554</revremark>
+        <revremark>Change Request 1528, 1529, 1530, 1531, 1532, 1533, 1534, 1535, 1536, 1543,
+          1554</revremark>
       </revision>
       <revision>
         <revnumber>1.2</revnumber>
@@ -66,7 +83,8 @@
         <author>
           <personname>Dirk Stegemann</personname>
         </author>
-        <revremark>Change Request 1552, 1555, 1565, 1580, 1583, 1590, 1615, 1616, 1617, 1618, 1619. Added certificate-based client authentication</revremark>
+        <revremark>Change Request 1552, 1555, 1565, 1580, 1583, 1590, 1615, 1616, 1617, 1618, 1619.
+          Added certificate-based client authentication</revremark>
       </revision>
       <revision>
         <revnumber>1.3</revnumber>
@@ -114,7 +132,8 @@
         <author>
           <personname>Oksana Tyushkina, Rick Boer</personname>
         </author>
-        <revremark>Fix typo in commands names. Fix inconsistency in Security NoMatchingPrivateKey</revremark>
+        <revremark>Fix typo in commands names. Fix inconsistency in Security
+          NoMatchingPrivateKey</revremark>
       </revision>
       <revision>
         <revnumber>22.06</revnumber>
@@ -122,7 +141,8 @@
         <author>
           <personname>Hans Busch</personname>
         </author>
-        <revremark>Fix fault namespace prefix and remove requirement to accept missing MAC when passphrase is present.</revremark>
+        <revremark>Fix fault namespace prefix and remove requirement to accept missing MAC when
+          passphrase is present.</revremark>
       </revision>
       <revision>
         <revnumber>22.12</revnumber>
@@ -130,7 +150,8 @@
         <author>
           <personname>Hans Busch</personname>
         </author>
-        <revremark>Do not require to support multiple identical pathes. Remove CRL requirement on client authentication.</revremark>
+        <revremark>Do not require to support multiple identical pathes. Remove CRL requirement on
+          client authentication.</revremark>
       </revision>
       <revision>
         <revnumber>23.06</revnumber>
@@ -146,7 +167,8 @@
         <author>
           <personname>Ottavio Campana, Fredrik Svensson</personname>
         </author>
-        <revremark>Added support for ECC cryptography, JSON Web Tokens, Authorization Servers using OAuth2 and OpenID Connect.</revremark>
+        <revremark>Added support for ECC cryptography, JSON Web Tokens, Authorization Servers using
+          OAuth2 and OpenID Connect.</revremark>
       </revision>
       <revision>
         <revnumber>24.06</revnumber>
@@ -154,15 +176,20 @@
         <author>
           <personname>Sriram Bhetanabottla, Hans Busch</personname>
         </author>
-        <revremark>Improve readability of section on authorization server. Move JWT example to annex.</revremark>
+        <revremark>Improve readability of section on authorization server. Move JWT example to
+          annex.</revremark>
       </revision>
       <revision>
         <revnumber>24.12</revnumber>
         <date>Dec-2024</date>
         <author>
-          <personname>Fredrik Svensson, Sriram Bhetanabottla, Hans Busch, Jose Melancon, Sujith Raman, Kieran McCartan</personname>
+          <personname>Fredrik Svensson, Sriram Bhetanabottla, Hans Busch, Jose Melancon, Sujith
+            Raman, Kieran McCartan</personname>
         </author>
-        <revremark>Add media signing capabilities and operations. Clarify JWT and OAuth sections.  Add CertPathValidationPolicyId to AuthorizationServer &amp; StorageConfiguration. Recommend strong signature selection. Update CreateEccKeyPair and Curve name references. Add annex on TLS ciphers.</revremark>
+        <revremark>Add media signing capabilities and operations. Clarify JWT and OAuth sections.
+          Add CertPathValidationPolicyId to AuthorizationServer &amp; StorageConfiguration.
+          Recommend strong signature selection. Update CreateEccKeyPair and Curve name references.
+          Add annex on TLS ciphers.</revremark>
       </revision>
     </revhistory>
   </info>
@@ -1576,6 +1603,7 @@
           <section xml:id="_Ref361388129">
             <title>GetKeyStatus</title>
             <para>This operation returns the status of a key as defined in Sect. <xref linkend="_Ref353728108"/>.</para>
+            <para>An ONVIF conformant device shall support this command.</para>
             <para>Keys are uniquely identified using key IDs. If no key is stored under the requested key ID in the keystore, an InvalidKeyID fault is produced. Otherwise, the status of the key is returned.</para>
             <variablelist role="op">
               <varlistentry>
@@ -1649,7 +1677,8 @@
             <title>GetAllKeys</title>
             <para>This operation returns information about all keys that are stored in the device’s keystore.</para>
             <para>This operation may be used, e.g., if a client lost track of which keys are present on the device.</para>
-            <para>If no key is stored on the device, an empty list is returned.</para>
+            <para>If no key is stored on the device, an empty list is returned. An ONVIF conformant
+              device shall support this command.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
@@ -1680,7 +1709,8 @@
           </section>
           <section xml:id="_Ref363540841">
             <title>DeleteKey</title>
-            <para>This operation deletes a key from the device’s keystore.</para>
+            <para>This operation deletes a key from the device’s keystore. An ONVIF conformant
+              device shall support this command.</para>
             <para>Keys are uniquely identified using key IDs. If no key is stored under the requested key ID in the keystore, a device shall produce an InvalidArgVal fault. If a reference exists for the specified key, a device shall produce the corresponding fault and shall not delete the key. If there is a key under the requested key ID stored in the keystore and the key could not be deleted, a device shall produce a KeyDeletion fault. If the key has the status <emphasis>generating</emphasis>, a device shall abort the generation of the key and delete from the keystore all data generated for this key.</para>
             <para>After a key is successfully deleted, the device may assign its former ID to other keys.</para>
             <variablelist role="op">
@@ -1868,6 +1898,7 @@
             <para>The device shall assign the supplied Alias to the uploaded certificate.</para>
             <para>If a new key pair is generated, the device shall assign the supplied KeyAlias to it. Otherwise, the device shall ignore an eventually supplied KeyAlias.</para>
             <para>How the link between the uploaded certificate and a key pair is established is illustrated in <xref linkend="_Ref338934863"/>.</para>
+            <para>An ONVIF compliant device shall support this command.</para>
             <figure xml:id="_Ref338934863">
               <title>Link establishment between certificate and key pair for Upload Certificate</title>
               <mediaobject>
@@ -2090,7 +2121,8 @@
           </section>
           <section>
             <title>GetAllCertificates</title>
-            <para>This operation returns all certificates that are stored in the device’s keystore.</para>
+            <para>This operation returns all certificates that are stored in the device’s keystore.
+              An ONVIF compliant device shall support this command.</para>
             <para>This operation may be used, e.g., if a client lost track of which certificates are present on the device.</para>
             <para>The certificates shall be returned in DER encoding.</para>
             <para>If no certificate is stored in the device’s keystore, an empty list is returned.</para>
@@ -2124,7 +2156,8 @@
           </section>
           <section>
             <title>DeleteCertificate</title>
-            <para>This operation deletes a certificate from the device’s keystore.</para>
+            <para>This operation deletes a certificate from the device’s keystore. An ONVIF
+              compliant device shall support this command.</para>
             <para>The operation shall not delete the public key that is contained in the certificate from the keystore.</para>
             <para>Certificates are uniquely identified using certificate IDs. If no certificate is stored under the requested certificate ID in the keystore, an InvalidArgVal fault is produced. If there is a certificate under the requested certificate ID stored in the keystore and the certificate could not be deleted, a CertificateDeletion fault is produced.</para>
             <para>If a reference exists for the specified certificate, the certificate shall not be deleted and the corresponding fault shall be produced.</para>
@@ -2514,7 +2547,8 @@
           <title>Certification Path Validation Policy Management</title>
           <section>
             <title>CreateCertPathValidationPolicy</title>
-            <para>This operation creates a certification path validation policy.</para>
+            <para>This operation creates a certification path validation policy. An ONVIF compliant
+              device shall support this command.</para>
             <para>Certification path validation policies are uniquely identified using certification path validation policy IDs. The device shall generate a new certification path validation policy ID for the created certification path validation policy.</para>
             <para>If the device does not have enough storage capacity for storing the certification path validation policy to be created, the device shall produce a maximum number of certification path validation policies reached fault and shall not create a certification path validation policy.</para>
             <para>If there is at least one trust anchor certificate ID in the request for which there exists no certificate in the device’s keystore, the device shall produce a CertificateID fault and shall not create a certification path validation policy.</para>
@@ -2562,7 +2596,8 @@
           </section>
           <section>
             <title>GetCertPathValidationPolicy</title>
-            <para>This operation returns a certification path validation policy from the keystore on the device.</para>
+            <para>This operation returns a certification path validation policy from the keystore on
+              the device. An ONVIF compliant device shall support this command.</para>
             <para>Certification path validation policies are uniquely identified using certification path validation policy IDs. If no certification path validation policy is stored under the requested certification path validation policy ID, the device shall produce a CertPathValidationPolicyID fault.</para>
             <variablelist role="op">
               <varlistentry>
@@ -2596,7 +2631,9 @@
           </section>
           <section>
             <title>GetAllCertPathValidationPolicies</title>
-            <para>This operation returns all certification path validation policies that are stored in the keystore on the device.</para>
+            <para>This operation returns all certification path validation policies that are stored
+              in the keystore on the device. An ONVIF compliant device shall support this
+              command.</para>
             <para>If no certification path validation policy is stored in the device’s keystore, an empty list is returned.</para>
             <variablelist role="op">
               <varlistentry>
@@ -2630,7 +2667,8 @@
             <title>SetCertPathValidationPolicy</title>
             <para>This operation allows to modify a certification path validation policy in the
               keystore on the device. A device shall support this method if support for SetCertPath
-              is signaled via its capabilities.</para>
+              is signaled via its capabilities. A device signaling support via the SetCertPathPolicy
+              shall support this command.</para>
             <variablelist role="op">
               <varlistentry>
                 <term>request</term>
@@ -4361,30 +4399,15 @@
                 </entry>
               </row>
               <row>
-                <entry>
-                  <para>MaximumNumberOfKeys</para>
-                </entry>
-                <entry>
-                  <para>If greater than zero, then the following commands shall be supported:</para>
-                  <itemizedlist>
-                    <listitem>
-                      <para>GetKeyStatus</para>
-                    </listitem>
-                    <listitem>
-                      <para>GetAllKeys</para>
-                    </listitem>
-                    <listitem>
-                      <para>DeleteKey</para>
-                    </listitem>
-                  </itemizedlist>
-                </entry>
+                <entry>MaximumNumberOfKeys</entry>
+                <entry>Shall be at least four</entry>
               </row>
               <row>
                 <entry>
                   <para>MaximumNumberOfCertificates</para>
                 </entry>
                 <entry>
-                  <para>If greater than zero, then MaximumNumberOfKeys&gt;0 shall hold.</para>
+                  <para>Shall be at lest four</para>
                 </entry>
               </row>
               <row>
@@ -4392,36 +4415,32 @@
                   <para>MaximumNumberOfCertificationPaths</para>
                 </entry>
                 <entry>
-                  <para>If greater than zero, MaximumNumberOfCertificates&gt;=2 shall hold.</para>
+                  <para>Shall be at least two</para>
                 </entry>
               </row>
               <row>
+                <entry>MaximumNumberOfCertificationPathValidationPolicies</entry>
+                <entry>Shall be at least two</entry>
+              </row>
+              <row>
                 <entry>
-                  <para>RSAKeyPairGeneration</para>
+                  <para>KeyPairGeneration</para>
                 </entry>
                 <entry>
-                  <para>If true, the following commands shall be supported:</para>
+                  <para>If true, then either the list of supported RSA key length is not empty and
+                    the device supports the command:</para>
                   <itemizedlist>
                     <listitem>
                       <para>CreateRSAKeyPair</para>
                     </listitem>
                   </itemizedlist>
-                  <para>If true, the list of supported RSA key lengths as indicated by the RSAKeyLenghts capability shall not be empty.</para>
-                  <para>If true, MaximumNumberOfKeys&gt;0 shall hold.</para>
-                </entry>
-              </row>
-              <row>
-                <entry>
-                  <para>ECCKeyPairGeneration</para>
-                </entry>
-                <entry>
-                  <para>If true, the following commands shall be supported:</para>
+                  <para>or the list of supported elliptic curves indicated by the EllipticCurves
+                    capability is not empty and the device supports the commands:</para>
                   <itemizedlist>
                     <listitem>
                       <para>CreateECCKeyPair</para>
                     </listitem>
                   </itemizedlist>
-                  <para>If true, the list of supported elliptic curves indicated by the EllipticCurves capability shall not be empty.</para>
                   <para>If true, MaximumNumberOfKeys&gt;0 shall hold.</para>
                 </entry>
               </row>
@@ -4436,20 +4455,10 @@
                       <para>UploadKeyPairInPKCS8</para>
                     </listitem>
                   </itemizedlist>
-                  <para>If true, MaximumNumberOfKeys &gt; 0 shall hold.</para>
                   <para>If true, the list of supported password-based encryption algorithms as
                     indicated by the PasswordBasedEncryptionAlgorithms capability shall contain at
                     least the algorithm <phrase>pbeWithSHAAnd3-KeyTripleDES-CBC</phrase>.</para>
                   <para>If true, at least one capability between EllipticCurves and RSAKeyLenghts shall be specified.</para>
-                </entry>
-              </row>
-              <row>
-                <entry>
-                  <para>PKCS8RSAKeyPairUpload</para>
-                </entry>
-                <entry>
-                  <para>If true, the conditions of  PKCS8 shall be supported:</para>
-                  <para>If true, the list of supported RSA key lengths as indicated by the RSAKeyLenghts capability shall not be empty.</para>
                 </entry>
               </row>
               <row>
@@ -4481,21 +4490,12 @@
                       <para>DeleteCertificationPath</para>
                     </listitem>
                   </itemizedlist>
-                  <para>If true, MaximumNumberOfKeys &gt;=2 shall hold.</para>
-                  <para>If true, MaximumNumberOfCertificates &gt;=2 shall hold.</para>
-                  <para>If true, MaximumNumberOfCertificattionPaths &gt;0 shall hold.</para>
-                  <para>If true, the list of supported password-based encryption algorithms as indicated by the PasswordBasedEncryptionAlgorithms capability shall contain at least the algorithm <phrase>pbeWithSHAAnd3-KeyTripleDES-CBC</phrase>.</para>
+                  <para>If true, the list of supported password-based encryption algorithms as
+                    indicated by the PasswordBasedEncryptionAlgorithms capability shall include the
+                    baseline specified in table Key Derivation Functions of the ONVIF Security
+                    Baseline.</para>
                   <para>If true, the list of supported password-based MAC algorithms as indicated by the PasswordBasedMACAlgorithms capability shall contain at least the algorithm <phrase>hmacWithSHA256</phrase>.</para>
                   <para>If true, the list of supported X.509 versions as indicated by the X.509Versions capability shall contain at least the value 3.</para>
-                </entry>
-              </row>
-              <row>
-                <entry>
-                  <para>PKCS12CertificateWithRSAPrivateKeyUpload</para>
-                </entry>
-                <entry>
-                  <para>If true, the conditions of capability PKCS12 shall be fulfilled.</para>
-                  <para>If true, the list of supported RSA key lengths as indicated by the RSAKeyLenghts capability shall not be empty.</para>
                 </entry>
               </row>
               <row>
@@ -4542,13 +4542,6 @@
                 </entry>
               </row>
               <row>
-                <entry><para>PKCS10ExternalCertificationWithRSA</para></entry>
-                <entry>
-                  <para>If true, the conditions of capability PKCS10 shall be fulfilled.</para>
-                  <para>If true, the list of supported RSA key lengths as indicated by the RSAKeyLenghts capability shall not be empty.</para>
-                </entry>
-              </row>
-              <row>
                 <entry>
                   <para>SelfSignedCertificateCreation</para>
                 </entry>
@@ -4581,7 +4574,9 @@
                       <para>The capability RSAKeyPairGeneration shall be specified .</para>
                     </listitem>
                     <listitem>
-                      <para>The list of supported signature algorithms as indicated by the SignatureAlgorithms capability shall contain at least the algorithms sha1-WithRSAEncryption and sha256WithRSAEncryption.</para>
+                      <para>The list of supported signature algorithms as indicated by the
+                        SignatureAlgorithms capability shall contain the RSA baseline defined in
+                        table signature algorithms of the ONVIF Security Baseline.</para>
                     </listitem>
                   </itemizedlist>
                   <para>If true and the capability EllipticCurves is provided, the following condition shall be fulfilled:</para>
@@ -4590,15 +4585,6 @@
                       <para>The capability ECCKeyPairGeneration shall be specified.</para>
                     </listitem>
                   </itemizedlist>
-                </entry>
-              </row>
-              <row>
-                <entry>
-                  <para>SelfSignedCertificateCreationWithRSA</para>
-                </entry>
-                <entry>
-                  <para>If true, the conditions of the SelfSignedCertificateCreation capability shall be supported.</para>
-                  <para>If true, the list of supported RSA key lengths as indicated by the RSAKeyLenghts capability shall not be empty.</para>
                 </entry>
               </row>
               <row>
@@ -4635,30 +4621,6 @@
                     </listitem>
                   </itemizedlist>
                   <para>If not empty, MaximumNumberOfCertificationPaths&gt;=2 and MaximumNumberOfTLSCertificationPaths&gt;0 shall hold.</para>
-                </entry>
-              </row>
-              <row>
-                <entry>
-                  <para>TLSServerSupported and PKCS10ExternalCertificationWithRSA</para>
-                </entry>
-                <entry>
-                  <para>If TLSServerSupported is non-empty and PKCS10ExternalCertificationWithRSA is true, MaximumNumberOfCertificates&gt;=3 shall hold.</para>
-                </entry>
-              </row>
-              <row>
-                <entry>
-                  <para>TLSServerSupported and PKCS10</para>
-                </entry>
-                <entry>
-                  <para>If TLSServerSupported is non-empty and PKCS10 is true, MaximumNumberOfCertificates&gt;=3 shall hold.</para>
-                </entry>
-              </row>
-              <row>
-                <entry>
-                  <para>MaximumNumberOfTLSCertificationPaths</para>
-                </entry>
-                <entry>
-                  <para>If greater than zero, MaximumNumberOfCertificationPaths&gt;0 shall hold.</para>
                 </entry>
               </row>
               <row>
@@ -4711,29 +4673,6 @@
               </row>
               <row>
                 <entry>
-                  <para>MaximumNumberOfCertificationPathValidationPolicies</para>
-                </entry>
-                <entry>
-                  <para>If greater than zero, then the following command shall be supported</para>
-                  <itemizedlist>
-                    <listitem>
-                      <para>CreateCertPathValidationPolicy</para>
-                    </listitem>
-                    <listitem>
-                      <para>GetCertPathValidationPolicy</para>
-                    </listitem>
-                    <listitem>
-                      <para>GetAllCertPathValidationPolicies</para>
-                    </listitem>
-                    <listitem>
-                      <para>DeleteCertPathValidationPolicy</para>
-                    </listitem>
-                  </itemizedlist>
-                  <para>If greater than zero, PKCS12CertificateWithRSAPrivateKeyUpload, PKCS10ExternalCertificationWithRSA or SelfSignedCertificateCreationWithRSA or PKCS12 or PKCS10 or SelfSignedCertificateCreation shall be true.</para>
-                </entry>
-              </row>
-              <row>
-                <entry>
                   <para>TLSClientAuthSupported</para>
                 </entry>
                 <entry>
@@ -4759,7 +4698,8 @@
                     </listitem>
                   </itemizedlist>
                   <para>If true, TLSServerSupported shall not be empty.</para>
-                  <para>If true, MaximumNumberOfCertificationPathValidationPolicies&gt;=2 and MaximumNumberOfTLSCertificationPathValidationPolicies&gt;0 shall hold.</para>
+                  <para>If true, MaximumNumberOfTLSCertificationPathValidationPolicies&gt;0 shall
+                    hold.</para>
                   <para>If true, the device shall support</para>
                   <itemizedlist>
                     <listitem>
@@ -4777,14 +4717,6 @@
                       </itemizedlist>
                     </listitem>
                   </itemizedlist>
-                </entry>
-              </row>
-              <row>
-                <entry>
-                  <para>MaximumNumberOfTLSCertificationPathValidationPolicies</para>
-                </entry>
-                <entry>
-                  <para>If greater than zero, MaximumNumberOfCertificationPathValidationPolicies &gt;0 shall hold.</para>
                 </entry>
               </row>
               <row>
@@ -4846,7 +4778,7 @@
               </row>
               <row>
                 <entry>EllipticCurves</entry>
-                <entry>The list of supported elliptic curves.</entry>
+                <entry><para>The list of supported elliptic curves. </para><para>If the entry is non-empty it shall contain at least the baseline </para></entry>
               </row>
             </tbody>
           </tgroup>
@@ -4887,11 +4819,8 @@
       <listitem>
         <para>Secure up to date signature algorithm should be implemented by devices and clients.
           Devices signal the supported algorithm via their capabilities and clients should select
-          the algorithm with highest security strength supported by both parties. As common baseline
-          this specification requires device side support for SHA-2, particularly
-          sha256WithRSAEncryption as specified in RFC 4055. Note that for backward compatibility of
-          some usages this specification currently mandates device side support for
-          sha1WithRSAEncryption as specified in RFC 3279. </para>
+          the algorithm with highest security strength supported by both parties. See ONVIF Security
+          Baseline for algorithm to be supported.  </para>
       </listitem>
       <listitem>
         <para>Operations with arguments that need protection against eavesdropping or manipulation shall only be executed over sufficiently protected communication channels. </para>
@@ -5087,53 +5016,6 @@ User-Agent: ./onvifClient
 Accept: application/sdp]]></programlisting>
   </appendix>
 
-  <appendix xml:id= "b14_55m_51d">
-    <title>Cipher Reference (Informative)</title>
-
-	<para>This Annex is advocating a small subset of Ciphers as part of the ONVIF standard that readers of this specification can use as an informative guide. The following small subset of ciphers covering TLS 1.2 / 1.3 are common recommendations issued as guidance by the bodies Cloudflare, IETF (TLS 1.2, TLS1.3), Mozilla, and ciphersuite.info (TLS 1.2, TLS 1.3).</para>
-
-	<para>While TLS 1.2 and 1.3 are both currently viable, we would suggest that TLS 1.3 is preferred. Do note that the table is not ordered by the strength of the cipher.</para>
-
-    <table>
-        <title>TLS 1.3 / 1.2 Cipher list</title>
-	<tgroup cols="2">
-            <colspec colname="c1" colwidth="50*"/>
-            <colspec colname="c2" colwidth="50*"/>
-	   <thead>
-		<row>
-		   <entry><para>Minimum Protocol</para></entry><entry><para>IANA Name</para></entry>
-		</row>
-	   </thead>
-
-	   <tbody valign="top">
-		<row>
-		   <entry><para>TLS 1.3</para></entry><entry><para>TLS_AES_256_GCM_SHA384</para></entry>
-		</row>
-		<row>
-		   <entry><para>TLS 1.3</para></entry><entry><para>TLS_CHACHA20_POLY1305_SHA256</para></entry>
-		</row>
-		<row>
-		   <entry><para>TLS 1.2</para></entry><entry><para>TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256</para></entry>
-		</row>
-		<row>
-		   <entry><para>TLS 1.2</para></entry><entry><para>TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256</para></entry>
-		</row>
-		<row>
-		   <entry><para>TLS 1.2</para></entry><entry><para>TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256</para></entry>
-		</row>
-		<row>
-		   <entry><para>TLS 1.2</para></entry><entry><para>TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256</para></entry>
-		</row>
-		<row>
-		   <entry><para>TLS 1.2</para></entry><entry><para>TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384</para></entry>
-		</row>
-		<row>
-		   <entry><para>TLS 1.2</para></entry><entry><para>TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384</para></entry>
-		</row>
-	   </tbody>
-	</tgroup>
-    </table>
-  </appendix>
 
   <appendix role="revhistory">
     <title>Revision History</title>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -4467,7 +4467,9 @@
                     indicated by the PasswordBasedEncryptionAlgorithms capability shall include the
                     baseline specified in table Key Derivation Functions of the ONVIF Security
                     Baseline.</para>
-                  <para>If true, the list of supported password-based MAC algorithms as indicated by the PasswordBasedMACAlgorithms capability shall contain at least the algorithm <phrase>hmacWithSHA256</phrase>.</para>
+                  <para>If true, the list of supported password-based MAC algorithms as indicated by
+                    the PasswordBasedMACAlgorithms capability shall include the baseline specified
+                    in table Key Derivation Functions of the ONVIF Security Baseline.</para>
                   <para>If true, the list of supported X.509 versions as indicated by the X.509Versions capability shall contain at least the value 3.</para>
                 </entry>
               </row>
@@ -4508,7 +4510,9 @@
                       <para>The capability ECCKeyPairGeneration shall be specified.</para>
                     </listitem>
                     <listitem>
-                      <para>The list of supported signature algorithms as indicated by the SignatureAlgorithms capability shall contain at least the algorithms ECDSA-With-SHA1 and ECDSA-With-SHA256.</para>
+                      <para>The list of supported signature algorithms as indicated by the
+                        SignatureAlgorithms capability shall contain at least the algorithm defined
+                        in the security baseline.</para>
                     </listitem>
                   </itemizedlist>
                   
@@ -4642,6 +4646,15 @@
                       <para>DeleteCRL</para>
                     </listitem>
                   </itemizedlist>
+                  <para>If greater than zero, then processing X.509 CRLs that are compliant to the
+                    CRL profile defined in RFC 5280, Sect. 5 and that</para>
+                  <itemizedlist>
+                    <listitem>
+                      <para>are complete direct CRLs as defined in RFC 5280 that are signed with the
+                        same signature key as the signature key that the CA uses to sign issued
+                        certificates</para>
+                    </listitem>
+                  </itemizedlist>
                 </entry>
               </row>
               <row>
@@ -4676,18 +4689,8 @@
                   <para>If true, the device shall support</para>
                   <itemizedlist>
                     <listitem>
-                      <para>validating certification paths containing X.509v3 certificates that are signed with signatures of type sha1-WithRSAEncryption or sha256WithRSAEncrpytion</para>
-                    </listitem>
-                    <listitem>
-                      <para>processing X.509 CRLs that are compliant to the CRL profile defined in RFC 5280, Sect. 5 and that</para>
-                      <itemizedlist>
-                        <listitem>
-                          <para>are signed with signatures of type sha1-WithRSAEncryption or, sha256WithRSAEncryption and</para>
-                        </listitem>
-                        <listitem>
-                          <para>are complete direct CRLs as defined in RFC 5280 that are signed with the same signature key as the signature key that the CA uses to sign issued certificates</para>
-                        </listitem>
-                      </itemizedlist>
+                      <para>validating certification paths containing X.509v3 certificates that are
+                        signed with signature algorithm listed in the security baseline.</para>
                     </listitem>
                   </itemizedlist>
                 </entry>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -1439,8 +1439,6 @@
           to be present in the keystore under different IDs, respectively.</para>
         <para>A device shall allow multiple copies of the same IEEE 802.1X configuration to be
           present in the keystore under different IDs simultaneously.</para>
-        <para>A device shall not allow multiple copies of the same key to be present in the keystore
-          simultaneously.</para>
       </section>
       <section>
         <title>Referential Integrity</title>
@@ -2079,14 +2077,15 @@
             <title>DeleteKey</title>
             <para>This operation deletes a key from the device’s keystore. An ONVIF conformant
               device shall support this command.</para>
-            <para>Keys are uniquely identified using key IDs. If no key is stored under the
-              requested key ID in the keystore, a device shall produce an InvalidArgVal fault. If a
-              reference exists for the specified key, a device shall produce the corresponding fault
-              and shall not delete the key. If there is a key under the requested key ID stored in
-              the keystore and the key could not be deleted, a device shall produce a KeyDeletion
-              fault. If the key has the status <emphasis>generating</emphasis>, a device shall abort
-              the generation of the key and delete from the keystore all data generated for this
-              key.</para>
+            <para>If no key is stored under the requested key ID in the keystore and AutoDeleteKey
+              is signaled a device shall signal no fault. Otherwise it may produce an InvalidArgVal
+              fault. </para>
+            <para>If a reference exists for the specified key, a device shall produce the
+              corresponding fault and shall not delete the key. If there is a key under the
+              requested key ID stored in the keystore and the key could not be deleted, a device
+              shall produce a KeyDeletion fault. If the key has the status
+                <emphasis>generating</emphasis>, a device shall abort the generation of the key and
+              delete from the keystore all data generated for this key.</para>
             <para>After a key is successfully deleted, the device may assign its former ID to other
               keys.</para>
             <variablelist role="op">
@@ -2797,8 +2796,9 @@
             <title>DeleteCertificate</title>
             <para>This operation deletes a certificate from the device’s keystore. An ONVIF
               compliant device shall support this command.</para>
-            <para>The operation shall not delete the public key that is contained in the certificate
-              from the keystore.</para>
+            <para>If the device signals AutoDeleteKey the associated key shall be deleted when no
+              more references to it exist. Otherwise the operation shall not delete the associated
+              key.</para>
             <para>Certificates are uniquely identified using certificate IDs. If no certificate is
               stored under the requested certificate ID in the keystore, an InvalidArgVal fault is
               produced. If there is a certificate under the requested certificate ID stored in the
@@ -5140,6 +5140,11 @@
                   <para>The device supports modification of certificate path and certificate
                     validation path.</para>
                 </entry>
+              </row>
+              <row>
+                <entry>AutoDeleteKey</entry>
+                <entry>DeleteCertificate automatically deletes the referenced key when there are no
+                  more references.</entry>
               </row>
             </tbody>
           </tgroup>

--- a/doc/SecurityBaseline.xml
+++ b/doc/SecurityBaseline.xml
@@ -1,0 +1,348 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href="docbook.xsl" type="text/xsl" ?>
+<book xmlns="http://docbook.org/ns/docbook" version="5.0">
+  <info>
+    <title>Security Baseline Specification</title>
+    <titleabbrev>SecurityBaseline</titleabbrev>
+    <releaseinfo>25.12 Draft</releaseinfo>
+    <author>
+      <orgname>ONVIF™</orgname>
+      <uri>www.onvif.org</uri>
+    </author>
+    <pubdate>March 2025</pubdate>
+    <mediaobject>
+      <imageobject>
+        <imagedata fileref="media/logo.png" contentwidth="60mm"/>
+      </imageobject>
+    </mediaobject>
+    <copyright>
+      <year>2008-2025</year>
+      <holder>ONVIF™ All rights reserved.</holder>
+    </copyright>
+    <legalnotice>
+      <para>Recipients of this document may copy, distribute, publish, or display this document so
+        long as this copyright notice, license and disclaimer are retained with all copies of the
+        document. No license is granted to modify this document.</para>
+      <para>THIS DOCUMENT IS PROVIDED "AS IS," AND THE CORPORATION AND ITS MEMBERS AND THEIR
+        AFFILIATES, MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+        LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+        NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THIS DOCUMENT ARE SUITABLE FOR ANY PURPOSE;
+        OR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY PATENTS, COPYRIGHTS,
+        TRADEMARKS OR OTHER RIGHTS.</para>
+      <para>IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FOR ANY
+        DIRECT, INDIRECT, SPECIAL, INCIDENTAL, PUNITIVE OR CONSEQUENTIAL DAMAGES, ARISING OUT OF OR
+        RELATING TO ANY USE OR DISTRIBUTION OF THIS DOCUMENT, WHETHER OR NOT (1) THE CORPORATION,
+        MEMBERS OR THEIR AFFILIATES HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES, OR (2)
+        SUCH DAMAGES WERE REASONABLY FORESEEABLE, AND ARISING OUT OF OR RELATING TO ANY USE OR
+        DISTRIBUTION OF THIS DOCUMENT.  THE FOREGOING DISCLAIMER AND LIMITATION ON LIABILITY DO NOT
+        APPLY TO, INVALIDATE, OR LIMIT REPRESENTATIONS AND WARRANTIES MADE BY THE MEMBERS AND THEIR
+        RESPECTIVE AFFILIATES TO THE CORPORATION AND OTHER MEMBERS IN CERTAIN WRITTEN POLICIES OF
+        THE CORPORATION.</para>
+    </legalnotice>
+    <revhistory>
+      <revision>
+        <revnumber>25.12</revnumber>
+        <date>Dec-2025</date>
+        <author>
+          <personname>Hans Busch</personname>
+        </author>
+        <revremark>Draft</revremark>
+      </revision>
+    </revhistory>
+  </info>
+  <chapter>
+    <title>Scope</title>
+    <para>This document defines the security baseline for ONVIF specifications. Its content is based on state of the art technology as published by NIST or BSI. </para>
+    <para>Note, that any updates to this specification require a review of implications on technical, profile and addon specifications. 
+      Publication of updates must synchronized with ONVIF Technical and Technical Service Committee</para>
+  </chapter>
+  <chapter>
+    <title>Normative References</title>
+    <para>NIST FIPS 180-4 Secure Hash Standard (SHS)</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf"/>&gt; </para>
+    <para>NIST FIPS 186-5 Digital Signature Standard (DSS) - February 3, 2023</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf"/>&gt;</para>
+    <para>BSI – Technical Guideline, Cryptographic Mechanisms: Recommendations and Key Length- January 31, 2025</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-1.pdf?__blob=publicationFile&amp;v=9"/>&gt;</para>
+  </chapter>
+  <chapter>
+    <title>Definitions</title>
+    <informaltable>
+      <tgroup cols="2">
+        <colspec colname="c1" colwidth="27*" />
+        <colspec colname="c2" colwidth="73*" />
+        <tbody valign="top">
+          <row>
+            <entry>
+              <para>Provisioning</para>
+            </entry>
+            <entry>
+              <para>Doing something in advance to prepare for something else.</para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>Video Source</para>
+            </entry>
+            <entry>
+              <para>Entity defined by [ONVIF Device I/O Specification]</para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>Video Source Token</para>
+            </entry>
+            <entry>
+              <para>Token referencing a Device I/O Video Source</para>
+            </entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </informaltable>
+  </chapter>
+  <chapter>
+    <title>Overview</title>
+    <para>All sections in this specification are normative unless explicitly marked as informative.</para>
+  </chapter>
+  <chapter>
+    <title>Asymmetric Encryption Schemes and Key Agreement</title>
+    <para>ONVIF recommends to support the following mechanism</para>
+    <table xml:id="_Ref395173040">
+      <title>Assymmetric Key Schemes</title>
+      <tgroup cols="3">
+        <colspec colname="c1" colwidth="52*"/>
+        <colspec colname="c2" colwidth="12*"/>
+        <thead>
+          <row>
+            <entry>
+              <para>Name</para>
+            </entry>
+            <entry>
+              <para>Key Length </para>
+            </entry>
+            <entry>
+              <para>Comment</para>
+            </entry>
+          </row>
+        </thead>
+        <tbody valign="top">
+          <row>
+            <entry>
+              <para>RSA</para>
+            </entry>
+            <entry>
+              <para>>3000 Bit</para>
+            </entry>
+            <entry>RFC xxxx</entry>
+          </row>
+          <row>
+            <entry>sha256WithRSAEncrpytion</entry>
+            <entry>4096</entry>
+            <entry>RSA Baseline</entry>
+          </row>
+          <row>
+            <entry>EC Diffie-Hellman</entry>
+            <entry>>250 Bit</entry>
+            <entry></entry>
+          </row>
+          <row>
+            <entry>secp256r1</entry>
+            <entry>256</entry>
+            <entry>EC Baseline</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </chapter>
+  <chapter>
+    <title>Symmetric Encryption Schemes</title>
+    <para></para>
+    <table xml:id="symTable">
+      <title>Symmetric Encryption Schemes</title>
+      <tgroup cols="3">
+        <colspec colname="c1" colwidth="52*"/>
+        <colspec colname="c2" colwidth="12*"/>
+        <thead>
+          <row>
+            <entry>
+              <para>Name</para>
+            </entry>
+            <entry>
+              <para>Key Length </para>
+            </entry>
+            <entry>
+              <para>Comment</para>
+            </entry>
+          </row>
+        </thead>
+        <tbody valign="top">
+          <row>
+            <entry>
+              <para>AES</para>
+            </entry>
+            <entry>
+              <para>>= 192 Bit</para>
+            </entry>
+            <entry></entry>
+          </row>
+          <row>
+            <entry>AES-256</entry>
+            <entry>256</entry>
+            <entry>Baseline</entry>
+          </row>
+          <row>
+            <entry>AES-GCM</entry>
+            <entry>>= 192 Bit</entry>
+          </row>
+          <row>
+            <entry>AES-AEAD</entry>
+            <entry>>= 256 Bit</entry>
+            <entry>RFC 7539</entry>
+          </row>
+          <row>
+            <entry>CHACHA20_POLY1305</entry>
+            <entry>>= 256 Bit</entry>
+            <entry>RFC 8439</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </chapter>
+  <chapter>
+    <title>Hash Functions and Signatures</title>
+    <para></para>
+    <table xml:id="sigTable">
+      <title>Hashes and Signatures</title>
+      <tgroup cols="3">
+        <colspec colname="c1" colwidth="52*"/>
+        <colspec colname="c2" colwidth="12*"/>
+        <thead>
+          <row>
+            <entry>
+              <para>Name</para>
+            </entry>
+            <entry>
+              <para>Key Length </para>
+            </entry>
+            <entry>
+              <para>Reference</para>
+            </entry>
+          </row>
+        </thead>
+        <tbody valign="top">
+          <row>
+            <entry>
+              <para>SHA-2</para>
+            </entry>
+            <entry>
+              <para>>= 384 Bit</para>
+            </entry>
+          </row>
+          <row>
+            <entry>sha256WithRSAEncryption</entry>
+            <entry>256 Bit</entry>
+            <entry>RFC 4055</entry>
+          </row>
+          <row>
+            <entry>SHA-3</entry>
+            <entry>>= 256 Bit</entry>
+          </row>
+          <row>
+            <entry>RSASSA-PSS</entry>
+            <entry>>= 3000</entry>
+          </row>
+          <row>
+            <entry>ECDSA</entry>
+            <entry>>= 256 Bit</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </chapter>
+  <chapter>
+    <title>Key Derivation</title>
+    <table xml:id="sigTable">
+      <title>Key Derivation Functions</title>
+      <tgroup cols="3">
+        <colspec colname="c1" colwidth="52*"/>
+        <colspec colname="c2" colwidth="12*"/>
+        <thead>
+          <row>
+            <entry>
+              <para>Name</para>
+            </entry>
+            <entry>
+              <para>Key Length </para>
+            </entry>
+            <entry>
+              <para>Reference</para>
+            </entry>
+          </row>
+        </thead>
+        <tbody valign="top">
+          <row>
+            <entry>
+              <para>pbeWithSHAAnd3-KeyTripleDES-CBC replace !!!!</para>
+            </entry>
+            <entry>
+              <para/>
+            </entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+    <para>As common baseline devices and clients shall support sha256WithRSAEncryption or
+      sha256</para>
+  </chapter>
+  <appendix xml:id= "b14_55m_51d">
+    <title>Cipher Reference (Informative)</title>
+    
+    <para>This Annex is advocating a small subset of Ciphers as part of the ONVIF standard that readers of this specification can use as an informative guide. The following small subset of ciphers covering TLS 1.2 / 1.3 are common recommendations issued as guidance by the bodies Cloudflare, IETF (TLS 1.2, TLS1.3), Mozilla, and ciphersuite.info (TLS 1.2, TLS 1.3).</para>
+    
+    <para>While TLS 1.2 and 1.3 are both currently viable, we would suggest that TLS 1.3 is preferred. Do note that the table is not ordered by the strength of the cipher.</para>
+    
+    <table>
+      <title>TLS 1.3 / 1.2 Cipher list</title>
+      <tgroup cols="2">
+        <colspec colname="c1" colwidth="50*"/>
+        <colspec colname="c2" colwidth="50*"/>
+        <thead>
+          <row>
+            <entry><para>Minimum Protocol</para></entry><entry><para>IANA Name</para></entry>
+          </row>
+        </thead>
+        
+        <tbody valign="top">
+          <row>
+            <entry><para>TLS 1.3</para></entry><entry><para>TLS_AES_256_GCM_SHA384</para></entry>
+          </row>
+          <row>
+            <entry><para>TLS 1.3</para></entry><entry><para>TLS_CHACHA20_POLY1305_SHA256</para></entry>
+          </row>
+          <row>
+            <entry><para>TLS 1.2</para></entry><entry><para>TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256</para></entry>
+          </row>
+          <row>
+            <entry><para>TLS 1.2</para></entry><entry><para>TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256</para></entry>
+          </row>
+          <row>
+            <entry><para>TLS 1.2</para></entry><entry><para>TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256</para></entry>
+          </row>
+          <row>
+            <entry><para>TLS 1.2</para></entry><entry><para>TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256</para></entry>
+          </row>
+          <row>
+            <entry><para>TLS 1.2</para></entry><entry><para>TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384</para></entry>
+          </row>
+          <row>
+            <entry><para>TLS 1.2</para></entry><entry><para>TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384</para></entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </appendix>
+  <appendix role="revhistory">
+    <title>Revision History</title>
+    <para />
+  </appendix>
+</book>

--- a/doc/SecurityBaseline.xml
+++ b/doc/SecurityBaseline.xml
@@ -222,10 +222,10 @@
     </table>
   </chapter>
   <chapter>
-    <title>Hash Functions and Signatures</title>
+    <title>Hash Functions</title>
     <para/>
     <table xml:id="sigTable">
-      <title>Hashes and Signatures</title>
+      <title>Hashes</title>
       <tgroup cols="3">
         <colspec colname="c1" colwidth="52*"/>
         <colspec colname="c2" colwidth="12*"/>
@@ -253,14 +253,40 @@
             <entry><para>FIPS 180-4</para></entry>
           </row>
           <row>
-            <entry><para>sha256WithRSAEncryption</para></entry>
-            <entry><para>>= 3000 Bit</para></entry>
-            <entry><para>RFC 4055</para></entry>
-          </row>
-          <row>
             <entry><para>SHA-3</para></entry>
             <entry><para>>= 256 Bit</para></entry>
             <entry><para>FIPS 202</para></entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </chapter>
+  <chapter>
+    <title>Signatures</title>
+    <para/>
+    <table xml:id="sigTable">
+      <title>Signatures</title>
+      <tgroup cols="3">
+        <colspec colname="c1" colwidth="52*"/>
+        <colspec colname="c2" colwidth="12*"/>
+        <thead>
+          <row>
+            <entry>
+              <para>Name</para>
+            </entry>
+            <entry>
+              <para>Size</para>
+            </entry>
+            <entry>
+              <para>Reference</para>
+            </entry>
+          </row>
+        </thead>
+        <tbody valign="top">
+          <row>
+            <entry><para>sha256WithRSAEncryption</para></entry>
+            <entry><para>>= 3000 Bit</para></entry>
+            <entry><para>RFC 4055</para></entry>
           </row>
           <row>
             <entry><para>RSASSA-PSS</para></entry>
@@ -302,7 +328,7 @@
               <para>PBKDF2</para>
             </entry>
             <entry><para>RFC 8018</para></entry>
-            <entry><para>Preferred</para></entry>
+            <entry><para>Password only</para></entry>
           </row>
           <row>
             <entry>

--- a/doc/SecurityBaseline.xml
+++ b/doc/SecurityBaseline.xml
@@ -88,7 +88,7 @@
         <tbody valign="top">
           <row>
             <entry>
-              <para>Assymetric Encryption</para>
+              <para>Asymmetric Encryption</para>
             </entry>
             <entry>
               <para>Encryption with public and private key pair.</para>
@@ -117,7 +117,7 @@
   </chapter>
   <chapter>
     <title>Overview</title>
-    <para>The content of this is document bases on state of the art technology as published by the American institute NIST and the German department BSI. 
+    <para>The content of this document is based on state of the art technology as published by the American institute NIST and the German department BSI. 
       Note, that any updates to this specification require a review of implications on technical, profile and addon specifications.</para>
     <para>Publication of updates must synchronized with ONVIF Technical and Technical Service Committee</para>
   </chapter>
@@ -125,7 +125,7 @@
     <title>Asymmetric Encryption Schemes and Key Agreement</title>
     <para/>
     <table xml:id="_Ref395173040">
-      <title>Assymmetric Key Schemes</title>
+      <title>Asymmetric Key Schemes</title>
       <tgroup cols="3">
         <colspec colname="c1" colwidth="52*"/>
         <colspec colname="c2" colwidth="12*"/>

--- a/doc/SecurityBaseline.xml
+++ b/doc/SecurityBaseline.xml
@@ -66,6 +66,8 @@
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-1.pdf?__blob=publicationFile&amp;v=9"/>&gt;</para>
     <para>RFC 4055 - Additional Algorithms and Identifiers for RSA Cryptography for use in the Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile</para>
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc4055"/>&gt;</para>
+    <para>RFC 4868 -  Using HMAC-SHA-256, HMAC-SHA-384, and HMAC-SHA-512 with IPsec</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc4868"/>&gt;</para>
     <para>RFC 5758 - Internet X.509 Public Key Infrastructure: Additional Algorithms and Identifiers for DSA and ECDSA</para>
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc5758"/>&gt;</para>
     <para>RFC 5869 - HMAC-based Extract-and-Expand Key Derivation Function (HKDF)</para>
@@ -284,7 +286,7 @@
     <table xml:id="keyTable">
       <title>Key Derivation Functions</title>
       <tgroup cols="3">
-        <colspec colname="c1" colwidth="52*"/>
+        <colspec colname="c1" colwidth="15*"/>
         <colspec colname="c2" colwidth="12*"/>
         <thead>
           <row>
@@ -292,31 +294,34 @@
               <para>Name</para>
             </entry>
             <entry>
-              <para>Key Length </para>
+              <para>Reference</para>
             </entry>
             <entry>
-              <para>Reference</para>
+              <para>Comment</para>
             </entry>
           </row>
         </thead>
         <tbody valign="top">
           <row>
             <entry>
-              <para>HKDF</para>
+              <para>PBKDF2</para>
             </entry>
-            <entry>
-              <para/>
-            </entry>
-            <entry><para>RFC 5869</para></entry>
+            <entry><para>RFC 8018</para></entry>
+            <entry><para>Preferred</para></entry>
           </row>
           <row>
             <entry>
-              <para>PBKDF2</para>
+              <para>HKDF</para>
             </entry>
+            <entry><para>RFC 5869</para></entry>
+            <entry><para/></entry>
+          </row>
+          <row>
             <entry>
-              <para/>
+              <para>hmacWithSHA256</para>
             </entry>
-            <entry><para>RFC 8018</para></entry>
+            <entry><para>RFC 4868</para></entry>
+            <entry><para>For PKCS12 only</para></entry>
           </row>
         </tbody>
       </tgroup>

--- a/doc/SecurityBaseline.xml
+++ b/doc/SecurityBaseline.xml
@@ -68,6 +68,8 @@
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc4055"/>&gt;</para>
     <para>RFC 5758 - Internet X.509 Public Key Infrastructure: Additional Algorithms and Identifiers for DSA and ECDSA</para>
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc5758"/>&gt;</para>
+    <para>RFC 5869 - HMAC-based Extract-and-Expand Key Derivation Function (HKDF)</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc5869"/>&gt;</para>
     <para>RFC 8017 - PKCS #1: RSA Cryptography Specifications Version 2.2</para>
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc8017"/>&gt;</para>
     <para>RFC 8018 - PKCS #5: Password-Based Cryptography Specification Version 2.1</para>
@@ -368,9 +370,9 @@
     </table>
   </appendix>
   <appendix>
-    <title>Recording Encryption (Informative)</title>
-    <para>This section lists the encryption baseline and links them to the relevant IANA registry.
-      The listed algorithm map to the definitions in the normative sections above. </para>
+    <title>Hybrid Public Key Encryption (Informative)</title>
+    <para>This section lists the HPKE encryption baseline and links them to the relevant IANA
+      registry. The listed algorithm map to the definitions in the normative sections above. </para>
     <para>
       <table frame="all">
         <title>HPKE KEM Identifiers</title>
@@ -424,7 +426,7 @@
           <tbody>
             <row>
               <entry><para>2</para></entry>
-              <entry><para>AEAS-256-GCM</para></entry>
+              <entry><para>AES-256-GCM</para></entry>
             </row>
           </tbody>
         </tgroup>

--- a/doc/SecurityBaseline.xml
+++ b/doc/SecurityBaseline.xml
@@ -74,26 +74,27 @@
         <tbody valign="top">
           <row>
             <entry>
-              <para>Provisioning</para>
+              <para>Assymetric Encryption</para>
             </entry>
             <entry>
-              <para>Doing something in advance to prepare for something else.</para>
-            </entry>
-          </row>
-          <row>
-            <entry>
-              <para>Video Source</para>
-            </entry>
-            <entry>
-              <para>Entity defined by [ONVIF Device I/O Specification]</para>
+              <para>Encryption with public and private key pair.</para>
             </entry>
           </row>
           <row>
             <entry>
-              <para>Video Source Token</para>
+              <para>Hash</para>
             </entry>
             <entry>
-              <para>Token referencing a Device I/O Video Source</para>
+              <para>Method to create a unique fingerprint of a large data set.</para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>Signature</para>
+            </entry>
+            <entry>
+              <para>Private key signed hash that can be verified with the corresponding public
+                key.</para>
             </entry>
           </row>
         </tbody>
@@ -102,11 +103,13 @@
   </chapter>
   <chapter>
     <title>Overview</title>
-    <para>All sections in this specification are normative unless explicitly marked as informative.</para>
+    <para>The content of this is document bases on state of the art technology as published by the American institute NIST and the German department BSI. 
+      Note, that any updates to this specification require a review of implications on technical, profile and addon specifications.</para>
+    <para>Publication of updates must synchronized with ONVIF Technical and Technical Service Committee</para>
   </chapter>
   <chapter>
     <title>Asymmetric Encryption Schemes and Key Agreement</title>
-    <para>ONVIF recommends to support the following mechanism</para>
+    <para></para>
     <table xml:id="_Ref395173040">
       <title>Assymmetric Key Schemes</title>
       <tgroup cols="3">
@@ -131,24 +134,24 @@
               <para>RSA</para>
             </entry>
             <entry>
-              <para>>3000 Bit</para>
+              <para>>= 3000 Bit</para>
             </entry>
-            <entry>RFC xxxx</entry>
+            <entry><para>RFC xxxx</para></entry>
           </row>
           <row>
-            <entry>sha256WithRSAEncrpytion</entry>
-            <entry>4096</entry>
-            <entry>RSA Baseline</entry>
+            <entry><para>sha256WithRSAEncrpytion</para></entry>
+            <entry><para>4096</para></entry>
+            <entry><para>RSA Baseline</para></entry>
           </row>
           <row>
-            <entry>EC Diffie-Hellman</entry>
-            <entry>>250 Bit</entry>
+            <entry><para>EC Diffie-Hellman</para></entry>
+            <entry><para>> 250 Bit</para></entry>
             <entry></entry>
           </row>
           <row>
-            <entry>secp256r1</entry>
-            <entry>256</entry>
-            <entry>EC Baseline</entry>
+            <entry><para>secp256r1</para></entry>
+            <entry><para>256</para></entry>
+            <entry><para>EC Baseline</para></entry>
           </row>
         </tbody>
       </tgroup>
@@ -186,23 +189,24 @@
             <entry></entry>
           </row>
           <row>
-            <entry>AES-256</entry>
-            <entry>256</entry>
-            <entry>Baseline</entry>
+            <entry><para>AES-256</para></entry>
+            <entry><para>256 Bit</para></entry>
+            <entry><para>Baseline</para></entry>
           </row>
           <row>
-            <entry>AES-GCM</entry>
-            <entry>>= 192 Bit</entry>
+            <entry><para>AES-GCM</para></entry>
+            <entry><para>>= 192 Bit</para></entry>
+            <entry/>
           </row>
           <row>
-            <entry>AES-AEAD</entry>
-            <entry>>= 256 Bit</entry>
-            <entry>RFC 7539</entry>
+            <entry><para>AES-AEAD</para></entry>
+            <entry><para>>= 256 Bit</para></entry>
+            <entry><para>RFC 7539</para></entry>
           </row>
           <row>
-            <entry>CHACHA20_POLY1305</entry>
-            <entry>>= 256 Bit</entry>
-            <entry>RFC 8439</entry>
+            <entry><para>CHACHA20_POLY1305</para></entry>
+            <entry><para>>= 256 Bit</para></entry>
+            <entry><para>RFC 8439</para></entry>
           </row>
         </tbody>
       </tgroup>
@@ -222,7 +226,7 @@
               <para>Name</para>
             </entry>
             <entry>
-              <para>Key Length </para>
+              <para>Size</para>
             </entry>
             <entry>
               <para>Reference</para>
@@ -237,23 +241,27 @@
             <entry>
               <para>>= 384 Bit</para>
             </entry>
+            <entry><para>FIPS 180-4</para></entry>
           </row>
           <row>
-            <entry>sha256WithRSAEncryption</entry>
-            <entry>256 Bit</entry>
-            <entry>RFC 4055</entry>
+            <entry><para>sha256WithRSAEncryption</para></entry>
+            <entry><para>>= 3000 Bit</para></entry>
+            <entry><para>RFC 4055</para></entry>
           </row>
           <row>
-            <entry>SHA-3</entry>
-            <entry>>= 256 Bit</entry>
+            <entry><para>SHA-3</para></entry>
+            <entry><para>>= 256 Bit</para></entry>
+            <entry><para>FIPS 202</para></entry>
           </row>
           <row>
-            <entry>RSASSA-PSS</entry>
-            <entry>>= 3000</entry>
+            <entry><para>RSASSA-PSS</para></entry>
+            <entry><para>>= 3000 Bit</para></entry>
+            <entry><para>RFC 8017</para></entry>
           </row>
           <row>
-            <entry>ECDSA</entry>
-            <entry>>= 256 Bit</entry>
+            <entry><para>ECDSA</para></entry>
+            <entry><para>>= 256 Bit</para></entry>
+            <entry><para>RFC 5758, X9.62</para></entry>
           </row>
         </tbody>
       </tgroup>
@@ -261,7 +269,7 @@
   </chapter>
   <chapter>
     <title>Key Derivation</title>
-    <table xml:id="sigTable">
+    <table xml:id="keyTable">
       <title>Key Derivation Functions</title>
       <tgroup cols="3">
         <colspec colname="c1" colwidth="52*"/>
@@ -282,23 +290,22 @@
         <tbody valign="top">
           <row>
             <entry>
-              <para>pbeWithSHAAnd3-KeyTripleDES-CBC replace !!!!</para>
+              <para>PBKDF2</para>
             </entry>
             <entry>
               <para/>
             </entry>
+            <entry><para>RFC 8018</para></entry>
           </row>
         </tbody>
       </tgroup>
     </table>
-    <para>As common baseline devices and clients shall support sha256WithRSAEncryption or
-      sha256</para>
   </chapter>
   <appendix xml:id= "b14_55m_51d">
     <title>Cipher Reference (Informative)</title>
     
-    <para>This Annex is advocating a small subset of Ciphers as part of the ONVIF standard that readers of this specification can use as an informative guide. The following small subset of ciphers covering TLS 1.2 / 1.3 are common recommendations issued as guidance by the bodies Cloudflare, IETF (TLS 1.2, TLS1.3), Mozilla, and ciphersuite.info (TLS 1.2, TLS 1.3).</para>
-    
+    <para>This Annex is advocating a small subset of Ciphers as part of the ONVIF standard that readers of this specification can use as an informative guide. </para>
+    <para>The following small subset of ciphers covering TLS 1.2 / 1.3 are based on the baseline defined in this document and match common practise by Cloudflare, Mozilla, and ciphersuite.info.</para>
     <para>While TLS 1.2 and 1.3 are both currently viable, we would suggest that TLS 1.3 is preferred. Do note that the table is not ordered by the strength of the cipher.</para>
     
     <table>

--- a/doc/SecurityBaseline.xml
+++ b/doc/SecurityBaseline.xml
@@ -64,13 +64,23 @@
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf"/>&gt;</para>
     <para>BSI – Technical Guideline, Cryptographic Mechanisms: Recommendations and Key Length- January 31, 2025</para>
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-1.pdf?__blob=publicationFile&amp;v=9"/>&gt;</para>
+    <para>RFC 4055 - Additional Algorithms and Identifiers for RSA Cryptography for use in the Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc4055"/>&gt;</para>
+    <para>RFC 5758 - Internet X.509 Public Key Infrastructure: Additional Algorithms and Identifiers for DSA and ECDSA</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc5758"/>&gt;</para>
+    <para>RFC 8017 - PKCS #1: RSA Cryptography Specifications Version 2.2</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc8017"/>&gt;</para>
+    <para>RFC 8018 - PKCS #5: Password-Based Cryptography Specification Version 2.1</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc8018"/>&gt;</para>
+    <para>RFC 8439 - ChaCha20 and Poly1305 for IETF Protocols</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc8439"/>&gt;</para>
   </chapter>
   <chapter>
     <title>Definitions</title>
     <informaltable>
       <tgroup cols="2">
-        <colspec colname="c1" colwidth="27*" />
-        <colspec colname="c2" colwidth="73*" />
+        <colspec colname="c1" colwidth="27*"/>
+        <colspec colname="c2" colwidth="73*"/>
         <tbody valign="top">
           <row>
             <entry>
@@ -109,7 +119,7 @@
   </chapter>
   <chapter>
     <title>Asymmetric Encryption Schemes and Key Agreement</title>
-    <para></para>
+    <para/>
     <table xml:id="_Ref395173040">
       <title>Assymmetric Key Schemes</title>
       <tgroup cols="3">
@@ -136,7 +146,7 @@
             <entry>
               <para>>= 3000 Bit</para>
             </entry>
-            <entry><para>RFC xxxx</para></entry>
+            <entry><para/></entry>
           </row>
           <row>
             <entry><para>sha256WithRSAEncrpytion</para></entry>
@@ -146,7 +156,7 @@
           <row>
             <entry><para>EC Diffie-Hellman</para></entry>
             <entry><para>> 250 Bit</para></entry>
-            <entry></entry>
+            <entry/>
           </row>
           <row>
             <entry><para>secp256r1</para></entry>
@@ -159,7 +169,7 @@
   </chapter>
   <chapter>
     <title>Symmetric Encryption Schemes</title>
-    <para></para>
+    <para/>
     <table xml:id="symTable">
       <title>Symmetric Encryption Schemes</title>
       <tgroup cols="3">
@@ -186,7 +196,7 @@
             <entry>
               <para>>= 192 Bit</para>
             </entry>
-            <entry></entry>
+            <entry/>
           </row>
           <row>
             <entry><para>AES-256</para></entry>
@@ -214,7 +224,7 @@
   </chapter>
   <chapter>
     <title>Hash Functions and Signatures</title>
-    <para></para>
+    <para/>
     <table xml:id="sigTable">
       <title>Hashes and Signatures</title>
       <tgroup cols="3">
@@ -290,6 +300,15 @@
         <tbody valign="top">
           <row>
             <entry>
+              <para>HKDF</para>
+            </entry>
+            <entry>
+              <para/>
+            </entry>
+            <entry><para>RFC 5869</para></entry>
+          </row>
+          <row>
+            <entry>
               <para>PBKDF2</para>
             </entry>
             <entry>
@@ -301,8 +320,8 @@
       </tgroup>
     </table>
   </chapter>
-  <appendix xml:id= "b14_55m_51d">
-    <title>Cipher Reference (Informative)</title>
+  <appendix xml:id="b14_55m_51d">
+    <title>TLS Cipher Reference (Informative)</title>
     
     <para>This Annex is advocating a small subset of Ciphers as part of the ONVIF standard that readers of this specification can use as an informative guide. </para>
     <para>The following small subset of ciphers covering TLS 1.2 / 1.3 are based on the baseline defined in this document and match common practise by Cloudflare, Mozilla, and ciphersuite.info.</para>
@@ -348,8 +367,72 @@
       </tgroup>
     </table>
   </appendix>
+  <appendix>
+    <title>Recording Encryption (Informative)</title>
+    <para>This section lists the encryption baseline and links them to the relevant IANA registry.
+      The listed algorithm map to the definitions in the normative sections above. </para>
+    <para>
+      <table frame="all">
+        <title>HPKE KEM Identifiers</title>
+        <tgroup cols="2">
+          <colspec colname="c1" colnum="1" colwidth="1.0*"/>
+          <colspec colname="c2" colnum="2" colwidth="1.0*"/>
+          <thead>
+            <row>
+              <entry>IANA Registry</entry>
+              <entry>Reference</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry><para>0x0010</para></entry>
+              <entry><para>DHKEM(P-256, HKDF-SHA256)</para></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+      <table frame="all">
+        <title>HPKE KDF Identifiers</title>
+        <tgroup cols="2">
+          <colspec colname="c1" colnum="1" colwidth="1.0*"/>
+          <colspec colname="c2" colnum="2" colwidth="1.0*"/>
+          <thead>
+            <row>
+              <entry>IANA Registry</entry>
+              <entry>Reference</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry><para>1</para></entry>
+              <entry><para>HKDF-SHA256</para></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+      <table frame="all">
+        <title>HPKE AEAD Identifiers</title>
+        <tgroup cols="2">
+          <colspec colname="c1" colnum="1" colwidth="1.0*"/>
+          <colspec colname="c2" colnum="2" colwidth="1.0*"/>
+          <thead>
+            <row>
+              <entry>IANA Registry</entry>
+              <entry>Reference</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry><para>2</para></entry>
+              <entry><para>AEAS-256-GCM</para></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </para>    
+  </appendix>
   <appendix role="revhistory">
     <title>Revision History</title>
-    <para />
+    <para/>
   </appendix>
 </book>

--- a/doc/SecurityBaseline.xml
+++ b/doc/SecurityBaseline.xml
@@ -153,11 +153,6 @@
             <entry><para/></entry>
           </row>
           <row>
-            <entry><para>sha256WithRSAEncrpytion</para></entry>
-            <entry><para>4096</para></entry>
-            <entry><para>RSA Baseline</para></entry>
-          </row>
-          <row>
             <entry><para>EC Diffie-Hellman</para></entry>
             <entry><para>> 250 Bit</para></entry>
             <entry/>

--- a/doc/index.html
+++ b/doc/index.html
@@ -171,6 +171,11 @@ For the default branch of onvif/specs ONVIF provides a proxy that fixes this beh
 </tr>
 <tr>
 <td></td>
+<td><a href="SecurityBaseline.xml">Security Baseline</a></td>
+<td></td>
+</tr>
+<tr>
+<td></td>
 <td><a href="Thermal.xml">Thermal</a></td>
 <td><a href="../wsdl/ver10/thermal/wsdl/thermal.wsdl">thermal.wsdl</a></td>
 <td><a href="../wsdl/ver20/analytics/radiometry.xsd">radiometry.xsd</a></td>

--- a/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
+++ b/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
@@ -82,6 +82,12 @@
 					</xs:enumeration>
 				</xs:restriction>
 			</xs:simpleType>
+			<xs:simpleType name="KeyPairAlgorithm">
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="RSA"/>
+					<xs:enumeration value="ECC"/>
+				</xs:restriction>
+			</xs:simpleType>
 			<!--===============================-->
 			<xs:simpleType name="DotDecimalOID">
 				<xs:annotation>
@@ -726,14 +732,19 @@
 						<xs:documentation>Indicates support for modifying an existing certification path or certification path validation policy.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
+				<xs:attribute name="KeyPairGeneration" type="tt:StringList">
+					<xs:annotation>
+						<xs:documentation>List of defined key pair algorithm. See tas:KeyPairAlgorithm.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:attribute name="RSAKeyPairGeneration" type="xs:boolean">
 					<xs:annotation>
-						<xs:documentation>Indication that the device supports on-board RSA key pair generation.</xs:documentation>
+						<xs:documentation>Deprecated - Indication that the device supports on-board ECC key pair generation.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:attribute name="ECCKeyPairGeneration" type="xs:boolean">
 					<xs:annotation>
-						<xs:documentation>Indication that the device supports on-board ECC key pair generation.</xs:documentation>
+						<xs:documentation>Deprecated - Indication that the device supports on-board ECC key pair generation.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:attribute name="RSAKeyLengths" type="tas:RSAKeyLengths">
@@ -748,7 +759,7 @@
 				</xs:attribute>
 				<xs:attribute name="PKCS10ExternalCertificationWithRSA" type="xs:boolean">
 					<xs:annotation>
-						<xs:documentation>Indicates support for creating PKCS#10 requests for RSA keys and uploading the certificate obtained from a CA..</xs:documentation>
+						<xs:documentation>Deprecated - Indicates support for creating PKCS#10 requests for RSA keys and uploading the certificate obtained from a CA..</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:attribute name="PKCS10" type="xs:boolean">
@@ -758,7 +769,7 @@
 				</xs:attribute>
 				<xs:attribute name="SelfSignedCertificateCreationWithRSA" type="xs:boolean">
 					<xs:annotation>
-						<xs:documentation>Indicates support for creating self-signed certificates for RSA keys.</xs:documentation>
+						<xs:documentation>Deprecated - Indicates support for creating self-signed certificates for RSA keys.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:attribute name="SelfSignedCertificateCreation" type="xs:boolean">
@@ -778,7 +789,7 @@
 				</xs:attribute>
 				<xs:attribute name="PKCS8RSAKeyPairUpload" type="xs:boolean">
 					<xs:annotation>
-						<xs:documentation>Indicates support for uploading an RSA key pair in a PKCS#8 data structure.</xs:documentation>
+						<xs:documentation>Deprecated - Indicates support for uploading an RSA key pair in a PKCS#8 data structure.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:attribute name="PKCS8" type="xs:boolean">
@@ -786,7 +797,7 @@
 						<xs:documentation>Indicates support for uploading a key pair in a PKCS#8 data structure.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
-				<xs:attribute name="PKCS12CertificateWithRSAPrivateKeyUpload" type="xs:boolean">
+				<xs:attribute name="Deprecated - PKCS12CertificateWithRSAPrivateKeyUpload" type="xs:boolean">
 					<xs:annotation>
 						<xs:documentation>Indicates support for uploading a certificate along with an RSA private key in a PKCS#12 data structure.</xs:documentation>
 					</xs:annotation>

--- a/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
+++ b/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
@@ -434,6 +434,11 @@
 							<xs:documentation>The base64-encoded DER representation of the X.509 certificate.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
+					<xs:element name="HasPrivateKey" type="xs:boolean" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>The keystore has a matching private key.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
 					<xs:any minOccurs="0" maxOccurs="unbounded" namespace="##any" processContents="lax"/>   <!-- first ONVIF then Vendor -->
 				</xs:sequence>
 				<xs:anyAttribute processContents="lax"/>


### PR DESCRIPTION
This PR picks up part of Sriram's proposal with Stefan's suggestion using automatic deletion of stale keys. The new behavior is signaled via a new capability AutoDeleteKey. Additional behavior on DeleteKey fault handling are designed to minimize backward compatibility clients who are not aware of the new shortcut.

GetAllKeys and DeleteKey may only need to be used on failtures of assymetric key creation. All other use cases can be handled by uploading and deleting certificates.

The boolean property HasPrivateKey has been added to the certificate information, to avoid the need for the key API.

Note that these changes have a small impact on the DTT:
* Negative test cases on key deletion need to be skipped.

All in all this proposal is much less intrusive than #580. It's a bit harder to understand, as it adds more implementation options.