### PR TITLE
Add clarification that SegmentDuration might be truncated

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -1970,7 +1970,7 @@ SetRecordingJobMode(JobToken, Active)
         the open segment of this span and open a new segment for this span. When closing the open
         segment of a span and opening a new segment for this span, there shall be no time gap
         between the two segments. Note that the actual segment duration may vary and can be plus or 
-        minus one GOP size from the configured duration because a segment must start with an I-Frame.
+        minus one GOP size from the configured duration because a segment shall start with an I-Frame.
         Depending on resource constraints, the device may close the segment earlier than the
         configured <literal>SegmentDuration</literal> if the requested length cannot be
         achieved. This might happen, for example, if the device runs out of available memory to generate


### PR DESCRIPTION
This codifies the expectation that was said during the meetings. If a client configures 1 hour segments, a device might be forced to produce segments of a few minutes anyway depending on its resources.

Closes #589