### PR TITLE
method to list the available firmwares to be used with upgradefirmware.

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -5008,8 +5008,8 @@ onvif://www.onvif.org/name/ARV-453
       <section xml:id="_Ref276040130">
         <title>GetAvailableFirmwares</title>
         <para>This operation retrieves a list of available firmware versions for the device.</para>
-        <para>The returned list contains firmware information including version, description, and optional information about the release date and whether it is a beta version. The firmware versions returned can be used with the <emphasis role="bold">UpgradeFirmware</emphasis> operation.</para>
-        <para>The device shall list only firmware versions that are valid upgrade or downgrade from the current firmware version. If none of the returned firmware versions have the IsLatest flag set, the client may call this operation again after completing a firmware upgrade to obtain an updated list of available versions.</para>
+          <para>The returned list contains firmware information including the firmware version string, description, and optional information about the release date, release information URI, and whether it is a beta version. The firmware version strings returned shall be valid values for the Version parameter of the <emphasis role="bold">UpgradeFirmware</emphasis> operation.</para>
+          <para>The device shall list only firmware versions that are valid upgrade or downgrade targets from the current firmware version. If no such firmware version exists, the response shall contain an empty list. If none of the returned firmware versions have the IsLatest flag set, the client may call this operation again after completing a firmware upgrade to obtain an updated list of available versions.</para>
         <para>When requesting for old firmware using IncludePreviousVersions, listing old firmware versions is up to the device implementation; not all devices may support this.</para>
         <variablelist role="op">
           <varlistentry>
@@ -5020,7 +5020,7 @@ onvif://www.onvif.org/name/ARV-453
             </listitem>
             <listitem>
               <para role="param">IncludePreviousVersions - optional [xs:boolean]</para>
-              <para role="text">Optional flag to include previous firmware versions in the response. If not specified or set to false, only the latest versions are returned.</para>
+              <para role="text">Optional flag to include previous firmware versions in the response. If not specified or set to false, only newer firmware versions are returned.</para>
             </listitem>
           </varlistentry>
           <varlistentry>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -5008,7 +5008,9 @@ onvif://www.onvif.org/name/ARV-453
       <section xml:id="_Ref276040130">
         <title>GetAvailableFirmwares</title>
         <para>This operation retrieves a list of available firmware versions for the device.</para>
-        <para>The returned list contains firmware information including version, description, and optional information about the release date, whether it is a beta version, and whether it is a bridge firmware essential for upgrade or downgrade. The firmware versions returned can be used with the <emphasis role="bold">UpgradeFirmware</emphasis> operation.</para>
+        <para>The returned list contains firmware information including version, description, and optional information about the release date and whether it is a beta version. The firmware versions returned can be used with the <emphasis role="bold">UpgradeFirmware</emphasis> operation.</para>
+        <para>The device should list only firmware versions that are valid upgrade or downgrade from the current firmware version. If none of the returned firmware versions have the IsLatest flag set, the client may call this operation again after completing a firmware upgrade to obtain an updated list of available versions.</para>
+        <para>Listing old firmware versions is up to the device implementation; not all devices may support this.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -5008,7 +5008,7 @@ onvif://www.onvif.org/name/ARV-453
       <section xml:id="_Ref276040130">
         <title>GetAvailableFirmwares</title>
         <para>This operation retrieves a list of available firmware versions for the device.</para>
-        <para>The returned list contains firmware information including name, description, and optional information about the release date, whether it is a beta version, and whether it is a bridge firmware essential for upgrade or downgrade. The firmware names returned can be used with the <emphasis role="bold">UpgradeFirmware</emphasis> operation.</para>
+        <para>The returned list contains firmware information including version, description, and optional information about the release date, whether it is a beta version, and whether it is a bridge firmware essential for upgrade or downgrade. The firmware versions returned can be used with the <emphasis role="bold">UpgradeFirmware</emphasis> operation.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -5008,13 +5008,13 @@ onvif://www.onvif.org/name/ARV-453
       <section xml:id="_Ref276040130">
         <title>GetAvailableFirmwares</title>
         <para>This operation retrieves a list of available firmware versions for the device.</para>
-        <para>The returned list contains firmware information including name, description, and optional information about release date, whether its official one and whether its a bridge firmware essential for upgrade or downgrade. The firmware names returned can be used with firmware upgrade operations.</para>
+        <para>The returned list contains firmware information including name, description, and optional information about the release date, whether it is a beta version, and whether it is a bridge firmware essential for upgrade or downgrade. The firmware names returned can be used with the <emphasis role="bold">UpgradeFirmware</emphasis> operation.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>
             <listitem>
