### PR TITLE
clarify data removal event not applicable for external storage targets

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -1759,7 +1759,7 @@ Change Request 2061, 2063, 2065, 2109</revremark>
   </tt:Data> 
 </tt:MessageDescription>
 ]]></programlisting>
-        <para>This event is not applicable for data removal from external storage targets for e.g. Object Storage S3.</para>
+        <para>This event is not applicable for data removal from object storage targets for e.g. Object Storage S3.</para>
       </section>
       <section>
         <title>Recording and track creation and deletion</title>


### PR DESCRIPTION
Ref: https://www.onvif.org/specs/srv/rec/ONVIF-RecordingControl-Service-Spec.pdf
- Section 5.26.3 Data deletion
Whenever data is deleted, a device shall provide the following event:
Topic: tns1:RecordingConfig/DeleteTrackData
```xml
<tt:MessageDescription IsProperty="false">
 <tt:Source>
 <tt:SimpleItemDescription Name="RecordingToken" Type="tt:RecordingReference"/>
 <tt:SimpleItemDescription Name="TrackToken" Type="tt:TrackReference"/>
 </tt:Source>
 <tt:Data>
 <tt:SimpleItemDescription Name="StartTime" Type="xsDateTime"/>
 <tt:SimpleItemDescription Name="EndTime" Type="xsDateTime"/>
 </tt:Data>
</tt:MessageDescription>
```

this event is not relevant for data stored in external targets hence added a clarification to the spec
- This event is not applicable for data removal from external storage targets for e.g. Object Storage S3

We added similar clarifications to interfaces like DeleteRecording and DeleteTrack and this seems to have missed to be included in https://github.com/onvif/specs/pull/478/files