### PR TITLE
Object storage recording (Annex B): Fix wording from must to shall in Segment section

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -1970,7 +1970,7 @@ SetRecordingJobMode(JobToken, Active)
         the open segment of this span and open a new segment for this span. When closing the open
         segment of a span and opening a new segment for this span, there shall be no time gap
         between the two segments. Note that the actual segment duration may vary and can be plus or 
-		minus one GOP size from the configured duration because a segment must start with an I-Frame.</para>
+		minus one GOP size from the configured duration because a segment shall start with an I-Frame.</para>
       <para>
         The device shall generate each segment as a fragmented MP4 file according to ISO/IEC 14496-12, the ISO base media file format.
         A segment shall contain recorded media for the time it was open.


### PR DESCRIPTION
This pull request makes a minor wording update in the documentation. The change clarifies the requirement for segment start frames.

* Documentation update: Changed the wording to specify that a segment "shall start with an I-Frame" instead of "must start with an I-Frame" in `doc/RecordingControl.xml`.

onvif/wg_profile_cloud#84