-              <para role="param">IncludeUnofficial - optional [xs:boolean]</para>
-              <para role="text">Optional flag to include non-official firmware versions (like beta firmwares or customized firmwares) in the response. If not specified or set to false, only official firmware versions are returned.</para>
+              <para role="param">IncludeBeta - optional [xs:boolean]</para>
+              <para role="text">Optional flag to include beta firmware versions in the response. If not specified or set to false, only stable firmware versions are returned. Note that beta versions may not be available for devices via this channel.</para>
             </listitem>
             <listitem>
               <para role="param">IncludePreviousVersions - optional [xs:boolean]</para>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -3172,6 +3172,14 @@ onvif://www.onvif.org/name/ARV-453
                 </row>
                 <row>
                   <entry>
+                    <para>AvailableFirmwareListing</para>
+                  </entry>
+                  <entry>
+                    <para>Indication if the device supports firmware listing as specified in Section <xref linkend="_Ref276040130" />.</para>
+                  </entry>
+                </row>
+                <row>
+                  <entry>
                     <para>SystemLogging</para>
                   </entry>
                   <entry>
@@ -4996,6 +5004,40 @@ onvif://www.onvif.org/name/ARV-453
         </variablelist>
         <para xml:id="_Ref276040030">In case it is not possible to provide exact figures for
           ExpectedDownTime, the device shall provide best-effort estimates.</para>
+      </section>
+      <section xml:id="_Ref276040130">
+        <title>GetAvailableFirmwares</title>
+        <para>This operation retrieves a list of available firmware versions for the device. A device may support firmware list retrieval through the GetAvailableFirmwares command.</para>
+        <para>The returned list contains firmware information including name, description, and optional download URL. The firmware names returned can be used with firmware upgrade operations.</para>
+        <variablelist role="op">
+          <varlistentry>
+            <term>request</term>
+            <listitem>
+              <para role="param">OnlyOfficial - optional [xs:boolean]</para>
+              <para role="text">Optional flag to filter only official firmware versions. If not specified or set to false, all available firmware versions are returned.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>response</term>
+            <listitem>
+              <para role="param">FirmwareInfo [tds:FirmwareInfo] optional unbounded</para>
+              <para role="text">List of available firmware versions. Each FirmwareInfo contains:</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>faults</term>
+            <listitem>
+              <para role="param" />
+              <para role="text">No command-specific faults.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>access class</term>
+            <listitem>
+              <para role="access">READ_SYSTEM</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
       </section>
       <section xml:id="_Ref482093370">
         <title>GetSystemLog</title>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -5009,8 +5009,8 @@ onvif://www.onvif.org/name/ARV-453
         <title>GetAvailableFirmwares</title>
         <para>This operation retrieves a list of available firmware versions for the device.</para>
         <para>The returned list contains firmware information including version, description, and optional information about the release date and whether it is a beta version. The firmware versions returned can be used with the <emphasis role="bold">UpgradeFirmware</emphasis> operation.</para>
-        <para>The device should list only firmware versions that are valid upgrade or downgrade from the current firmware version. If none of the returned firmware versions have the IsLatest flag set, the client may call this operation again after completing a firmware upgrade to obtain an updated list of available versions.</para>
-        <para>Listing old firmware versions is up to the device implementation; not all devices may support this.</para>
+        <para>The device shall list only firmware versions that are valid upgrade or downgrade from the current firmware version. If none of the returned firmware versions have the IsLatest flag set, the client may call this operation again after completing a firmware upgrade to obtain an updated list of available versions.</para>
+        <para>When requesting for old firmware using IncludePreviousVersions, listing old firmware versions is up to the device implementation; not all devices may support this.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -5013,8 +5013,8 @@ onvif://www.onvif.org/name/ARV-453
           <varlistentry>
             <term>request</term>
             <listitem>
-              <para role="param">OnlyOfficial - optional [xs:boolean]</para>
-              <para role="text">Optional flag to filter only official firmware versions. If not specified or set to false, all available firmware versions are returned.</para>
+              <para role="param">IncludeUnofficial - optional [xs:boolean]</para>
+              <para role="text">Optional flag to include non-official firmware versions (like beta firmwares or customized firmwares) in the response. If not specified or set to false, only official firmware versions are returned.</para>
             </listitem>
             <listitem>
               <para role="param">IncludePreviousVersions - optional [xs:boolean]</para>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -5007,8 +5007,8 @@ onvif://www.onvif.org/name/ARV-453
       </section>
       <section xml:id="_Ref276040130">
         <title>GetAvailableFirmwares</title>
