### PR TITLE
Add ABR support

### DIFF
--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -1124,10 +1124,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<xs:documentation>the maximum output bitrate in kbps</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="TargetAverageBitrate" type="xs:int">
+			<xs:element name="AverageBitrate" type="xs:int">
 				<xs:annotation>
-					<xs:documentation>the target average output bitrate in kbps</xs:documentation>
+					<xs:documentation>The target average output bitrate in kbps. If this parameter is set to 0, AverageBitrate shall be ignored.</xs:documentation>
 					<xs:documentation>If this parameter is configured beyond BitrateLimit, device adapts to BitrateLimit.</xs:documentation>
+					<xs:documentation>When this parameter is set to a non-zero value, constant bitrate mode shall be ignored.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
@@ -1135,11 +1136,6 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:attribute name="ConstantBitRate" type="xs:boolean">
 			<xs:annotation>
 				<xs:documentation>Enforce constant bitrate.</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="AverageBitRate" type="xs:boolean">
-			<xs:annotation>
-				<xs:documentation>Enforce average bitrate. When this parameter is set, constant bitrate mode shall be ignored.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:anyAttribute processContents="lax"/>

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -1124,6 +1124,13 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<xs:documentation>the maximum output bitrate in kbps</xs:documentation>
 				</xs:annotation>
 			</xs:element>
+			<xs:element name="TargetAverageBitrate" type="xs:int">
+				<xs:annotation>
+					<xs:documentation>the target average output bitrate in kbps</xs:documentation>
+					<xs:documentation>When this parameter is set, constant bitrate mode shall be ignored.</xs:documentation>
+					<xs:documentation>This parameter shall always be ≤ BitrateLimit</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
 		</xs:sequence>
 		<xs:attribute name="ConstantBitRate" type="xs:boolean">
@@ -1181,6 +1188,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:attribute name="ConstantBitRateSupported" type="xs:boolean">
 			<xs:annotation>
 				<xs:documentation>Signal whether enforcing constant bitrate is supported.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="AverageBitRateSupported" type="xs:boolean">
+			<xs:annotation>
+				<xs:documentation>Signal whether enforcing average bitrate is supported.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="GuaranteedFrameRateSupported" type="xs:boolean">

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -1127,7 +1127,6 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:element name="TargetAverageBitrate" type="xs:int">
 				<xs:annotation>
 					<xs:documentation>the target average output bitrate in kbps</xs:documentation>
-					<xs:documentation>When this parameter is set, constant bitrate mode shall be ignored.</xs:documentation>
 					<xs:documentation>This parameter shall always be ≤ BitrateLimit</xs:documentation>
 				</xs:annotation>
 			</xs:element>
@@ -1136,6 +1135,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:attribute name="ConstantBitRate" type="xs:boolean">
 			<xs:annotation>
 				<xs:documentation>Enforce constant bitrate.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="AverageBitRate" type="xs:boolean">
+			<xs:annotation>
+				<xs:documentation>Enforce average bitrate. When this parameter is set, constant bitrate mode shall be ignored.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:anyAttribute processContents="lax"/>

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -1128,7 +1128,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				<xs:annotation>
 					<xs:documentation>The target average output bitrate in kbps. If this parameter is set to 0, AverageBitrate shall be ignored.</xs:documentation>
 					<xs:documentation>If this parameter is configured beyond BitrateLimit, device adapts to BitrateLimit.</xs:documentation>
-					<xs:documentation>When this parameter is set to a non-zero value, constant bitrate mode shall be ignored.</xs:documentation>
+					<xs:documentation>When this parameter is set to a non-zero value, ConstantBitRate shall be ignored.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -1124,9 +1124,9 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<xs:documentation>the maximum output bitrate in kbps</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="AverageBitrate" type="xs:int">
+			<xs:element name="AverageBitRate" type="xs:int">
 				<xs:annotation>
-					<xs:documentation>The target average output bitrate in kbps. If this parameter is set to 0, AverageBitrate shall be ignored.</xs:documentation>
+					<xs:documentation>The target average output bitrate in kbps. If this parameter is set to 0, AverageBitRate shall be ignored.</xs:documentation>
 					<xs:documentation>If this parameter is configured beyond BitrateLimit, device adapts to BitrateLimit.</xs:documentation>
 					<xs:documentation>When this parameter is set to a non-zero value, ConstantBitRate shall be ignored.</xs:documentation>
 				</xs:annotation>

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -1127,7 +1127,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:element name="TargetAverageBitrate" type="xs:int">
 				<xs:annotation>
 					<xs:documentation>the target average output bitrate in kbps</xs:documentation>
-					<xs:documentation>This parameter shall always be ≤ BitrateLimit</xs:documentation>
+					<xs:documentation>If this parameter is configured beyond BitrateLimit, device adapts to BitrateLimit.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->


### PR DESCRIPTION
**Feature background/motivation** 
-  IP video surveillance needs to balance video quality with predictable storage and bandwidth. Currently ONVIF Media2 service specification only supports Constant bitrate and Maximum bitrate parameters
- Average bitrate feature, if standardized/configured from ONVIF, devices can try and adapt output bitrate internally to provide target bitrate over time, allowing higher instantaneous bitrates for complex scenes while not exceeding an overall target average.

**Spec proposal**
- Extended video rate control structure **_tt:VideoRateControl2_** with 2 parameters
  - AverageBitRate (feature toggle) 
  - TargetAverageBitrate (target bitrate devices should adapt output to meet the client storage targets)
 - Extended tt:**_VideoEncoder2ConfigurationOptions_** with below parameter
   - AverageBitRateSupported (capability flag)