### PR TITLE
Authorization server: clarify ServerUri meaning

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -974,7 +974,7 @@
                   <para>ServerUri</para>
                 </entry>
                 <entry>
-                  <para>Authorization server address</para>
+                  <para>Authorization server address including metadata endpoint conforming to RFC8414, such as "https://your.domain/.well-known/openid-configuration". May be used to retrieve endpoint URIs for authorization, token and JWKS.</para>
                 </entry>
               </row>
               <row>
@@ -1091,8 +1091,6 @@
                 </entry>
                 <entry>
                   <para>OpenID Connect authorization code flow per Open ID Connect Core.</para>
-                  <para>The ServerUri is used as metadata URI, where you can retrieve the endpoint
-                    URIs for authorization, token and JWKS.</para>
                 </entry>
               </row>
             </tbody>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -974,7 +974,7 @@
                   <para>ServerUri</para>
                 </entry>
                 <entry>
-                  <para>Authorization server metadata endpoint conforming to RFC8414, such as "https://your.domain/.well-known/openid-configuration". Will be used to retrieve endpoint URIs for authorization, token or JWKS.</para>
+                  <para>Authorization server metadata endpoint conforming to RFC8414, such as "https://your.domain/.well-known/openid-configuration", that is used to retrieve endpoint URIs for authorization, token or JWKS.</para>
                 </entry>
               </row>
               <row>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -974,7 +974,7 @@
                   <para>ServerUri</para>
                 </entry>
                 <entry>
-                  <para>Authorization server address including metadata endpoint conforming to RFC8414, such as "https://your.domain/.well-known/openid-configuration". May be used to retrieve endpoint URIs for authorization, token and JWKS.</para>
+                  <para>Authorization server metadata endpoint conforming to RFC8414, such as "https://your.domain/.well-known/openid-configuration". Will be used to retrieve endpoint URIs for authorization, token or JWKS.</para>
                 </entry>
               </row>
               <row>

--- a/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
+++ b/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
@@ -948,7 +948,7 @@
 				<xs:sequence>
 					<xs:element name="ServerUri" type="xs:anyURI">
 						<xs:annotation>
-							<xs:documentation>Authorization server address including metadata endpoint conforming to RFC8414, such as "https://your.domain/.well-known/openid-configuration".</xs:documentation>
+							<xs:documentation>Authorization server metadata endpoint conforming to RFC8414, such as "https://your.domain/.well-known/openid-configuration"</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="ClientID" type="xs:string" minOccurs="0">

--- a/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
+++ b/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
@@ -948,7 +948,7 @@
 				<xs:sequence>
 					<xs:element name="ServerUri" type="xs:anyURI">
 						<xs:annotation>
-							<xs:documentation>Authorization server address</xs:documentation>
+							<xs:documentation>Authorization server address including metadata endpoint conforming to RFC8414, such as "https://your.domain/.well-known/openid-configuration".</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="ClientID" type="xs:string" minOccurs="0">


### PR DESCRIPTION
Fix for https://github.com/onvif/specs/issues/608.

Clarifies meaning of ServerUri. In proposed change it will point to the full metadata URI (Oauth2.0 or OIDC).