### PR TITLE
Add metadata aspect ratio transformation

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -660,32 +660,26 @@
         <section>
           <title>Aspect Ratio Dependant Transformation</title>
           <para>This section describes the transformation specific to a scene aspect ratio.</para>
-          <para>Same as the transformation node, this node is used to apply geometric transformations to the scene elements. It allows for the adjustment of position, scale, and aspect ratio of the objects within the scene.</para>
-          <para>However, when the device offers more than one aspect ratio, this node lets the client choose which transformation to apply to match the metadata aspect ratio to the rendered aspect ratio</para>
+          <para>Same as the transformation node, this node is used to apply initial geometric transformations to the scene elements. It allows for the adjustment of the position, scale, and aspect ratio of the objects within the scene.</para>
+          <para>However, when the device supports more than one aspect ratio, this node allows the client to choose which transformation to apply, matching the metadata aspect ratio to the rendered aspect ratio.</para>
           <para>The aspect ratio transformation node can contain the following elements:</para>
           <programlisting><![CDATA[<xs:complexType name="AspectRatioTransformation">
   <xs:sequence>
-    <xs:element name="AspectRatio" type="string" minOccurs="0"/>
-    <xs:element name="Transformation" type="tt:Transformation" minOccurs="0"/>
+    <xs:element name="Translate" type="Vector" minOccurs="0"/>
+    <xs:element name="Scale" type="Vector" minOccurs="0"/>
     ...
   </xs:sequence>
 </xs:complexType>
 ]]></programlisting>
-          <para>For example, the coordinates of the scene description are given in a frame coordinate system, where the lower-left corner has coordinates (0,0) and the upper-right corner coordinates (320,240). The video source aspect is 4:3. The frame node resembles the following code where the scale is set to crop image to other supported aspect ratios:</para>
+          <para>For example, the coordinates of the scene description are given in a frame coordinate system, where the lower-left corner has coordinates (0,0) and the upper-right corner coordinates (320,240). The video source aspect is 4:3. The frame node resembles the following code, where the scale is set to crop the image to other supported aspect ratios:</para>
           <programlisting><![CDATA[<tt:Frame UtcTime="2008-10-10T12:24:57.321">
-  <tt:AspectRatioTransformation>
-    <tt:AspectRatio>15:9</tt:AspectRatio>
-    <tt:Transformation>
-      <tt:Translate x="0" y="0"/>
-      <tt:Scale x="1" y="1.25"/>
-    </tt:Transformation>
+  <tt:AspectRatioTransformation ratio="1.66666667">
+	<tt:Translate x="0" y="0"/>
+	<tt:Scale x="1" y="1.25"/>
   </tt:AspectRatioTransformation>
-    <tt:AspectRatioTransformation>
-    <tt:AspectRatio>16:9</tt:AspectRatio>
-    <tt:Transformation>
-      <tt:Translate x="0" y="0"/>
-      <tt:Scale x="1" y="1.33333333"/>
-    </tt:Transformation>
+  <tt:AspectRatioTransformation ratio="1.77777778>
+    <tt:Translate x="0" y="0"/>
+    <tt:Scale x="1" y="1.33333333"/>
   </tt:AspectRatioTransformation>
   ...
 </tt:Frame>

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -661,7 +661,7 @@
         <section>
           <title>Aspect Ratio Dependant Transformation</title>
           <para>This section describes the transformation specific to a scene aspect ratio.</para>
-          <para>Same as the transformation node, this node is used to apply initial geometric transformations to the scene elements. However, when the device supports more than one aspect ratio, this node allows the client to choose which transformation to apply, matching the metadata aspect ratio to the rendered aspect ratio.</para>
+          <para>Same as the transformation node, this node is used to apply final geometric transformations to the scene elements when the device supports more than one aspect ratio. This node allows the client to choose which transformation to apply, matching the metadata aspect ratio to the rendered aspect ratio.</para>
           <para>The aspect ratio transformation node can contain the following elements:</para>
           <programlisting><![CDATA[<xs:complexType name="AspectRatioTransformation">
   <xs:sequence>

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -671,19 +671,18 @@
   </xs:sequence>
 </xs:complexType>
 ]]></programlisting>
-          <para>For example, the coordinates of the scene description are given in a frame coordinate system, where the lower-left corner has coordinates (0,0) and the upper-right corner coordinates (320,240). The video source aspect is 4:3. The frame node resembles the following code, where the scale is set to crop the image to other supported aspect ratios:</para>
+          <para>For example, the coordinates of the scene description are given in a frame coordinate system, where the lower-left corner has coordinates (0,0) and the upper-right corner coordinates (320,240). The video source aspect ratio is 4:3. The frame node resembles the following code, where the scale is set to crop the image to other supported aspect ratios:</para>
           <programlisting><![CDATA[<tt:Frame UtcTime="2008-10-10T12:24:57.321">
   <tt:AspectRatioTransformation ratio="1.66666667">
-    <tt:Translate x="0" y="0"/>
     <tt:Scale x="1" y="1.25"/>
   </tt:AspectRatioTransformation>
   <tt:AspectRatioTransformation ratio="1.77777778>
-    <tt:Translate x="0" y="0"/>
     <tt:Scale x="1" y="1.33333333"/>
   </tt:AspectRatioTransformation>
   ...
 </tt:Frame>
 ]]></programlisting>
+      <para>In every Frame, the device must add the nodes for at least the currently configured aspect ratios. The node for the video source aspect ratio should be omitted.</para>
       </section>
       <section>
         <title>Scene Elements</title>

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -657,6 +657,7 @@
 </tt:Frame>
 ]]></programlisting>
         </section>
