### PR TITLE
Replaced quotes to utf-8 to fix rendering issues

### DIFF
--- a/wsdl/ver10/accessrules/wsdl/accessrules.wsdl
+++ b/wsdl/ver10/accessrules/wsdl/accessrules.wsdl
@@ -136,7 +136,7 @@ CERTAIN WRITTEN POLICIES OF THE CORPORATION.
 							<xs:documentation>
 								Optional entity type; if missing, an access point type as defined by the ONVIF Access
 								Control Service Specification should be assumed. This can also be represented by the
-								QName value	“tac:AccessPoint” where tac is the namespace of ONVIF Access Control
+								QName value	"tac:AccessPoint" where tac is the namespace of ONVIF Access Control
 								Service Specification. This field is provided for future extensions; it will allow an
 								access policy being	extended to cover entity types other than access points as well.
 							</xs:documentation>

--- a/wsdl/ver10/credential/wsdl/credential.wsdl
+++ b/wsdl/ver10/credential/wsdl/credential.wsdl
@@ -126,7 +126,7 @@ CERTAIN WRITTEN POLICIES OF THE CORPORATION.
 						<xs:documentation>
 							The default time period that the credential will temporary be suspended (e.g. by using
 							the wrong PIN a predetermined number of times).
-							The time period is defined as an [ISO 8601] duration string (e.g. “PT5M”).
+							The time period is defined as an [ISO 8601] duration string (e.g. "PT5M").
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -3661,9 +3661,9 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<li>Server reprograms itself using the uploaded image, then reboots.</li>
 				</ol>
 				If the firmware upgrade fails because the upgrade file was invalid, the HTTP POST response
-				shall be “415 Unsupported Media Type”. If the firmware upgrade fails due to an error at the
-				device, the HTTP POST response shall be “500 Internal Server Error”.<br/>
-				The value of the Content-Type header in the HTTP POST request shall be “application/octetstream”.</wsdl:documentation>
+				shall be "415 Unsupported Media Type". If the firmware upgrade fails due to an error at the
+				device, the HTTP POST response shall be "500 Internal Server Error".<br/>
+				The value of the Content-Type header in the HTTP POST request shall be "application/octetstream".</wsdl:documentation>
 			<wsdl:input message="tds:StartFirmwareUpgradeRequest"/>
 			<wsdl:output message="tds:StartFirmwareUpgradeResponse"/>
 		</wsdl:operation>
@@ -3699,9 +3699,9 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<li>Server applies the uploaded configuration, then reboots if necessary.</li>
 				</ol>
 				If the system restore fails because the uploaded file was invalid, the HTTP POST response
-				shall be “415 Unsupported Media Type”. If the system restore fails due to an error at the
-				device, the HTTP POST response shall be “500 Internal Server Error”.<br/>
-				The value of the Content-Type header in the HTTP POST request shall be “application/octetstream”.</wsdl:documentation>
+				shall be "415 Unsupported Media Type". If the system restore fails due to an error at the
+				device, the HTTP POST response shall be "500 Internal Server Error".<br/>
+				The value of the Content-Type header in the HTTP POST request shall be "application/octetstream".</wsdl:documentation>
 			<wsdl:input message="tds:StartSystemRestoreRequest"/>
 			<wsdl:output message="tds:StartSystemRestoreResponse"/>
 		</wsdl:operation>

--- a/wsdl/ver10/events/wsdl/event-vs.wsdl
+++ b/wsdl/ver10/events/wsdl/event-vs.wsdl
@@ -551,7 +551,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				deletion in a uniform way. When a client wants to synchronize its properties with the
 				properties of the device, it can request a synchronization point which repeats the current
 				status of all properties to which a client has subscribed. The PropertyOperation of all
-				produced notifications is set to “Initialized”. The Synchronization Point is
+				produced notifications is set to "Initialized". The Synchronization Point is
 				requested directly from the SubscriptionManager which was returned in either the
 				SubscriptionResponse or in the CreatePullPointSubscriptionResponse. The property update is
 				transmitted via the notification transportation of the notification interface. This method is mandatory.

--- a/wsdl/ver10/events/wsdl/event.wsdl
+++ b/wsdl/ver10/events/wsdl/event.wsdl
@@ -551,7 +551,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				deletion in a uniform way. When a client wants to synchronize its properties with the
 				properties of the device, it can request a synchronization point which repeats the current
 				status of all properties to which a client has subscribed. The PropertyOperation of all
-				produced notifications is set to “Initialized”. The Synchronization Point is
+				produced notifications is set to "Initialized". The Synchronization Point is
 				requested directly from the SubscriptionManager which was returned in either the
 				SubscriptionResponse or in the CreatePullPointSubscriptionResponse. The property update is
 				transmitted via the notification transportation of the notification interface. This method is mandatory.