-        <para>This operation retrieves a list of available firmware versions for the device. A device may support firmware list retrieval through the GetAvailableFirmwares command.</para>
-        <para>The returned list contains firmware information including name, description, and optional download URL. The firmware names returned can be used with firmware upgrade operations.</para>
+        <para>This operation retrieves a list of available firmware versions for the device.</para>
+        <para>The returned list contains firmware information including name, description, and optional information about release date, whether its official one and whether its a bridge firmware essential for upgrade or downgrade. The firmware names returned can be used with firmware upgrade operations.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>
@@ -5016,12 +5016,16 @@ onvif://www.onvif.org/name/ARV-453
               <para role="param">OnlyOfficial - optional [xs:boolean]</para>
               <para role="text">Optional flag to filter only official firmware versions. If not specified or set to false, all available firmware versions are returned.</para>
             </listitem>
+            <listitem>
+              <para role="param">IncludePreviousVersions - optional [xs:boolean]</para>
+              <para role="text">Optional flag to include previous firmware versions in the response. If not specified or set to false, only the latest versions are returned.</para>
+            </listitem>
           </varlistentry>
           <varlistentry>
             <term>response</term>
             <listitem>
               <para role="param">FirmwareInfo [tds:FirmwareInfo] optional unbounded</para>
-              <para role="text">List of available firmware versions. Each FirmwareInfo contains:</para>
+              <para role="text">List of available firmware versions.</para>
             </listitem>
           </varlistentry>
           <varlistentry>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -1310,10 +1310,11 @@
           stage process; first the client sends the StartFirmwareUpgrade command to instruct the
           device to prepare for upgrade, then it sends the firmware image using HTTP POST.</para>
         <para>The HTTP method is designed for resource-limited devices that may not be capable of receiving a new firmware image in its normal operating state.</para>
-        <para>The second method applies to cloud connected devices and involves an interaction
-          between the Operational Cloud Service (OCS), the Manufacturer Cloud Service (MCS) and the
-          device, in order to trigger the firmware upgrade. For the complete description of the
-          roles of the cloud clients, please refer to the Cloud Integration Specification.</para>
+        <para>The second method applies to cloud connected devices. A simple interface allows
+          upgrading firmware by providing a requested version. The device interacts via propriatary
+          means with its manufacturer cloud to perform the requested update. Available options can
+          be retrieved via the method GetAvailableFirmwares or the Manufacturer Cloud Service
+          (MCS).</para>
       </section>
       <section>
         <title>System Restore</title>
@@ -4953,7 +4954,8 @@ onvif://www.onvif.org/name/ARV-453
         <para>Cloud firmware upgrade  may be achieved using the following steps:</para>
         <orderedlist>
           <listitem>
-            <para>Client retrieves the list of available firmware versions from the MCS.</para>
+            <para>Client retrieves the list of available firmware versions via GetAvailableFirmwares
+              or from the MCS.</para>
           </listitem>
           <listitem>
             <para>Client calls StartCloudFirmwareUpgrade, selecting the desired FW version.</para>

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -2512,9 +2512,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 								<xs:documentation> Optional flag to include previous firmware versions in the response (for downgrade or rollback). If not passed, only newer firmware versions would be listed. </xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
 					</xs:sequence>
-					<xs:anyAttribute processContents="lax"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="GetAvailableFirmwaresResponse">
@@ -2525,9 +2523,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 								<xs:documentation>List of available firmware versions.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
 					</xs:sequence>
-					<xs:anyAttribute processContents="lax"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:complexType name="FirmwareInfo">

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -316,6 +316,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:documentation>Indicates support for firmware upgrade through the cloud.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
+				<xs:attribute name="AvailableFirmwareListing" type="xs:boolean">
+					<xs:annotation>
+						<xs:documentation>Specifies support for retrieving the list of available firmware through GetAvailableFirmwares.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:attribute name="HttpFirmwareUpgrade" type="xs:boolean">
 					<xs:annotation>
 						<xs:documentation>Indicates support for firmware upgrade through HTTP.</xs:documentation>
@@ -2494,6 +2499,49 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:complexType>
 			</xs:element>	 		
 			<!--===============================-->
