### PR TITLE
Do not require dubble authorization

### DIFF
--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -395,12 +395,13 @@
         <title>register</title>
         <para> A signaling server shall expect this command to be sent once before any other command
           is sent over the WebSocket connection. The signaling server shall verify the validity of
-          the access token. Token details are outside of the scope of this specification.</para>
+          the access token either provided by the http connect request or as request parameter.
+          Token details are outside of the scope of this specification.</para>
         <variablelist role="op">
         <varlistentry>
           <term>request</term>
           <listitem>
-            <para role="param">authorization [string]</para>
+            <para role="param">authorization optional [string]</para>
             <para role="text">Access token that authorizes the device or client.</para>
             <para role="param">id optional [string]</para>
             <para role="text">The unique ID of the device or client.</para>


### PR DESCRIPTION
When the header passed authorization token was made mandatory the register authorization wasn't updated.

Thie PR suggest to not require to send the authorization token via http request and register command. Note that this change has a small impact on new DTT test cases.