### PR TITLE
Media Signing: Added requirement on SEI order

### DIFF
--- a/doc/MediaSigning.xml
+++ b/doc/MediaSigning.xml
@@ -293,6 +293,9 @@
               or complete GOP.</para>
             <para>This is necessary to secure the order of frames from tampering.</para>
           </listitem>
+          <listitem>
+            <para>The generated SEIs shall be added to the stream in sequence order.</para>
+          </listitem>
         </itemizedlist>
       </para>
     </section>
@@ -496,6 +499,9 @@
       <para>All, by this specification, generated SEI frames without a signature must be hashed and
         added to the list of NAL Unit hashes. Note that they have to be hashed in the same order as
         they appear in the stream.</para>
+      <para>The SEI frames shall be added in the exact order they are generated, regardless of their readiness.
+        For example, a SEI frame without a signature that is ready before the previous
+        signed SEI is, cannot be added until the signed SEI is completed.</para>
       <section>
         <title>Example</title>
         <para>The following example figures show how multiple short GOPs can be signed. The yellow
@@ -527,9 +533,9 @@
             </imageobject>
           </mediaobject>
         </figure>
-        <para>While the third SEI is being signed a SEI representing GOP 4 is generated and injected to the stream as shown in <xref linkend="smg04"/>.</para>
+        <para>While the third SEI is being signed, a SEI representing GOP 4 is generated and waiting to be injected to the stream as shown in <xref linkend="smg04"/>.</para>
         <figure xml:id="smg04">
-          <title>Injection of SEI representing GOP 4.</title>
+          <title>Pending injection of SEI representing GOP 4.</title>
           <mediaobject>
             <imageobject>
               <imagedata fileref="media/MediaSigning/SigningMultipleGops04.svg" contentwidth="150mm"/>
@@ -538,7 +544,7 @@
         </figure>
         <para>When the signature is ready it is added to the corresponding SEI and injected to the stream as shown in <xref linkend="smg05"/>.</para>
         <figure xml:id="smg05">
-          <title>Out of order injection of signed SEI.</title>
+          <title>In order injection of signed SEI.</title>
           <mediaobject>
             <imageobject>
               <imagedata fileref="media/MediaSigning/SigningMultipleGops05.svg" contentwidth="150mm"/>

