### PR TITLE
webrtc docbook validation error

### DIFF
--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -300,7 +300,6 @@
         </imageobject>
       </mediaobject>
     </figure>
-    <xref linkend="_Ref493258797"/> shows an overview of the messages being sent between client, signaling server and device.
     <para><xref linkend="_Ref493258797"/> shows an overview of the messages being sent between client, signaling server and device.</para>
     <section>
       <title>WebSocket Connection Management</title>
@@ -874,5 +873,6 @@ Server -> Client: { "error": {"code": 1001, "message": "Insufficient resources"}
     <para/>
   </appendix>
 </book>
+
 
 


### PR DESCRIPTION
- Duplicate XREF
- XREF not wrapped inside a para resulting in docbook validation error.