### PR TITLE
webrtc: Remove ID from register in sequence diagram

### DIFF
--- a/doc/media/WebRTC/webrtc_signaling_flow.svg
+++ b/doc/media/WebRTC/webrtc_signaling_flow.svg
@@ -369,8 +369,6 @@
          id="tspan194"
          style="fill:#000000;stroke:none;stroke-width:27.2272">register(Auth, <tspan
    style="fill:#0000ff"
-   id="tspan16">ID</tspan>, <tspan
-   style="fill:#0000ff"
    id="tspan15">Name</tspan>, <tspan
    style="fill:#0000ff"
    id="tspan27">Capabilities[]</tspan>)</tspan></tspan></tspan></text>


### PR DESCRIPTION
It was removed from the spec previously, I'm just syncing the diagram with those changes.

Fixes onvif/wg_profile_cloud#137