### PR TITLE
Remove requirements on integrity password derivation.

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -5320,9 +5320,6 @@
                   <para>If true, the list of supported password-based encryption algorithms as
                     indicated by the PasswordBasedEncryptionAlgorithms capability shall include the
                     baseline specified in the ONVIF Security Baseline.</para>
-                  <para>If true, the list of supported password-based MAC algorithms as indicated by
-                    the PasswordBasedMACAlgorithms capability shall include the baseline specified
-                    in table Key Derivation Functions of the ONVIF Security Baseline.</para>
                   <para>If true, the list of supported X.509 versions as indicated by the
                     X.509Versions capability shall contain at least the value 3.</para>
                 </entry>


### PR DESCRIPTION
Fix for #691 which states a requirement on a deprecated capability.
Even RFC 7292 Appendix B states that the mechanism should not be used.