+			<xs:element name="GetAvailableFirmwares">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="OnlyOfficial" type="xs:boolean" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Optional flag to filter only official firmware versions.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
+					</xs:sequence>
+					<xs:anyAttribute processContents="lax"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="GetAvailableFirmwaresResponse">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="FirmwareInfo" type="tds:FirmwareInfo" minOccurs="0" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>List of available firmware versions.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
+					</xs:sequence>
+					<xs:anyAttribute processContents="lax"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:complexType name="FirmwareInfo">
+				<xs:sequence>
+					<xs:element name="FirmwareName" type="xs:string">
+						<xs:annotation>
+							<xs:documentation>The name of the firmware version.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="FirmwareDescription" type="xs:string">
+						<xs:annotation>
+							<xs:documentation>Description of the firmware version.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
+				</xs:sequence>
+				<xs:anyAttribute processContents="lax"/>
+			</xs:complexType>
+			<!--===============================-->
 			<!--===============================-->
 		</xs:schema>
 	</wsdl:types>
@@ -3115,6 +3163,12 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	</wsdl:message>
 	<wsdl:message name="SetHashingAlgorithmResponse">
 		<wsdl:part name="parameters" element="tds:SetHashingAlgorithmResponse"/>
+	</wsdl:message>
+	<wsdl:message name="GetAvailableFirmwaresRequest">
+		<wsdl:part name="parameters" element="tds:GetAvailableFirmwares"/>
+	</wsdl:message>
+	<wsdl:message name="GetAvailableFirmwaresResponse">
+		<wsdl:part name="parameters" element="tds:GetAvailableFirmwaresResponse"/>
 	</wsdl:message>
 	
 	<wsdl:portType name="Device">
@@ -3770,6 +3824,13 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</wsdl:documentation>
 			<wsdl:input message="tds:SetHashingAlgorithmRequest"/>
 			<wsdl:output message="tds:SetHashingAlgorithmResponse"/>
+		</wsdl:operation>
+		<wsdl:operation name="GetAvailableFirmwares">
+			<wsdl:documentation>
+				This operation returns the list of firmware versions available for the device. The retrieved firmware name can then be used with the UpgradeFirmware operation.
+			</wsdl:documentation>
+			<wsdl:input message="tds:GetAvailableFirmwaresRequest"/>
+			<wsdl:output message="tds:GetAvailableFirmwaresResponse"/>
 		</wsdl:operation>
 
 		<!--===============================-->
@@ -4776,6 +4837,15 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		</wsdl:operation>
 		<wsdl:operation name="SetHashingAlgorithm">
 			<soap:operation soapAction="http://www.onvif.org/ver10/device/wsdl/SetHashingAlgorithm"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="GetAvailableFirmwares">
+			<soap:operation soapAction="http://www.onvif.org/ver10/device/wsdl/GetAvailableFirmwares"/>
 			<wsdl:input>
 				<soap:body use="literal"/>
 			</wsdl:input>

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -2520,7 +2520,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<xs:sequence>
 						<xs:element name="FirmwareInfo" type="tds:FirmwareInfo" minOccurs="0" maxOccurs="unbounded">
 							<xs:annotation>
-								<xs:documentation>List of available firmware versions.</xs:documentation>
+								<xs:documentation>List of available firmware versions. If no valid upgrade or downgrade target exists, the list shall be empty.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 					</xs:sequence>
@@ -2541,6 +2541,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<xs:element name="ReleaseDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
 						<xs:annotation>
 							<xs:documentation>The release date of the firmware version.</xs:documentation>	
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="ReleaseInfoUri" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+						<xs:annotation>
+							<xs:documentation>URI of release information for the firmware version, such as a release letter or release notes.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
@@ -3843,7 +3848,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		</wsdl:operation>
 		<wsdl:operation name="GetAvailableFirmwares">
 			<wsdl:documentation>
-				This operation returns the list of firmware versions available for the device. The retrieved firmware name can then be used with the UpgradeFirmware operation.
+				This operation returns the list of firmware versions available for the device. The returned firmware version strings shall be valid values for the Version parameter of the UpgradeFirmware operation.
 			</wsdl:documentation>
 			<wsdl:input message="tds:GetAvailableFirmwaresRequest"/>
 			<wsdl:output message="tds:GetAvailableFirmwaresResponse"/>

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -2554,11 +2554,6 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:documentation>Indicates whether the firmware version is a beta release.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
-				<xs:attribute name="BridgeFirmware" type="xs:boolean" use="optional">
-					<xs:annotation>
-						<xs:documentation>Indicates whether the firmware is a bridge firmware essential for upgrade.</xs:documentation>
-					</xs:annotation>
-				</xs:attribute>
 				<xs:attribute name="IsLatest" type="xs:boolean" use="optional">
 					<xs:annotation>
 						<xs:documentation>Indicates whether the firmware version is the latest official release.</xs:documentation>

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -2502,9 +2502,9 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:element name="GetAvailableFirmwares">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="OnlyOfficial" type="xs:boolean" minOccurs="0" maxOccurs="1">
+						<xs:element name="IncludeUnofficial" type="xs:boolean" minOccurs="0" maxOccurs="1">
 							<xs:annotation>
