### PR TITLE
Add commonly used certificate signing algorithms to baseline

### DIFF
--- a/doc/SecurityBaseline.xml
+++ b/doc/SecurityBaseline.xml
@@ -253,42 +253,6 @@
     </table>
   </chapter>
   <chapter>
-    <title>Signatures</title>
-    <para/>
-    <table xml:id="sigTable">
-      <title>Signatures</title>
-      <tgroup cols="3">
-        <colspec colname="c1" colwidth="52*"/>
-        <colspec colname="c2" colwidth="12*"/>
-        <thead>
-          <row>
-            <entry>
-              <para>Name</para>
-            </entry>
-            <entry>
-              <para>Size</para>
-            </entry>
-            <entry>
-              <para>Reference</para>
-            </entry>
-          </row>
-        </thead>
-        <tbody valign="top">
-          <row>
-            <entry><para>RSASSA-PSS</para></entry>
-            <entry><para>>= 3000 Bit</para></entry>
-            <entry><para>RFC 8017</para></entry>
-          </row>
-          <row>
-            <entry><para>ECDSA</para></entry>
-            <entry><para>>= 256 Bit</para></entry>
-            <entry><para>RFC 5758, X9.62</para></entry>
-          </row>
-        </tbody>
-      </tgroup>
-    </table>
-  </chapter>
-  <chapter>
     <title>Key Derivation</title>
     <table xml:id="keyTable">
       <title>Key Derivation Functions</title>
@@ -452,6 +416,36 @@
               <para>RFC 7292</para>
             </entry>
             <entry/>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </chapter>
+  <chapter>
+    <title>JWT</title>
+    <para>Requirements for JWT generation or validation.</para>
+    <table xml:id="jwtTable">
+      <title>JSON Web Signatures</title>
+      <tgroup cols="3">
+        <colspec colname="c1" colwidth="52*"/>
+        <thead>
+          <row>
+            <entry>
+              <para>Name</para>
+            </entry>
+            <entry>
+              <para>Comment</para>
+            </entry>
+          </row>
+        </thead>
+        <tbody valign="top">
+          <row>
+            <entry><para>RS256</para></entry>
+            <entry><para>RFC 7515</para></entry>
+          </row>
+          <row>
+            <entry><para>ES256</para></entry>
+            <entry><para>RFC 7515</para></entry>
           </row>
         </tbody>
       </tgroup>


### PR DESCRIPTION
During plugfesting, we discovered with the CCTT that the minimum requirements of the specs today do not include a good coverage of the existing certificates in use on the web today. The requirements are only for RSA withn SHA-256, and ECDSA with SHA-256. In practice, about 50% of CAs in public use today (Based on https://www.ccadb.org/) use SHA-384 or higher as their signing algorithms, and so their intermediates need such algorithms to validate the chains.

I also took the opportunity of expanding the table a bit to also refer to the OIDs, as the names often take different forms in on the internet and can be harder to lookup. The `SignatureAlgorithms` capability in the Security spec already use those OIDs so the mapping felt logical.