### PR TITLE
Add note that client to signaling server communication is an example

### DIFF
--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -79,6 +79,8 @@
     <para>This document defines how WebRTC and related protocols are to be used for ONVIF clients
       and devices to establish a peer-to-peer connection between a client and a device using a
       signaling server.</para>
+    <para>The client communication with its signaling server is provided as an example, both those
+      components belong the the Client and may interact differently.</para>
     <para>Sending PTZ and other commands via WebRTC datachannels is outside of the scope of this 
       version of the specification.</para>
   </chapter>
@@ -382,7 +384,6 @@
               <row>
                 <entry><para>extend</para></entry>
                 <entry><para>The Connect command will return an expiry time parameter. It is possible to call the extend command
-
                     before the expiry time ends to extend the session. </para></entry>
               </row>
             </tbody>


### PR DESCRIPTION
As discussed during F2F, add a mention that the client communication to its signaling server is provided as an example, and usually both Signaling Server and Client belongs to the same entity so may communicate in a different way