### PR TITLE
Clarify usage of mp4 content type

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -2052,7 +2052,8 @@ secfrac = "." 1*6DIGIT</programlisting>
       <para>
         The device shall open a single span for an active recording containing all tracks of the recording.
         The device shall use <literal>mp4</literal> as the extension for this span type.
-        The device shall upload each segment object belonging to a span of this type with the content type <literal>video/mp4</literal>.
+        The device shall upload each segment object belonging to a span of this type with the content type <literal>video/mp4</literal>. 
+        This content type is also used for audio-only recordings or metadata-only recordings.
         The device should include the <literal>codecs</literal> parameter in the content type according to RFC 6381.
       </para>
       <para>


### PR DESCRIPTION
Add clarification for multiplex mp4 usage of video/mp4 content type for audio only or metadata only. onvif/wg_profile_cloud#88