### PR TITLE
Remove Specification Version

### DIFF
--- a/doc/MediaSigning.xml
+++ b/doc/MediaSigning.xml
@@ -75,12 +75,6 @@
       signing feature, and also how an ONVIF client should validate the authenticity of a signed
       stream. Audio is outside of scope.</para>
   </chapter>
-  <chapter xml:id="chapter_spec_version">
-    <title>Specification version v1.0</title>
-    <para>This number should be updated when an update to the specification breaks the bitstream
-      format or when new features are added. Such features could be new ways of hashing or support
-      of more codecs.</para>
-  </chapter>
   <chapter xml:id="chapter_a3s_njq_bwb">
     <title>Normative references</title>
     <para>ITU-T Recommendation, H.264: Advanced video coding for generic audiovisual services</para>
@@ -940,8 +934,7 @@
           </listitem>
           <listitem>
             <para>Specification version (3 byte)</para>
-            <para>The major and minor bytes shall be set to the version of this specification, that
-              is, [1, 0]; See Chapter <xref linkend="chapter_spec_version"/>.</para>
+            <para>The major and minor bytes shall be set to the specification revision, e.g., [25, 12].</para>
             <para>The patch byte is reserved by the open-source reference implementation code
               (github.com/onvif/media-signing-framework). Should be set to 0 if not using
               media-signing-framework.</para>


### PR DESCRIPTION
Was added back by accident. Now is properly fixed and chapter reference removed.