### PR TITLE
Remove obsolete validation policy requirement.

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -5560,10 +5560,6 @@
                     If the entry is non-empty it shall contain at least the baseline</para>
                 </entry>
               </row>
-              <row>
-                <entry><para>AuthorizationServer.MaxConfigurations</para></entry>
-                <entry><para>If > 0, MaximumNumberOfCertificationPathValidationPolicies>=2</para></entry>
-              </row>
             </tbody>
           </tgroup>
         </table>


### PR DESCRIPTION
As of version 25.12  the security service requires to support at least two instances.