### PR TITLE
Remove EncodingInterval (deprecated for Media2 schema) from Media2 spec

### DIFF
--- a/doc/Media2.xml
+++ b/doc/Media2.xml
@@ -1018,7 +1018,8 @@
             <para>Quality – Determines the quality of the video. A high value within supported quality range means higher quality.</para>
           </listitem>
           <listitem>
-            <para>RateControl –  Defines parameters to configure the bitrate [kbps] as well as an EncodingInterval parameter (Interval at which images are encoded and transmitted) and a TargetFrameRate [fps] parameter to configure the output framerate.</para>
+            <para>RateControl – Defines parameters to configure the bitrate [kbps] and a
+              TargetFrameRate [fps] parameter to configure the output framerate.</para>
           </listitem>
           <listitem>
             <para>Encoding profile and GOV length [frame].</para>


### PR DESCRIPTION
Remove **EncodingInterval** description from Media2 spec in describing Rate control structure, as there is no reference to that element in schema

Ref: https://www.[onvif.org/ver10/schema/onvif.xsd](https://www.onvif.org/ver10/schema/onvif.xsd)

```xml
	<!--===============================-->
	<xs:complexType name="VideoRateControl2">
		<xs:sequence>
			<xs:element name="FrameRateLimit" type="xs:float">
				<xs:annotation>
					<xs:documentation>Desired frame rate in fps. The actual rate may be lower due to e.g. performance limitations.</xs:documentation>
				</xs:annotation>
			</xs:element>
			<xs:element name="BitrateLimit" type="xs:int">
				<xs:annotation>
					<xs:documentation>the maximum output bitrate in kbps</xs:documentation>
				</xs:annotation>
			</xs:element>
			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
		</xs:sequence>
		<xs:attribute name="ConstantBitRate" type="xs:boolean">
			<xs:annotation>
				<xs:documentation>Enforce constant bitrate.</xs:documentation>
			</xs:annotation>
		</xs:attribute>
		<xs:anyAttribute processContents="lax"/>
	</xs:complexType>
	<!--===============================-->
```