### PR TITLE
Remove redundant text from ZoomSpaces section in PTZ.xml

### DIFF
--- a/doc/PTZ.xml
+++ b/doc/PTZ.xml
@@ -2422,7 +2422,6 @@ tns1:PTZController/PTZPresets/Left
         <programlisting><![CDATA[<tt:RelativeZoomTranslationSpace>
   <tt:SpaceURI>
     http://www.onvif.org/ver10/tptz/ZoomSpaces/TranslationSpaceFov
-    TranslationSpace
   </tt:SpaceURI>
   <tt:XRange>
     <tt:Min>0</tt:Min>


### PR DESCRIPTION
remove "TranslationSpace" from the <tt:SpaceURI> as per discussed on issue #624 