-								<xs:documentation>Optional flag to filter only official firmware versions.</xs:documentation>
+								<xs:documentation>Optional flag to include non-official firmware versions in the response. If not passed, only official versions are listed.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="IncludePreviousVersions" type="xs:boolean" minOccurs="0" maxOccurs="1">

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -2532,9 +2532,9 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:complexType name="FirmwareInfo">
 				<xs:sequence>
-					<xs:element name="FirmwareName" type="xs:string">
+					<xs:element name="FirmwareVersion" type="xs:string">
 						<xs:annotation>
-							<xs:documentation>The name of the firmware version.</xs:documentation>
+							<xs:documentation>Version identifier of the firmware.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="FirmwareDescription" type="xs:string" minOccurs="0" maxOccurs="1">

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -2502,9 +2502,9 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:element name="GetAvailableFirmwares">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="IncludeUnofficial" type="xs:boolean" minOccurs="0" maxOccurs="1">
+						<xs:element name="IncludeBeta" type="xs:boolean" minOccurs="0" maxOccurs="1">
 							<xs:annotation>
-								<xs:documentation>Optional flag to include non-official firmware versions in the response. If not passed, only official versions are listed.</xs:documentation>
+								<xs:documentation>Optional flag to include beta firmware versions in the response. If not passed, only stable firmware versions would be listed. Note that beta versions may not be available for devices via this channel.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="IncludePreviousVersions" type="xs:boolean" minOccurs="0" maxOccurs="1">
@@ -2549,9 +2549,9 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					</xs:element>
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
 				</xs:sequence>
-				<xs:attribute name="Official" type="xs:boolean" use="optional">
+				<xs:attribute name="Beta" type="xs:boolean" use="optional">
 					<xs:annotation>
-						<xs:documentation>Indicates whether the firmware version is an official release.</xs:documentation>
+						<xs:documentation>Indicates whether the firmware version is a beta release.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:attribute name="BridgeFirmware" type="xs:boolean" use="optional">

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -2502,9 +2502,14 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:element name="GetAvailableFirmwares">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="OnlyOfficial" type="xs:boolean" minOccurs="0">
+						<xs:element name="OnlyOfficial" type="xs:boolean" minOccurs="0" maxOccurs="1">
 							<xs:annotation>
 								<xs:documentation>Optional flag to filter only official firmware versions.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="IncludePreviousVersions" type="xs:boolean" minOccurs="0" maxOccurs="1">
+							<xs:annotation>
+								<xs:documentation> Optional flag to include previous firmware versions in the response (for downgrade or rollback). If not passed, only newer firmware versions would be listed. </xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
@@ -2532,13 +2537,33 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 							<xs:documentation>The name of the firmware version.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="FirmwareDescription" type="xs:string">
+					<xs:element name="FirmwareDescription" type="xs:string" minOccurs="0" maxOccurs="1">
 						<xs:annotation>
 							<xs:documentation>Description of the firmware version.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
+					<xs:element name="ReleaseDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+						<xs:annotation>
+							<xs:documentation>The release date of the firmware version.</xs:documentation>	
+						</xs:annotation>
+					</xs:element>
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
 				</xs:sequence>
+				<xs:attribute name="Official" type="xs:boolean" use="optional">
+					<xs:annotation>
+						<xs:documentation>Indicates whether the firmware version is an official release.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="BridgeFirmware" type="xs:boolean" use="optional">
+					<xs:annotation>
+						<xs:documentation>Indicates whether the firmware is a bridge firmware essential for upgrade.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="IsLatest" type="xs:boolean" use="optional">
+					<xs:annotation>
+						<xs:documentation>Indicates whether the firmware version is the latest official release.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:complexType>
 			<!--===============================-->


### PR DESCRIPTION
Provides a device‑side method for listing available firmware, serving as an alternative to the cloud‑based **getAvailableFWImages** in the **CloudIntegration** specification.
Please review.