### PR TITLE
Make media signing capability backward compatible.

### DIFF
--- a/wsdl/ver20/media/wsdl/media.wsdl
+++ b/wsdl/ver20/media/wsdl/media.wsdl
@@ -43,7 +43,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 							<xs:documentation>Streaming capabilities.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="MediaSigningCapabilities" type="tr2:MediaSigningCapabilities">
+					<xs:element name="MediaSigningCapabilities" type="tr2:MediaSigningCapabilities" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>Media signing capabilities.</xs:documentation>
 						</xs:annotation>


### PR DESCRIPTION
Important fix for #590 reported by DTT team.