### PR TITLE
webrtc: clarify id field in error notifications

### DIFF
--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -609,7 +609,7 @@
     <section xml:id="section_error_notification">
       <title>error</title>
       <para>An ONVIF compliant signaling server, device and client shall support sending or receiving notifications signaling that an error has occurred.</para>
-			<para>This message is a [JSON-RPC] "Response" or "Notification" and shall contain [JSON-RPC] "Error object". If the error is not connected to a request, but sent as a notification, the id has to be null.</para>
+			<para>This message is a [JSON-RPC] "Response" or "Notification" and shall contain [JSON-RPC] "Error object". If the error is not connected to a request, but sent as a notification, the id shall be omitted.</para>
       <variablelist role="op">
         <varlistentry>
           <term>request</term>
@@ -732,8 +732,8 @@ Client -> Server: { "method": "extend", "params": {"session": "s1", "authorizati
                 "id": 4}
 Server -> Client: { "error": {"code": -32601, "message": "Method not found"}, "id": "4"}
 ...
-Device -> Server: { "error": {"code": 1001, "message": "Insufficient resources"}, "id": null}
-Server -> Client: { "error": {"code": 1001, "message": "Insufficient resources"}, "id": null}
+Device -> Server: { "error": {"code": 1001, "message": "Insufficient resources"}}
+Server -> Client: { "error": {"code": 1001, "message": "Insufficient resources"}}
 
 ]]></programlisting>
     </section>


### PR DESCRIPTION
Id should be omitted, not null, following recommendation from the JSON-RPC specification

Closes onvif/wg_profile_cloud#76