### PR TITLE
Add clarification that curve names are defined by IANA

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -4019,7 +4019,7 @@
                   <para>EllipticCurves</para>
                 </entry>
                 <entry>
-                  <para>Indicates which elliptic curves are supported by the device.</para>
+                  <para>Indicates which elliptic curves are supported by the device. Supported curve names can be found in the IANA TLS Supported Groups section.</para>
                 </entry>
               </row>
               <row>

--- a/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
+++ b/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
@@ -749,7 +749,7 @@
 				</xs:attribute>
 				<xs:attribute name="EllipticCurves" type="tas:EllipticCurves">
 					<xs:annotation>
-						<xs:documentation>Indicates which elliptic curves are supported by the device.</xs:documentation>
+						<xs:documentation>Indicates which elliptic curves are supported by the device. Supported curve names can be found in the IANA TLS Supported Groups section.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:attribute name="PKCS10ExternalCertificationWithRSA" type="xs:boolean">


### PR DESCRIPTION
Add clarification about elliptic curve names are defined by IANA registry.

Closes #648