### PR TITLE
Add kid header requirement for private_key_jwt

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -297,6 +297,10 @@
       >http://www.ietf.org/rfc/rfc6750.txt</link>&gt;</para>
     <para>RFC 7292 - PKCS #12: Personal Information Exchange Syntax v1.1</para>
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc7292"/>&gt;</para>
+    <para>IETF RFC 7515 JSON Web Signature (JWS)</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc7515.txt"
+      >http://www.ietf.org/rfc/rfc7515.txt</link>&gt;</para>
     <para>IETF RFC 7517 JSON Web Key (JWK)</para>
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
         xlink:href="http://www.ietf.org/rfc/rfc7517.txt"
@@ -1357,8 +1361,7 @@
         <para>A device signaling support for self_signed_tls_client_auth shall signal support for
           SelfSignedCertificateCreation.</para>
         <para>A device signaling support for private_key_jwt shall signal support for
-          KeyPairGeneration for ECC keys. The <literal>KeyId</literal> specified in the configuration shall 
-          also be included as the `kid` header field of the JWT assertion.</para>
+          KeyPairGeneration for ECC keys.</para>
       </section>
     </section>
   </chapter>
@@ -4597,6 +4600,9 @@
         <title>SetAuthorizationServerConfiguration</title>
         <para>This operation modifies an existing authorization server configuration. The device
           shall support this command if MaxConfigurations capability is greater than zero.</para>
+        <para>When the <literal>KeyID</literal> value of the configuration is set, the device shall
+          include that value in the <literal>kid</literal> header field of the client assertion defined
+          in RFC 7515 Section 4.1.4.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -1357,7 +1357,8 @@
         <para>A device signaling support for self_signed_tls_client_auth shall signal support for
           SelfSignedCertificateCreation.</para>
         <para>A device signaling support for private_key_jwt shall signal support for
-          KeyPairGeneration for ECC keys.</para>
+          KeyPairGeneration for ECC keys. The <literal>KeyId</literal> specified in the configuration shall 
+          also be included as the `kid` header field of the JWT assertion.</para>
       </section>
     </section>
   </chapter>


### PR DESCRIPTION
As discussed in Profile V working group, OpenId Connect specification requires the presence of the `kid` header field in `private_key_jwt` assertions to allow for the Identity Provider to determine which key it shall use for the given clientid to validate the assertion against.

I'm adding a requirement when using private_key_jwt to add the configured KeyID to the kid header. This value is already known by the client and can be configured (out of band) on the identity server so it can match it.

Closes onvif/wg_profile_cloud#142