### PR TITLE
Recording Job SourceToken clarified for Media2 profile

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -560,10 +560,13 @@ Change Request 2061, 2063, 2065, 2109</revremark>
           a ReceiverReference. In this case the device shall receive the data over the network. If
           Type is http://www.onvif.org/ver10/schema/Profile, the token identifies a media profile,
           provisioned via the ONVIF Media Service or the ONVIF Media2 Service, instructing the
-          device to obtain data from a profile that exists on the local device.</para>
-        <para>A device that includes the ONVIF Media Service or ONVIF Media2 service shall support a
+          device to obtain data from a profile that exists on the local device.
+        </para>
+        <para>
+          A device that includes the ONVIF Media Service or ONVIF Media2 service shall support a
           Media Profile token. A device that includes the ONVIF Receiver Service shall support a
-          Receiver token.</para>
+          Receiver token.
+        </para>
         <para>
           <emphasis role="bold">AutoCreateReceiver</emphasis>: If a request includes this field set to true and no source token is provided, the device shall create a
           receiver object (through the receiver service) and assign the ReceiverReference to the

--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -554,8 +554,16 @@ Change Request 2061, 2063, 2065, 2109</revremark>
         <para>
           <emphasis role="bold">EventFilter:</emphasis> This set of parameters allows to control recording depending on a given set of event condititions.</para>
         <para>
-          <emphasis role="bold">SourceToken</emphasis>: This field shall be a reference to the source of the data. The type of the source is determined by the attribute Type in the SourceToken structure. If Type is http://www.onvif.org/ver10/schema/Receiver, the token is a ReceiverReference. In this case the device shall receive the data over the network. If Type is http://www.onvif.org/ver10/schema/Profile, the token identifies a media profile, instructing the device to obtain data from a profile that exists on the local device. </para>
-        <para>A device that includes the ONVIF Media Service shall support a Media Profile token and a device that includes the ONVIF Receiver Service shall support a Receiver token.</para>
+          <emphasis role="bold">SourceToken</emphasis>: This field shall be a reference to the
+          source of the data. The type of the source is determined by the attribute Type in the
+          SourceToken structure. If Type is http://www.onvif.org/ver10/schema/Receiver, the token is
+          a ReceiverReference. In this case the device shall receive the data over the network. If
+          Type is http://www.onvif.org/ver10/schema/Profile, the token identifies a media profile,
+          provisioned via the ONVIF Media Service or the ONVIF Media2 Service, instructing the
+          device to obtain data from a profile that exists on the local device.</para>
+        <para>A device that includes the ONVIF Media Service or ONVIF Media2 service shall support a
+          Media Profile token. A device that includes the ONVIF Receiver Service shall support a
+          Receiver token.</para>
         <para>
           <emphasis role="bold">AutoCreateReceiver</emphasis>: If a request includes this field set to true and no source token is provided, the device shall create a
           receiver object (through the receiver service) and assign the ReceiverReference to the

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -8565,8 +8565,8 @@ and sample rate. </xs:documentation>
 				is determined by the attribute Type in the SourceToken structure. If Type is
 				http://www.onvif.org/ver10/schema/Receiver, the token is a ReceiverReference. In this case
 				the device shall receive the data over the network. If Type is
-				http://www.onvif.org/ver10/schema/Profile, the token identifies a media profile, instructing the
-				device to obtain data from a profile that exists on the local device.</xs:documentation>
+				http://www.onvif.org/ver10/schema/Profile, the token identifies a media profile, provisioned via the ONVIF Media Service or the ONVIF Media2 Service,
+				instructing the device to obtain data from a profile that exists on the local device.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="AutoCreateReceiver" type="xs:boolean" minOccurs="0">


### PR DESCRIPTION
**Issue/Problem Statement** 
- https://github.com/onvif/wg_profile_cloud/issues/150

Ref: https://www.onvif.org/specs/srv/rec/ONVIF-RecordingControl-Service-Spec.pdf 
Section 5.3.3. RecordingJobConfiguration

> If Type is http://www.onvif.org/ver10/schema/Profile, the token identifies a media profile, instructing the device to obtain data from a profile that exists on the local device.

> A device that includes the ONVIF Media Service shall support a Media Profile token and a device that includes
the ONVIF Receiver Service shall support a Receiver token.

**Proposed change**

> If Type is http://www.onvif.org/ver10/schema/Profile, the token identifies a media profile, **provisioned via the ONVIF Media Service or the ONVIF Media2 Service,** instructing the device to obtain data from a profile that exists on the local device.

>A device that includes the ONVIF Media Service **or ONVIF Media2 service** shall support a Media Profile token. A device that includes the ONVIF Receiver Service shall support a Receiver token.