### PR TITLE
Clarify credentials shall not be returned in responses

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -6353,7 +6353,11 @@ onvif://www.onvif.org/name/ARV-453
       </section>
       <section>
         <title>GetStorageConfiguration</title>
-        <para>This operation retrieves the Storage configuration when the storage configuration token is known. A device indicating storage configuration capability shall support retrieval of specific storage configuration through the GetStorageConfiguration command.</para>
+        <para>This operation retrieves the Storage configuration when the storage configuration
+          token is known. A device indicating storage configuration capability shall support
+          retrieval of specific storage configuration through the GetStorageConfiguration command.
+          Furthermore a device shall not return the credentials (password or access token) in the
+          reply.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -2162,7 +2162,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					</xs:element>
 					<xs:element name="Password" type="xs:string" minOccurs="0">
 						<xs:annotation>	
-							<xs:documentation> optional password</xs:documentation> 
+							<xs:documentation> optional password, device shall not return the credentials (password) in the reply. </xs:documentation> 
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="Extension" minOccurs="0">	<!-- deprecated -->
@@ -2174,7 +2174,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					</xs:element>
 					<xs:element name="Token" type="xs:string" minOccurs="0">
 						<xs:annotation>
-							<xs:documentation> optional access token</xs:documentation>
+							<xs:documentation> optional access token, device shall not return the credentials (token) in the reply. </xs:documentation>
 						</xs:annotation>
 					</xs:element>					
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->


### PR DESCRIPTION
Address feedback from https://github.com/onvif/wg_profile_cloud/issues/91

- Clarified password or token shall not be returned in response in devicemgmt.wsdl
- Updated the requirement in GetStorageConfiguration interface in Core spec.