+        </section>
         <section>
           <title>Aspect Ratio Dependant Transformation</title>
           <para>This section describes the transformation specific to a scene aspect ratio.</para>

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -657,6 +657,43 @@
 </tt:Frame>
 ]]></programlisting>
         </section>
+        <section>
+          <title>Aspect Ratio Dependant Transformation</title>
+          <para>This section describes the transformation specific to a scene aspect ratio.</para>
+          <para>Same as the transformation node, this node is used to apply geometric transformations to the scene elements. It allows for the adjustment of position, scale, and aspect ratio of the objects within the scene.</para>
+          <para>However, when the device offers more than one aspect ratio, this node lets the client choose which transformation to apply to match the metadata aspect ratio to the rendered aspect ratio</para>
+          <para>The aspect ratio transformation node can contain the following elements:</para>
+          <programlisting><![CDATA[<xs:complexType name="AspectRatioTransformation">
+  <xs:sequence>
+    <xs:element name="AspectRatio" type="string" minOccurs="0"/>
+    <xs:element name="Transformation" type="tt:Transformation" minOccurs="0"/>
+    ...
+  </xs:sequence>
+</xs:complexType>
+]]></programlisting>
+          <para>For example, the coordinates of the scene description are given in a frame coordinate system, where the lower-left corner has coordinates (0,0) and the upper-right corner coordinates (320,240). The video source aspect is 4:3. The frame node resembles the following code where the scale is set to crop image to other supported aspect ratios:</para>
+          <programlisting><![CDATA[<tt:Frame UtcTime="2008-10-10T12:24:57.321">
+  <tt:AspectRatioTransformation>
+    <tt:AspectRatio>15:9</tt:AspectRatio>
+    <tt:Transformation>
+      <tt:Translate x="0" y="0"/>
+      <tt:Scale x="1" y="1.25"/>
+    </tt:Transformation>
+  </tt:AspectRatioTransformation>
+    <tt:AspectRatioTransformation>
+    <tt:AspectRatio>16:9</tt:AspectRatio>
+    <tt:Transformation>
+      <tt:Translate x="0" y="0"/>
+      <tt:Scale x="1" y="1.33333333"/>
+    </tt:Transformation>
+  </tt:AspectRatioTransformation>
+  ...
+</tt:Frame>
+]]></programlisting>
+
+</tt:Frame>
+]]></programlisting>
+        </section>
       </section>
       <section>
         <title>Scene Elements</title>

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -674,8 +674,8 @@
           <para>For example, the coordinates of the scene description are given in a frame coordinate system, where the lower-left corner has coordinates (0,0) and the upper-right corner coordinates (320,240). The video source aspect is 4:3. The frame node resembles the following code, where the scale is set to crop the image to other supported aspect ratios:</para>
           <programlisting><![CDATA[<tt:Frame UtcTime="2008-10-10T12:24:57.321">
   <tt:AspectRatioTransformation ratio="1.66666667">
-	<tt:Translate x="0" y="0"/>
-	<tt:Scale x="1" y="1.25"/>
+    <tt:Translate x="0" y="0"/>
+    <tt:Scale x="1" y="1.25"/>
   </tt:AspectRatioTransformation>
   <tt:AspectRatioTransformation ratio="1.77777778>
     <tt:Translate x="0" y="0"/>

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -660,8 +660,7 @@
         <section>
           <title>Aspect Ratio Dependant Transformation</title>
           <para>This section describes the transformation specific to a scene aspect ratio.</para>
-          <para>Same as the transformation node, this node is used to apply initial geometric transformations to the scene elements. It allows for the adjustment of the position, scale, and aspect ratio of the objects within the scene.</para>
-          <para>However, when the device supports more than one aspect ratio, this node allows the client to choose which transformation to apply, matching the metadata aspect ratio to the rendered aspect ratio.</para>
+          <para>Same as the transformation node, this node is used to apply initial geometric transformations to the scene elements. However, when the device supports more than one aspect ratio, this node allows the client to choose which transformation to apply, matching the metadata aspect ratio to the rendered aspect ratio.</para>
           <para>The aspect ratio transformation node can contain the following elements:</para>
           <programlisting><![CDATA[<xs:complexType name="AspectRatioTransformation">
   <xs:sequence>
@@ -684,10 +683,6 @@
   ...
 </tt:Frame>
 ]]></programlisting>
-
-</tt:Frame>
-]]></programlisting>
-        </section>
       </section>
       <section>
         <title>Scene Elements</title>

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -671,7 +671,11 @@
   </xs:sequence>
 </xs:complexType>
 ]]></programlisting>
