### PR TITLE
Fix for 26.06 IPR Review, since we do not have any text in the specs

### DIFF
--- a/doc/Media2.xml
+++ b/doc/Media2.xml
@@ -1028,8 +1028,9 @@
             <para>Quality – Determines the quality of the video. A high value within supported quality range means higher quality.</para>
           </listitem>
           <listitem>
-            <para>RateControl – Defines parameters to configure the bitrate [kbps] and a
-              FrameRateLimit [fps] parameter to configure the output framerate.</para>
+            <para>RateControl – Defines parameters to configure the BitrateLimit [kbps],
+              AverageBitRate [kbps] and a FrameRateLimit [fps] parameter to configure the output
+              framerate.</para>
           </listitem>
           <listitem>
             <para>Encoding profile and GOV length [frame].</para>


### PR DESCRIPTION
#620 was accepted into development and it needs IPR review.

Unfortunately, there is no reference to the change in onvif.xsd from the specs. 

This minimal PR changes one sentence, including the new field in the rate control and corrects the wrong name for BitrateLimit.

I need a quick review, since this is the only item still missing to complete the files for the IPR review.