### PR TITLE
DeleteAuthorizationServerConfiguration: add ter:ReferenceExists fault

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -3790,6 +3790,7 @@
         <para>This operation deletes the given authorization server configuration and configuration
           change shall always be persistent. The device shall support this command if
           MaxConfigurations capability is greater than zero.</para>
+        <para>If a reference exists for the specified configuration, the device shall produce a ReferenceExists fault and shall not delete it.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>
@@ -3809,6 +3810,8 @@
             <listitem>
               <para role="param">env:Sender - ter:InvalidArgVal - ter:NoConfig</para>
               <para role="text">The requested configuration does not exist.</para>
+              <para role="param">ter:Sender - ter:InvalidArgVal - ter:ReferenceExists</para>
+              <para role="text"> A reference exists for the configuration that is to be deleted.</para>
             </listitem>
           </varlistentry>
           <varlistentry>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -2726,7 +2726,7 @@
                 <listitem>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:CertPathValidationPolicyID </para>
                   <para role="text">No certification path validation policy is stored under the requested certification path validation policy ID.</para>
-                  <para role="param">ter:Sender - ter:InvalidArgVal - ter:ReferenceExists</para>
+                  <para role="param">env:Sender - ter:InvalidArgVal - ter:ReferenceExists</para>
                   <para role="text"> A reference exists for the object that is to be deleted.</para>
                 </listitem>
               </varlistentry>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -2726,7 +2726,7 @@
                 <listitem>
                   <para role="param">env:Sender - ter:InvalidArgVal - ter:CertPathValidationPolicyID </para>
                   <para role="text">No certification path validation policy is stored under the requested certification path validation policy ID.</para>
-                  <para role="param">env:Sender - ter:InvalidArgVal - ter:ReferenceExists</para>
+                  <para role="param">ter:Sender - ter:InvalidArgVal - ter:ReferenceExists</para>
                   <para role="text"> A reference exists for the object that is to be deleted.</para>
                 </listitem>
               </varlistentry>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -3810,7 +3810,7 @@
             <listitem>
               <para role="param">env:Sender - ter:InvalidArgVal - ter:NoConfig</para>
               <para role="text">The requested configuration does not exist.</para>
-              <para role="param">ter:Sender - ter:InvalidArgVal - ter:ReferenceExists</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:ReferenceExists</para>
               <para role="text"> A reference exists for the configuration that is to be deleted.</para>
             </listitem>
           </varlistentry>


### PR DESCRIPTION
Deleting AuthorizationServerConfiguration, which is referenced by another object, like WebrtcConfiguration, shall be impossible and produce ter:ReferenceExists fault.