-          <para>For example, the coordinates of the scene description are given in a frame coordinate system, where the lower-left corner has coordinates (0,0) and the upper-right corner coordinates (320,240). The video source aspect ratio is 4:3. The frame node resembles the following code, where the scale is set to crop the image to other supported aspect ratios:</para>
+          <para>If the transformation is a centered crop on one axis, no Translate vector is needed and Scale vector is calculated with this formula.</para>
+		  <para>For the rendered aspect ratios greater than the video source aspect ratio, fix ScaleX = 1 and compute ScaleY = RenderedAspectRatio / VideoSourceAspectRatio.</para>
+		  <para>For the rendered aspect ratios less than the video source aspect ratio, fix ScaleY = 1 and compute ScaleX = VideoSourceAspectRatio / RenderedAspectRatio.</para>
+		  <para>For example, the coordinates of the scene description are given in a frame coordinate system, where the lower-left corner has coordinates (0,0) and the upper-right corner coordinates (1920,1440). The video source aspect ratio is 4:3. The device supports resolutions 1920x1080 and 960x576 corresponding aspect ratio 16:9 = 1.77777778 and 5:3 = 1.66666667.</para>
+		  <para>The frame node resembles the following code, where the scale is set to crop the image to other supported aspect ratios:</para>
           <programlisting><![CDATA[<tt:Frame UtcTime="2008-10-10T12:24:57.321">
   <tt:AspectRatioTransformation ratio="1.66666667">
     <tt:Scale x="1" y="1.25"/>

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -665,6 +665,7 @@
           <para>The aspect ratio transformation node can contain the following elements:</para>
           <programlisting><![CDATA[<xs:complexType name="AspectRatioTransformation">
   <xs:sequence>
+    <xs:attribute name="ratio" type="xs:float" use="required"/>
     <xs:element name="Translate" type="Vector" minOccurs="0"/>
     <xs:element name="Scale" type="Vector" minOccurs="0"/>
     ...

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -665,11 +665,11 @@
           <para>The aspect ratio transformation node can contain the following elements:</para>
           <programlisting><![CDATA[<xs:complexType name="AspectRatioTransformation">
   <xs:sequence>
-    <xs:attribute name="ratio" type="xs:float" use="required"/>
     <xs:element name="Translate" type="Vector" minOccurs="0"/>
     <xs:element name="Scale" type="Vector" minOccurs="0"/>
     ...
   </xs:sequence>
+  <xs:attribute name="ratio" type="xs:float" use="required"/>
 </xs:complexType>
 ]]></programlisting>
           <para>If the transformation is a centered crop on one axis, no Translate vector is needed and Scale vector is calculated with this formula.</para>

--- a/wsdl/ver10/schema/common.xsd
+++ b/wsdl/ver10/schema/common.xsd
@@ -267,6 +267,14 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- first Vendor then ONVIF -->
 		</xs:sequence>
 	</xs:complexType>
+	<xs:complexType name="AspectRatioTransformation">
+		<xs:sequence>
+			<xs:element name="Transformation" type="tt:Transformation" minOccurs="0"/>
+			<xs:element name="AspectRatio" type="xs:string" minOccurs="0"/>
+            <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:anyAttribute processContents="lax"/>
+	</xs:complexType>
 	<!--===============================-->
 	<!--  Location/Orientation Types   -->
 	<!--===============================-->

--- a/wsdl/ver10/schema/common.xsd
+++ b/wsdl/ver10/schema/common.xsd
@@ -269,8 +269,8 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	</xs:complexType>
 	<xs:complexType name="AspectRatioTransformation">
 		<xs:sequence>
-			<xs:element name="Transformation" type="tt:Transformation" minOccurs="0"/>
-			<xs:element name="AspectRatio" type="xs:string" minOccurs="0"/>
+			<xs:element name="Translate" type="tt:Vector" minOccurs="0"/>
+			<xs:element name="Scale" type="tt:Vector" minOccurs="0"/>
             <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 		<xs:anyAttribute processContents="lax"/>

--- a/wsdl/ver10/schema/common.xsd
+++ b/wsdl/ver10/schema/common.xsd
@@ -269,6 +269,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	</xs:complexType>
 	<xs:complexType name="AspectRatioTransformation">
 		<xs:sequence>
+            <xs:attribute name="ratio" type="xs:float" use="required"/>
 			<xs:element name="Translate" type="tt:Vector" minOccurs="0"/>
 			<xs:element name="Scale" type="tt:Vector" minOccurs="0"/>
             <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>

--- a/wsdl/ver10/schema/common.xsd
+++ b/wsdl/ver10/schema/common.xsd
@@ -269,11 +269,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	</xs:complexType>
 	<xs:complexType name="AspectRatioTransformation">
 		<xs:sequence>
-            <xs:attribute name="ratio" type="xs:float" use="required"/>
 			<xs:element name="Translate" type="tt:Vector" minOccurs="0"/>
 			<xs:element name="Scale" type="tt:Vector" minOccurs="0"/>
             <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
+        <xs:attribute name="ratio" type="xs:float" use="required"/>
 		<xs:anyAttribute processContents="lax"/>
 	</xs:complexType>
 	<!--===============================-->

--- a/wsdl/ver10/schema/metadatastream.xsd
+++ b/wsdl/ver10/schema/metadatastream.xsd
@@ -291,6 +291,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:element name="Extension" type="tt:FrameExtension" minOccurs="0"/>
 			<xs:element name="SceneImageRef" type="xs:anyURI" minOccurs="0"/>
 			<xs:element name="SceneImage" type="xs:base64Binary" minOccurs="0"/>
+			<xs:element name="AspectRatioTranformation" type="tt:AspectRatioTransformation" minOccurs="0"/>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- reserved for ONVIF -->
 		</xs:sequence>
 		<xs:attribute name="UtcTime" type="xs:dateTime" use="required"/>

--- a/wsdl/ver10/schema/metadatastream.xsd
+++ b/wsdl/ver10/schema/metadatastream.xsd
@@ -291,7 +291,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:element name="Extension" type="tt:FrameExtension" minOccurs="0"/>
 			<xs:element name="SceneImageRef" type="xs:anyURI" minOccurs="0"/>
 			<xs:element name="SceneImage" type="xs:base64Binary" minOccurs="0"/>
-			<xs:element name="AspectRatioTranformation" type="tt:AspectRatioTransformation" minOccurs="0"/>
+			<xs:element name="AspectRatioTransformation" type="tt:AspectRatioTransformation" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- reserved for ONVIF -->
 		</xs:sequence>
 		<xs:attribute name="UtcTime" type="xs:dateTime" use="required"/>


### PR DESCRIPTION
The metadata stream uses the camera’s sensor image as the transformation reference.

The client needs to transform the coordinates of the elements from the video source's aspect ratio to the resolution's aspect ratio.

Add to the Frame node a new transformation for each supported aspect ratio.

<img width="1185" height="514" alt="image" src="https://github.com/user-attachments/assets/e199efb5-d612-47d8-8dc3-8c4429bf4c9d" />
