### PR TITLE
MaxRetentiontTime not applicable for external storage targets

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -458,7 +458,9 @@ Change Request 2061, 2063, 2065, 2109</revremark>
         <title>RecordingConfiguration</title>
         <para>The RecordingConfiguration structure shall be used to configure recordings through CreateRecordings and Get/SetRecordingConfiguration.</para>
         <para>
-          <emphasis role="bold">MaximumRetentionTime</emphasis> specifies the maximum time that data in any track within the recording shall be stored. The device shall delete any data older than the maximum retention time. Such data shall not be accessible anymore. If the MaximumRetentionPeriod is set to 0, the device shall not limit the retention time of stored data, except by resource constraints. Whatever the value of MaximumRetentionTime, the device may automatically delete recordings to free up storage space for new recordings.</para>
+          <emphasis role="bold">MaximumRetentionTime</emphasis> specifies the maximum time that data in any track within the recording shall be stored. The device shall delete any data older than the maximum retention time. Such data shall not be accessible anymore. 
+          If the MaximumRetentionPeriod is set to 0, the device shall not limit the retention time of stored data, except by resource constraints. Whatever the value of MaximumRetentionTime, the device may automatically delete recordings to free up storage space for new recordings.
+          This parameter has no effect on the data stored in external targets for e.g. Object Storage.</para>
         <para>
           None of the other fields defined in this structure shall be used by the device.
           Instead, it simply stores this information, and it shall return it through the <emphasis>GetRecordingConfiguration</emphasis> and <emphasis>GetRecordingInformation</emphasis> (see ONVIF Recording Search Service Specification) methods.</para>

--- a/wsdl/ver10/recording.wsdl
+++ b/wsdl/ver10/recording.wsdl
@@ -879,8 +879,8 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<li>
 					META001 Metadata</li>
 				</ul>
-				All TrackConfigurations shall have the MaximumRetentionTime set to 0 (unlimited), and the
-				Description set to the empty string.
+				All tracks created as response to a CreateRecording request shall have the MaximumRetentionTime set to 0 (unlimited), and the
+				Description set to the empty string, by default.
 			</wsdl:documentation>
 			<wsdl:input message="trc:CreateRecordingRequest"/>
 			<wsdl:output message="trc:CreateRecordingResponse"/>

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -8390,12 +8390,12 @@ and sample rate. </xs:documentation>
 			</xs:element>
 			<xs:element name="MaximumRetentionTime" type="xs:duration">
 				<xs:annotation>
-					<xs:documentation>Sspecifies the maximum time that data in any track within the
+					<xs:documentation>Specifies the maximum time that data in any track within the
 				recording shall be stored. The device shall delete any data older than the maximum retention
 				time. Such data shall not be accessible anymore. If the MaximumRetentionPeriod is set to 0,
 				the device shall not limit the retention time of stored data, except by resource constraints.
 				Whatever the value of MaximumRetentionTime, the device may automatically delete
-				recordings to free up storage space for new recordings.</xs:documentation>
+				recordings to free up storage space for new recordings. This parameter has no effect on the data stored in external targets for e.g. Object Storage.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Target" type="tt:RecordingTargetConfiguration" minOccurs="0">


### PR DESCRIPTION
Ref: https://github.com/onvif/wg_profile_cloud/issues/144

This PR clarifies that MaxRetentionTime parameter has no affect on the data stored in external targets.