--- a/wsdl/ver10/media/wsdl/media.wsdl
+++ b/wsdl/ver10/media/wsdl/media.wsdl
@@ -2429,7 +2429,7 @@ AudioOutputConfiguration shall be removed.</xs:documentation>
 		<!--===============================-->
 		<wsdl:operation name="CreateProfile">
 			<wsdl:documentation>This operation creates a new empty media profile. The media profile shall be created in the
-device and shall be persistent (remain after reboot). A created profile shall be deletable and a device shall set the “fixed” attribute to false in the
+device and shall be persistent (remain after reboot). A created profile shall be deletable and a device shall set the "fixed" attribute to false in the
 returned Profile.</wsdl:documentation>
 			<wsdl:input message="trt:CreateProfileRequest"/>
 			<wsdl:output message="trt:CreateProfileResponse"/>

--- a/wsdl/ver10/schema/metadatastream.xsd
+++ b/wsdl/ver10/schema/metadatastream.xsd
@@ -406,7 +406,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		</xs:attribute>
 		<xs:attribute name="Cells" type="xs:base64Binary" use="required">
 			<xs:annotation>
-				<xs:documentation>A “1” denotes a cell where motion is detected and a “0” an empty cell. The first cell is in the upper left corner. Then the cell order goes first from left to right and then from up to down.  If the number of cells is not a multiple of 8 the last byte is filled with zeros. The information is run length encoded according to Packbit coding in ISO 12369 (TIFF, Revision 6.0).</xs:documentation>
+				<xs:documentation>A "1" denotes a cell where motion is detected and a "0" an empty cell. The first cell is in the upper left corner. Then the cell order goes first from left to right and then from up to down.  If the number of cells is not a multiple of 8 the last byte is filled with zeros. The information is run length encoded according to Packbit coding in ISO 12369 (TIFF, Revision 6.0).</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:anyAttribute processContents="lax"/>

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -229,7 +229,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:documentation>
 			A media profile consists of a set of media configurations. Media profiles are used by a client
 			to configure properties of a media stream from an NVT.<br/>
-			An NVT shall provide at least one media profile at boot. An NVT should provide “ready to use”
+			An NVT shall provide at least one media profile at boot. An NVT should provide "ready to use"
 			profiles for the most common media configurations that the device offers.<br/>
 			A profile consists of a set of interconnected configuration entities. Configurations are provided
 			by the NVT and can be either static or created dynamically by the NVT. For example, the
@@ -8384,8 +8384,8 @@ and sample rate. </xs:documentation>
 		<xs:sequence>
 			<xs:element name="TrackType" type="tt:TrackType">
 				<xs:annotation>
-					<xs:documentation>Type of the track. It shall be equal to the strings “Video”,
-				“Audio” or “Metadata”. The track shall only be able to hold data of that type.</xs:documentation>
+					<xs:documentation>Type of the track. It shall be equal to the strings "Video",
+				"Audio" or "Metadata". The track shall only be able to hold data of that type.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Description" type="tt:Description">
@@ -8459,7 +8459,7 @@ and sample rate. </xs:documentation>
 				<xs:annotation>
 					<xs:documentation>The mode of the job. If it is idle, nothing shall happen. If it is active, the device shall try
 				to obtain data from the receivers. A client shall use GetRecordingJobState to determine if data transfer is really taking place.<br/>
-				The only valid values for Mode shall be “Idle” and “Active”.</xs:documentation>
+				The only valid values for Mode shall be "Idle" and "Active".</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Priority" type="xs:int">
@@ -8666,7 +8666,7 @@ and sample rate. </xs:documentation>
 			<xs:element name="State" type="tt:RecordingJobState">
 				<xs:annotation>
 					<xs:documentation>Provides the job state of the track. The valid
-				values of state shall be “Idle”, “Active” and “Error”. If state equals “Error”, the Error field may be filled in with an implementation defined value.</xs:documentation>
+				values of state shall be "Idle", "Active" and "Error". If state equals "Error", the Error field may be filled in with an implementation defined value.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##targetNamespace" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>

--- a/wsdl/ver20/ptz/wsdl/ptz.wsdl
+++ b/wsdl/ver20/ptz/wsdl/ptz.wsdl
@@ -1073,7 +1073,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		</wsdl:operation>
 		<wsdl:operation name="SetHomePosition">
 			<wsdl:documentation>Operation to save current position as the home position.
-				The SetHomePosition command returns with a failure if the “home” position is fixed and
+				The SetHomePosition command returns with a failure if the "home" position is fixed and
 				cannot be overwritten. If the SetHomePosition is successful, it is possible to recall the
 				Home Position with the GotoHomePosition command.</wsdl:documentation>
 			<wsdl:input message="tptz:SetHomePositionRequest"/>


### PR DESCRIPTION
Few places in the schema and wsdls are using non utf-8 quote characters which results in rendering special characters affecting readability as shown in the screenshot below 

> <img width="1817" height="156" alt="Screenshot 2026-01-26 at 14 01 13" src="https://github.com/user-attachments/assets/1e00dcbc-cb30-4667-ac9a-5159ef6f2a6c" />

This PR provides fix for such instances/occurences.