### PR TITLE
Fix data type description text

### DIFF
--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -9161,7 +9161,7 @@ and sample rate. </xs:documentation>
 	<!--=========================================-->
 
 	<!--=========================================-->
-	<!--  Begin, StorageConfiguration            -->
+	<!--  Begin, ExportRecordedDataState         -->
 	<!--=========================================-->
 	<xs:complexType name="FileProgress">
     	<xs:sequence>
@@ -9221,7 +9221,7 @@ and sample rate. </xs:documentation>
 		<xs:anyAttribute processContents="lax"/>
 	</xs:complexType>
 	<!--=========================================-->
-	<!--  End, StorageConfiguration              -->
+	<!--  End, ExportRecordedDataState           -->
 	<!--=========================================-->
 	
 <xs:element name="PolygonOptions" type="tt:PolygonOptions"/>


### PR DESCRIPTION
**StorageConfiguration** type used as description instead of ExportRecordedDataState
- Fixed the discrepancy.