--- a/doc/media/MediaSigning/SigningMultipleGops04.svg
+++ b/doc/media/MediaSigning/SigningMultipleGops04.svg
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:xhtml="http://www.w3.org/1999/xhtml"
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    width="1090.0972"
    height="231"
    viewBox="-0.5 -0.5 1090.0972 231"
    id="svg314"
    sodipodi:docname="SigningMultipleGops04.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   inkscape:version="1.4.2 (ebf0e94, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <metadata
      id="metadata318">
     <rdf:RDF>
@@ -24,7 +24,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,8 +37,8 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="2304"
-     inkscape:window-height="1377"
+     inkscape:window-width="3440"
+     inkscape:window-height="1371"
      id="namedview316"
      showgrid="false"
      fit-margin-top="0"
@@ -46,12 +46,15 @@
      fit-margin-right="0"
      fit-margin-bottom="0"
      inkscape:zoom="0.81179198"
-     inkscape:cx="919.38529"
-     inkscape:cy="185.89771"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
+     inkscape:cx="918.95463"
+     inkscape:cy="186.00824"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg314" />
+     inkscape:current-layer="svg314"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs2" />
   <rect
@@ -369,13 +372,6 @@
          x="425">S</text>
     </switch>
   </g>
-  <path
-     style="fill:#ffffff;stroke:#000000;stroke-miterlimit:10"
-     inkscape:connector-curvature="0"
-     id="path248"
-     pointer-events="all"
-     stroke-miterlimit="10"
-     d="M 413,84 V 70 h -8 l 10,-16 10,16 h -8 v 14 h -2 z" />
   <rect
      style="fill:#fff2cc;stroke:#d6b656"
      id="rect250"

--- a/doc/media/MediaSigning/SigningMultipleGops05.svg
+++ b/doc/media/MediaSigning/SigningMultipleGops05.svg
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:xhtml="http://www.w3.org/1999/xhtml"
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    width="1091.0966"
    height="231"
    viewBox="-0.5 -0.5 1091.0966 231"
    id="svg310"
    sodipodi:docname="SigningMultipleGops05.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   inkscape:version="1.4.2 (ebf0e94, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <metadata
      id="metadata314">
     <rdf:RDF>
@@ -24,7 +24,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,8 +37,8 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="2304"
-     inkscape:window-height="1377"
+     inkscape:window-width="3440"
+     inkscape:window-height="1371"
      id="namedview312"
      showgrid="false"
      fit-margin-top="0"
@@ -46,12 +46,15 @@
      fit-margin-right="0"
      fit-margin-bottom="0"
      inkscape:zoom="1.1480472"
-     inkscape:cx="885.30156"
-     inkscape:cy="133.21098"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
+     inkscape:cx="884.98104"
+     inkscape:cy="133.26978"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg310" />
+     inkscape:current-layer="svg310"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs2" />
   <rect
@@ -567,11 +570,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="0"
-     x="392" />
+     y="90"
+     x="400" />
   <g
      id="g290"
-     transform="translate(-10.5,-160.5)">
+     transform="translate(-2.5,-70.5)">
     <switch
        id="switch288">
       <foreignObject

--- a/doc/media/MediaSigning/SigningMultipleGops06.svg
+++ b/doc/media/MediaSigning/SigningMultipleGops06.svg
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:xhtml="http://www.w3.org/1999/xhtml"
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
-   width="1090.2255"
-   height="231"
-   viewBox="-0.5 -0.5 1090.2255 231"
+   width="1090.2253"
+   height="241"
+   viewBox="-0.5 -0.5 1090.2254 241"
    id="svg342"
    sodipodi:docname="SigningMultipleGops06.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   inkscape:version="1.4.2 (ebf0e94, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <metadata
      id="metadata346">
     <rdf:RDF>
@@ -24,7 +24,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,21 +36,24 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="2304"
-     inkscape:window-height="1377"
+     inkscape:window-width="3440"
+     inkscape:window-height="1371"
      id="namedview344"
      showgrid="false"
      fit-margin-top="0"
      fit-margin-left="0"
      fit-margin-right="0"
      fit-margin-bottom="0"
-     inkscape:zoom="1.1480472"
-     inkscape:cx="945.55495"
-     inkscape:cy="208.97863"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
+     inkscape:zoom="2.2960944"
+     inkscape:cx="459.47588"
+     inkscape:cy="148.94858"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg342" />
+     inkscape:current-layer="svg342"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs2" />
   <rect
@@ -62,11 +64,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="10"
-     x="0" />
+     y="20"
+     x="2.220446e-16" />
   <g
      id="g186"
-     transform="translate(-10.499908,-160.5)">
+     transform="translate(-10.499908,-150.5)">
     <switch
        id="switch184">
       <foreignObject
@@ -101,11 +103,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="10"
+     y="20"
      x="50.000061" />
   <g
      id="g194"
-     transform="translate(-10.499908,-160.5)">
+     transform="translate(-10.499908,-150.5)">
     <switch
        id="switch192">
       <foreignObject
@@ -140,11 +142,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="10"
+     y="20"
      x="100.00006" />
   <g
      id="g202"
-     transform="translate(-10.499908,-160.5)">
+     transform="translate(-10.499908,-150.5)">
     <switch
        id="switch200">
       <foreignObject
@@ -179,11 +181,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="10"
+     y="20"
      x="200.00006" />
   <g
      id="g210"
-     transform="translate(-10.499908,-160.5)">
+     transform="translate(-10.499908,-150.5)">
     <switch
        id="switch208">
       <foreignObject
@@ -218,11 +220,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="10"
+     y="20"
      x="150.00006" />
   <g
      id="g218"
-     transform="translate(-10.499908,-160.5)">
+     transform="translate(-10.499908,-150.5)">
     <switch
        id="switch216">
       <foreignObject
@@ -257,11 +259,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="0"
+     y="10"
      x="90.000061" />
   <g
      id="g226"
-     transform="translate(-10.499908,-160.5)">
+     transform="translate(-10.499908,-150.5)">
     <switch
        id="switch224">
       <foreignObject
@@ -294,14 +296,14 @@
      id="path228"
      pointer-events="stroke"
      stroke-miterlimit="10"
-     d="M 315.00005,50.000002 V 110 h 178.63" />
+     d="M 315.00005,60.000002 V 120 h 178.63" />
   <path
      style="fill:#000000;stroke:#000000;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path230"
      pointer-events="all"
      stroke-miterlimit="10"
-     d="m 498.88005,110 -7,3.5 1.75,-3.5 -1.75,-3.5 z" />
+     d="m 498.88005,120 -7,3.5 1.75,-3.5 -1.75,-3.5 z" />
   <rect
      style="fill:#eeeeee;stroke:#36393d"
      id="rect232"
@@ -310,11 +312,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="10"
+     y="20"
      x="300.00006" />
   <g
      id="g238"
-     transform="translate(-10.499908,-160.5)">
+     transform="translate(-10.499908,-150.5)">
     <switch
        id="switch236">
       <foreignObject
@@ -349,11 +351,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="10"
+     y="20"
      x="250.00006" />
   <g
      id="g246"
-     transform="translate(-10.499908,-160.5)">
+     transform="translate(-10.499908,-150.5)">
     <switch
        id="switch244">
       <foreignObject
@@ -386,11 +388,11 @@
      pointer-events="all"
      height="60"
      width="120"
-     y="170"
+     y="180"
      x="260.00006" />
   <g
      id="g254"
-     transform="translate(-10.499908,-160.5)">
+     transform="translate(-10.499908,-150.5)">
     <switch
        id="switch252">
       <foreignObject
@@ -425,11 +427,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="0"
+     y="10"
      x="190.00006" />
   <g
      id="g262"
-     transform="translate(-10.499908,-160.5)">
+     transform="translate(-10.499908,-150.5)">
     <switch
        id="switch260">
       <foreignObject
@@ -462,14 +464,14 @@
      id="path264"
      pointer-events="stroke"
      stroke-miterlimit="10"
-     d="M 415.00005,50.000002 V 110 h 78.63" />
+     d="M 415.00005,60.000002 V 120 h 78.63" />
   <path
      style="fill:#000000;stroke:#000000;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path266"
      pointer-events="all"
      stroke-miterlimit="10"
-     d="m 498.88005,110 -7,3.5 1.75,-3.5 -1.75,-3.5 z" />
+     d="m 498.88005,120 -7,3.5 1.75,-3.5 -1.75,-3.5 z" />
   <rect
      style="fill:#eeeeee;stroke:#36393d"
      id="rect268"
@@ -478,11 +480,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="10"
+     y="20"
      x="400.00006" />
   <g
      id="g274"
-     transform="translate(-10.499908,-160.5)">
+     transform="translate(-10.499908,-150.5)">
     <switch
        id="switch272">
       <foreignObject
@@ -517,11 +519,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="10"
+     y="20"
      x="350.00006" />
   <g
      id="g282"
-     transform="translate(-10.499908,-160.5)">
+     transform="translate(-10.499908,-150.5)">
     <switch
        id="switch280">
       <foreignObject
@@ -554,14 +556,14 @@
      id="path284"
      pointer-events="stroke"
      stroke-miterlimit="10"
-     d="M 465.00005,50.000002 V 110 h 28.63" />
+     d="M 465.00005,60.000002 V 120 h 28.63" />
   <path
      style="fill:#000000;stroke:#000000;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path286"
      pointer-events="all"
      stroke-miterlimit="10"
-     d="m 498.88005,110 -7,3.5 1.75,-3.5 -1.75,-3.5 z" />
+     d="m 498.88005,120 -7,3.5 1.75,-3.5 -1.75,-3.5 z" />
   <rect
      style="fill:#ffffff;stroke:#000000"
      id="rect288"
@@ -570,11 +572,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="10"
+     y="20"
      x="450.00006" />
   <g
      id="g294"
-     transform="translate(-10.499908,-160.5)">
+     transform="translate(-10.499908,-150.5)">
     <switch
        id="switch292">
       <foreignObject
@@ -602,19 +604,19 @@
     </switch>
   </g>
   <path
-     style="fill:none;stroke:#000000;stroke-miterlimit:10"
+     style="fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:10;stroke-dasharray:none"
      inkscape:connector-curvature="0"
      id="path296"
      pointer-events="stroke"
      stroke-miterlimit="10"
-     d="M 407.00005,40.000002 V 110 h 86.63" />
+     d="m 454.6874,49.917109 v 70.164611 h 38.88718" />
   <path
      style="fill:#000000;stroke:#000000;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path298"
      pointer-events="all"
      stroke-miterlimit="10"
-     d="m 498.88005,110 -7,3.5 1.75,-3.5 -1.75,-3.5 z" />
+     d="m 498.88005,120 -7,3.5 1.75,-3.5 -1.75,-3.5 z" />
   <rect
      style="fill:#fff2cc;stroke:#d6b656"
      id="rect300"
@@ -623,11 +625,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="0"
-     x="392.00006" />
+     y="10"
+     x="440.00006" />
   <g
      id="g306"
-     transform="translate(-10.499908,-160.5)">
+     transform="translate(37.500092,-150.5)">
     <switch
        id="switch304">
       <foreignObject
@@ -663,10 +665,10 @@
      height="40"
      width="30"
      y="0"
-     x="440.00006" />
+     x="430.00006" />
   <g
      id="g314"
-     transform="translate(-10.499908,-160.5)">
+     transform="translate(-20.499908,-160.5)">
     <switch
        id="switch312">
       <foreignObject
@@ -699,7 +701,7 @@
      id="path316"
      pointer-events="all"
      stroke-miterlimit="10"
-     d="m 513.00005,84.000002 v -14 h -8 l 10,-16 10,16 h -8 v 14 h -2 z" />
+     d="m 513.00005,94.000002 v -14 h -8 l 10,-16 10,16 h -8 v 14 h -2 z" />
   <rect
      style="fill:#fff2cc;stroke:#d6b656"
      id="rect318"
@@ -708,11 +710,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="90"
+     y="100"
      x="500.00006" />
   <g
      id="g324"
-     transform="translate(-10.499908,-160.5)">
+     transform="translate(-10.499908,-150.5)">
     <switch
        id="switch322">
       <foreignObject
@@ -747,11 +749,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="10"
+     y="20"
      x="500.00006" />
   <g
      id="g332"
-     transform="translate(-10.499908,-160.5)">
+     transform="translate(-10.499908,-150.5)">
     <switch
        id="switch330">
       <foreignObject
@@ -780,7 +782,7 @@
   </g>
   <switch
      id="switch340"
-     transform="translate(-9.9999084,-160)">
+     transform="translate(-9.9999084,-150)">
     <g
        requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
        id="g336" />
@@ -791,10 +793,10 @@
        id="a338" />
   </switch>
   <rect
-     style="opacity:1;vector-effect:none;fill:none;fill-opacity:0.86915888;stroke:#ffffff;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     style="opacity:1;vector-effect:none;fill:none;fill-opacity:0.869159;stroke:#ffffff;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect1153"
      width="58.422459"
      height="29.832747"
      x="1030.8021"
-     y="44.406418" />
+     y="54.406418" />
 </svg>

--- a/doc/media/MediaSigning/SigningMultipleGops07.svg
+++ b/doc/media/MediaSigning/SigningMultipleGops07.svg
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:xhtml="http://www.w3.org/1999/xhtml"
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    width="1090.7992"
-   height="127.01563"
-   viewBox="-0.5 -0.5 1090.7992 127.01563"
+   height="134.68431"
+   viewBox="-0.5 -0.5 1090.7992 134.68431"
    id="svg500"
    sodipodi:docname="SigningMultipleGops07.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   inkscape:version="1.4.2 (ebf0e94, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <metadata
      id="metadata504">
     <rdf:RDF>
@@ -24,7 +24,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,8 +36,8 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="2304"
-     inkscape:window-height="1377"
+     inkscape:window-width="3440"
+     inkscape:window-height="1371"
      id="namedview502"
      showgrid="false"
      fit-margin-top="0"
@@ -46,12 +45,15 @@
      fit-margin-right="0"
      fit-margin-bottom="0"
      inkscape:zoom="3.2471679"
-     inkscape:cx="993.20038"
-     inkscape:cy="29.422583"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
+     inkscape:cx="341.83634"
+     inkscape:cy="43.422454"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg500" />
+     inkscape:current-layer="svg500"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs2" />
   <path
@@ -60,14 +62,14 @@
      id="path180"
      pointer-events="stroke"
      stroke-miterlimit="10"
-     d="m 15,70 q 0,50 95,50 95,0 95,-53.63" />
+     d="m 15,77.668686 q 0,50.000004 95,50.000004 95,0 95,-53.630004" />
   <path
      style="fill:#000000;stroke:#000000;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path182"
      pointer-events="all"
      stroke-miterlimit="10"
-     d="m 205,61.12 3.5,7 -3.5,-1.75 -3.5,1.75 z" />
+     d="m 205,68.788686 3.5,7 -3.5,-1.75 -3.5,1.75 z" />
   <rect
      style="fill:#eeeeee;stroke:#36393d"
      id="rect184"
@@ -76,11 +78,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
-     x="0" />
+     y="37.668686"
+     x="2.220446e-16" />
   <g
      id="g190"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch188">
       <foreignObject
@@ -115,11 +117,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
+     y="37.668686"
      x="50" />
   <g
      id="g198"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch196">
       <foreignObject
@@ -152,14 +154,14 @@
      id="path200"
      pointer-events="stroke"
      stroke-miterlimit="10"
-     d="m 115,70 q 0,20 45,20 45,0 45,-23.63" />
+     d="m 115,77.668686 q 0,20 45,20 45,0 45,-23.63" />
   <path
      style="fill:#000000;stroke:#000000;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path202"
      pointer-events="all"
      stroke-miterlimit="10"
-     d="m 205,61.12 3.5,7 -3.5,-1.75 -3.5,1.75 z" />
+     d="m 205,68.788686 3.5,7 -3.5,-1.75 -3.5,1.75 z" />
   <rect
      style="fill:#eeeeee;stroke:#36393d"
      id="rect204"
@@ -168,11 +170,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
+     y="37.668686"
      x="100" />
   <g
      id="g210"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch208">
       <foreignObject
@@ -207,11 +209,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
+     y="37.668686"
      x="200" />
   <g
      id="g218"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch216">
       <foreignObject
@@ -244,14 +246,14 @@
      id="path220"
      pointer-events="stroke"
      stroke-miterlimit="10"
-     d="m 165,70 q 0,20 20,20 20,0 20,-23.63" />
+     d="m 165,77.668686 q 0,20 20,20 20,0 20,-23.63" />
   <path
      style="fill:#000000;stroke:#000000;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path222"
      pointer-events="all"
      stroke-miterlimit="10"
-     d="m 205,61.12 3.5,7 -3.5,-1.75 -3.5,1.75 z" />
+     d="m 205,68.788686 3.5,7 -3.5,-1.75 -3.5,1.75 z" />
   <rect
      style="fill:#ffffff;stroke:#000000"
      id="rect224"
@@ -260,11 +262,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
+     y="37.668686"
      x="150" />
   <g
      id="g230"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch228">
       <foreignObject
@@ -297,14 +299,14 @@
      id="path232"
      pointer-events="stroke"
      stroke-miterlimit="10"
-     d="m 112.5,20 q 0,-20 42.5,-20 42.5,0 42.5,13.63" />
+     d="m 112.5,27.668686 q 0,-20.0000005 42.5,-20.0000005 42.5,0 42.5,13.6300005" />
   <path
      style="fill:#000000;stroke:#000000;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path234"
      pointer-events="all"
      stroke-miterlimit="10"
-     d="m 197.5,18.88 -3.5,-7 3.5,1.75 3.5,-1.75 z" />
+     d="m 197.5,26.548686 -3.5,-7 3.5,1.75 3.5,-1.75 z" />
   <rect
      style="fill:#fff2cc;stroke:#d6b656"
      id="rect236"
@@ -313,11 +315,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="20"
+     y="27.668686"
      x="90" />
   <g
      id="g242"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch240">
       <foreignObject
@@ -352,11 +354,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
+     y="37.668686"
      x="300" />
   <g
      id="g250"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch248">
       <foreignObject
@@ -391,11 +393,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
+     y="37.668686"
      x="250" />
   <g
      id="g258"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch256">
       <foreignObject
@@ -423,19 +425,19 @@
     </switch>
   </g>
   <path
-     style="fill:none;stroke:#000000;stroke-miterlimit:10"
+     style="fill:none;stroke:#000000;stroke-width:1.17558;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path260"
      pointer-events="stroke"
      stroke-miterlimit="10"
-     d="M 212.5,20 Q 212.5,0 330,0 447.5,0 447.5,13.63" />
+     d="m 212.562,27.741918 q 0,-27.65412799 117.438,-27.65412799 117.438,0 117.438,18.84628799" />
   <path
      style="fill:#000000;stroke:#000000;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path262"
      pointer-events="all"
      stroke-miterlimit="10"
-     d="m 447.5,18.88 -3.5,-7 3.5,1.75 3.5,-1.75 z" />
+     d="m 447.5,22.548686 -3.5,-7 3.5,1.75 3.5,-1.75 z" />
   <rect
      style="fill:#fff2cc;stroke:#d6b656"
      id="rect264"
@@ -444,11 +446,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="20"
+     y="27.668686"
      x="190" />
   <g
      id="g270"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch268">
       <foreignObject
@@ -483,11 +485,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
+     y="37.668686"
      x="400" />
   <g
      id="g278"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch276">
       <foreignObject
@@ -522,11 +524,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
+     y="37.668686"
      x="350" />
   <g
      id="g286"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch284">
       <foreignObject
@@ -561,11 +563,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
+     y="37.668686"
      x="450" />
   <g
      id="g294"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch292">
       <foreignObject
@@ -593,19 +595,19 @@
     </switch>
   </g>
   <path
-     style="fill:none;stroke:#000000;stroke-miterlimit:10"
+     style="fill:none;stroke:#000000;stroke-width:0.686852;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path296"
      pointer-events="stroke"
      stroke-miterlimit="10"
-     d="m 414.5,60 q 0,20 41.5,20 41.5,0 41.5,-13.63" />
+     d="m 458.96546,67.554016 q 0,20.223746 19.36169,20.223746 19.36169,0 19.36169,-13.782483" />
   <path
      style="fill:#000000;stroke:#000000;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path298"
      pointer-events="all"
      stroke-miterlimit="10"
-     d="m 497.5,61.12 3.5,7 -3.5,-1.75 -3.5,1.75 z" />
+     d="m 497.5,68.788686 3.5,7 -3.5,-1.75 -3.5,1.75 z" />
   <rect
      style="fill:#fff2cc;stroke:#d6b656"
      id="rect300"
@@ -614,11 +616,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="20"
-     x="392" />
+     y="27.668686"
+     x="444" />
   <g
      id="g306"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(41.5,-132.83131)">
     <switch
        id="switch304">
       <foreignObject
@@ -653,11 +655,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="20"
-     x="440" />
+     y="23.668686"
+     x="436" />
   <g
      id="g314"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-14.5,-136.83131)">
     <switch
        id="switch312">
       <foreignObject
@@ -692,11 +694,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
+     y="37.668686"
      x="500" />
   <g
      id="g322"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch320">
       <foreignObject
@@ -731,11 +733,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
+     y="37.668686"
      x="600" />
   <g
      id="g330"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch328">
       <foreignObject
@@ -770,11 +772,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
+     y="37.668686"
      x="1050" />
   <g
      id="g338"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch336">
       <foreignObject
@@ -809,11 +811,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
+     y="37.668686"
      x="950" />
   <g
      id="g346"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch344">
       <foreignObject
@@ -848,11 +850,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
+     y="37.668686"
      x="850" />
   <g
      id="g354"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch352">
       <foreignObject
@@ -887,11 +889,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
+     y="37.668686"
      x="750" />
   <g
      id="g362"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch360">
       <foreignObject
@@ -926,11 +928,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
+     y="37.668686"
      x="650" />
   <g
      id="g370"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch368">
       <foreignObject
@@ -965,11 +967,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
+     y="37.668686"
      x="550" />
   <g
      id="g378"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch376">
       <foreignObject
@@ -1004,11 +1006,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
+     y="37.668686"
      x="1000" />
   <g
      id="g386"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch384">
       <foreignObject
@@ -1043,11 +1045,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
+     y="37.668686"
      x="900" />
   <g
      id="g394"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch392">
       <foreignObject
@@ -1082,11 +1084,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
+     y="37.668686"
      x="800" />
   <g
      id="g402"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch400">
       <foreignObject
@@ -1121,11 +1123,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="30"
+     y="37.668686"
      x="700" />
   <g
      id="g410"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch408">
       <foreignObject
@@ -1153,19 +1155,19 @@
     </switch>
   </g>
   <path
-     style="fill:none;stroke:#000000;stroke-miterlimit:10"
+     style="fill:none;stroke:#000000;stroke-width:1.1825;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path412"
      pointer-events="stroke"
      stroke-miterlimit="10"
-     d="m 512.5,60 q 0,20 117.5,20 117.5,0 117.5,-13.63" />
+     d="m 512.55891,61.731925 q 0,28.889694 113.74556,28.889694 113.74556,0 113.74556,-19.688326" />
   <path
-     style="fill:#000000;stroke:#000000;stroke-miterlimit:10"
+     style="fill:#000000;stroke:#000000;stroke-width:0.930166;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path414"
      pointer-events="all"
      stroke-miterlimit="10"
-     d="m 747.5,61.12 3.5,7 -3.5,-1.75 -3.5,1.75 z" />
+     d="m 740.11592,64.71061 2.96216,7.156152 -2.96216,-1.789038 -2.96215,1.789038 z" />
   <rect
      style="fill:#fff2cc;stroke:#d6b656"
      id="rect416"
@@ -1174,11 +1176,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="20"
+     y="27.668686"
      x="490" />
   <g
      id="g422"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch420">
       <foreignObject
@@ -1213,11 +1215,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="20"
-     x="990" />
+     y="27.668686"
+     x="1044" />
   <g
      id="g430"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(43.5,-132.83131)">
     <switch
        id="switch428">
       <foreignObject
@@ -1245,19 +1247,19 @@
     </switch>
   </g>
   <path
-     style="fill:none;stroke:#000000;stroke-miterlimit:10"
+     style="fill:none;stroke:#000000;stroke-width:1.1426;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path432"
      pointer-events="stroke"
      stroke-miterlimit="10"
-     d="M 812.5,20 Q 812.5,0 930,0 1047.5,0 1047.5,13.63" />
+     d="m 812.55035,27.726489 q 0,-26.1217754 117.44965,-26.1217754 117.4496,0 117.4496,17.8019904" />
   <path
      style="fill:#000000;stroke:#000000;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path434"
      pointer-events="all"
      stroke-miterlimit="10"
-     d="m 1047.5,18.88 -3.5,-7 3.5,1.75 3.5,-1.75 z" />
+     d="m 1047.5,22.548686 -3.5,-7 3.5,1.75 3.5,-1.75 z" />
   <rect
      style="fill:#fff2cc;stroke:#d6b656"
      id="rect436"
@@ -1266,11 +1268,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="20"
+     y="27.668686"
      x="790" />
   <g
      id="g442"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-10.5,-132.83131)">
     <switch
        id="switch440">
       <foreignObject
@@ -1298,19 +1300,19 @@
     </switch>
   </g>
   <path
-     style="fill:none;stroke:#000000;stroke-miterlimit:10"
+     style="fill:none;stroke:#000000;stroke-width:0.59269;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path444"
      pointer-events="stroke"
      stroke-miterlimit="10"
-     d="m 712.5,20 q 0,-20 42.5,-20 42.5,0 42.5,13.63" />
+     d="m 768.3091,27.817837 q 0,-20.2910264 14.71532,-20.2910264 14.71533,0 14.71533,13.8283344" />
   <path
      style="fill:#000000;stroke:#000000;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path446"
      pointer-events="all"
      stroke-miterlimit="10"
-     d="m 797.5,18.88 -3.5,-7 3.5,1.75 3.5,-1.75 z" />
+     d="m 797.5,26.548686 -3.5,-7 3.5,1.75 3.5,-1.75 z" />
   <rect
      style="fill:#fff2cc;stroke:#d6b656"
      id="rect448"
@@ -1319,11 +1321,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="20"
-     x="690" />
+     y="27.668686"
+     x="744" />
   <g
      id="g454"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(45.5,-132.83131)">
     <switch
        id="switch452">
       <foreignObject
@@ -1358,11 +1360,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="20"
-     x="1040" />
+     y="23.668686"
+     x="1036" />
   <g
      id="g462"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-14.5,-136.83131)">
     <switch
        id="switch460">
       <foreignObject
@@ -1397,11 +1399,11 @@
      rx="4.5"
      height="40"
      width="30"
-     y="20"
-     x="740" />
+     y="23.668686"
+     x="736" />
   <g
      id="g470"
-     transform="translate(-10.5,-140.5)">
+     transform="translate(-14.5,-136.83131)">
     <switch
        id="switch468">
       <foreignObject
@@ -1434,73 +1436,73 @@
      id="path472"
      pointer-events="stroke"
      stroke-miterlimit="10"
-     d="m 65,70 q 0,20 20,20 20,0 20,-23.63" />
+     d="m 65,77.668686 q 0,20 20,20 20,0 20,-23.63" />
   <path
      style="fill:#000000;stroke:#000000;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path474"
      pointer-events="all"
      stroke-miterlimit="10"
-     d="m 105,61.12 3.5,7 -3.5,-1.75 -3.5,1.75 z" />
+     d="m 105,68.788686 3.5,7 -3.5,-1.75 -3.5,1.75 z" />
   <path
      style="fill:none;stroke:#000000;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path476"
      pointer-events="stroke"
      stroke-miterlimit="10"
-     d="m 15,70 q 0,20 45,20 45,0 45,-23.63" />
+     d="m 15,77.668686 q 0,20 45,20 45,0 45,-23.63" />
   <path
      style="fill:#000000;stroke:#000000;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path478"
      pointer-events="all"
      stroke-miterlimit="10"
-     d="m 105,61.12 3.5,7 -3.5,-1.75 -3.5,1.75 z" />
+     d="m 105,68.788686 3.5,7 -3.5,-1.75 -3.5,1.75 z" />
   <path
-     style="fill:none;stroke:#000000;stroke-miterlimit:10;stroke-dasharray:3, 3"
+     style="fill:none;stroke:#000000;stroke-width:1.02448;stroke-miterlimit:10;stroke-dasharray:3.07344, 3.07344"
      inkscape:connector-curvature="0"
      id="path480"
      pointer-events="stroke"
      stroke-miterlimit="10"
-     d="m 115,70 q 0,50 170,50 170,0 170,-53.63" />
+     d="m 115.0068,74.496621 q 0,53.154239 167.83748,53.154239 167.83747,0 167.83747,-57.013237" />
   <path
      style="fill:#000000;stroke:#000000;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path482"
      pointer-events="all"
      stroke-miterlimit="10"
-     d="m 455,61.12 3.5,7 -3.5,-1.75 -3.5,1.75 z" />
+     d="m 451,64.788686 3.5,7 -3.5,-1.75 -3.5,1.75 z" />
   <path
-     style="fill:none;stroke:#000000;stroke-miterlimit:10"
+     style="fill:none;stroke:#000000;stroke-width:1.05763;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path484"
      pointer-events="stroke"
      stroke-miterlimit="10"
-     d="m 265,70 q 0,20 95,20 95,0 95,-23.63" />
+     d="m 265.01727,74.77015 q 0,22.857461 92.98099,22.857461 92.98098,0 92.98098,-27.00609" />
   <path
      style="fill:#000000;stroke:#000000;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path486"
      pointer-events="all"
      stroke-miterlimit="10"
-     d="m 455,61.12 3.5,7 -3.5,-1.75 -3.5,1.75 z" />
+     d="m 451,64.788686 3.5,7 -3.5,-1.75 -3.5,1.75 z" />
   <path
-     style="fill:none;stroke:#000000;stroke-miterlimit:10"
+     style="fill:none;stroke:#000000;stroke-width:1.05998;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path488"
      pointer-events="stroke"
      stroke-miterlimit="10"
-     d="m 215,70 q 0,20 120,20 120,0 120,-23.63" />
+     d="m 215.01874,74.770645 q 0,22.856097 117.97952,22.856097 117.97951,0 117.97951,-27.004479" />
   <path
      style="fill:#000000;stroke:#000000;stroke-miterlimit:10"
      inkscape:connector-curvature="0"
      id="path490"
      pointer-events="all"
      stroke-miterlimit="10"
-     d="m 455,61.12 3.5,7 -3.5,-1.75 -3.5,1.75 z" />
+     d="m 451,64.788686 3.5,7 -3.5,-1.75 -3.5,1.75 z" />
   <switch
      id="switch498"
-     transform="translate(-10,-140)">
+     transform="translate(-10,-132.33131)">
     <g
        requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
        id="g494" />
@@ -1511,10 +1513,10 @@
        id="a496" />
   </switch>
   <rect
-     style="opacity:1;vector-effect:none;fill:none;fill-opacity:0.86915888;stroke:#ffffff;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     style="opacity:1;vector-effect:none;fill:none;fill-opacity:0.869159;stroke:#ffffff;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect1153"
      width="58.422459"
      height="29.832747"
      x="1031.376"
-     y="96.182098" />
+     y="103.85078" />
 </svg>


### PR DESCRIPTION
To make life easier for the client/validation side, the SEIs added to the stream by the device must be added in order. This is already what the open-source code does.

This affects updating four images of "Signing Multiple GOPs".