### PR TITLE
fix the garbled text in webrtc spec

### DIFF
--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -325,30 +325,51 @@
         <table xml:id="_Ref_parameter_encoding" frame="all">
           <title>Parameter encoding</title>
           <tgroup cols="2">
-            <colspec colname="c1" colnum="1" colwidth="2.0*"/>
-            <colspec colname="c2" colnum="2" colwidth="8.0*"/>
+            <colspec colname="c1" colnum="1" colwidth="1*"/>
+            <colspec colname="c2" colnum="2" colwidth="2.36*"/>
             <thead>
               <row>
-                <entry><para>Type</para></entry>
-                <entry><para>Encoding</para></entry>
+                <entry>
+                  <para>Type</para>
+                </entry>
+                <entry>
+                  <para>Encoding</para>
+                </entry>
               </row>
             </thead>
             <tbody>
               <row>
-                <entry><para>SDP</para></entry>
-                <entry><para>SDP according to RFC 8866 with \r\n escaping</para></entry>
+                <entry>
+                  <para>SDP</para>
+                </entry>
+                <entry>
+                  <para>SDP according to RFC 8866 with \r\n escaping</para>
+                </entry>
               </row>
               <row>
-                <entry><para>IceCandidate</para></entry>
-                <entry><para>JSON encoding according to W3C WebRTC RTCIceCandidateInit</para></entry>
+                <entry>
+                  <para>IceCandidate</para>
+                </entry>
+                <entry>
+                  <para>JSON encoding according to W3C WebRTC RTCIceCandidateInit</para>
+                </entry>
               </row>
               <row>
-                <entry><para>RTCIceServer</para></entry>
-                <entry><para>Connection parameters for a STUN or TURN server as defined by W3C WebRTC</para></entry>
+                <entry>
+                  <para>RTCIceServer</para>
+                </entry>
+                <entry>
+                  <para>Connection parameters for a STUN or TURN server as defined by W3C
+                    WebRTC</para>
+                </entry>
               </row>
               <row>
-                <entry><para>DataChannelSubprotocol</para></entry>
-                <entry><para>Data channel subprotocol identifier</para></entry>
+                <entry>
+                  <para>DataChannelSubprotocol</para>
+                </entry>
+                <entry>
+                  <para>Data channel subprotocol identifier</para>
+                </entry>
               </row>
             </tbody>
           </tgroup>


### PR DESCRIPTION
Text garbled in Webrtc spec as shown below 

<img width="723" height="169" alt="image" src="https://github.com/user-attachments/assets/27af1204-f0db-4f4b-a797-da33ea2640d9" />

**Changes**
- adjusted table width!
- Rest of the changes are just readjustments than any specific edits.