### PR TITLE
Shortening OverrideSegmentDurationSupported

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -1674,7 +1674,7 @@ Change Request 2061, 2063, 2065, 2109</revremark>
           </listitem>
         </varlistentry>
         <varlistentry>
-          <term>OverrideSegmentDurationSupported</term>
+          <term>OverrideSegmentDuration</term>
           <listitem>
             <para>Indicates that the device supports the OverrideSegmentDuration command.</para>
           </listitem>

--- a/wsdl/ver10/recording.wsdl
+++ b/wsdl/ver10/recording.wsdl
@@ -132,7 +132,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
-				<xs:attribute name="OverrideSegmentDurationSupported" type="xs:boolean">
+				<xs:attribute name="OverrideSegmentDuration" type="xs:boolean">
 					<xs:annotation>
 						<xs:documentation>
 							Indicates if the device supports the OverrideSegmentDuration command.


### PR DESCRIPTION
The capability name is too long and the docbook renders it poorly. Changing OverrideSegmentDurationSupported -> OverrideSegmentDuration for better readibility.