### PR TITLE
Fix DataSize field length in Asymmetric key system to fix Mp4 spec

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -2210,7 +2210,7 @@ aligned(8) class AsymmetricKeySystemHeaderBox extends FullBox('pssh', version=1,
   unsigned int(8)[16] SystemID;
   unsigned int(32) KID_count = 1;
   unsigned int(8)[16] KID;
-  unsigned int(8) DataSize;
+  unsigned int(32) DataSize;
   unsigned int(32) EncryptedKeyEntryCount;
   for (i=1; i <= EncryptedKeyEntryCount; i++) {
     unsigned int(32) CertificateThumbprintSize;


### PR DESCRIPTION
Prototypes were already using 32 bits there, it was actually a typo when uniformizing lengths. This field is actually covered by ISO 23001-7, and is defined at 32 bits, so this is simply not valid that we were reducing it.