### PR TITLE
Uplink connection status strings not in sync with schema

### DIFF
--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -440,7 +440,7 @@
     </section>
     <section>
       <title>GetUplinks</title>
-      <para>A device supporting uplinks shall support this command to retrieve the configured uplink configurations. The Status field shall signal whether a connection is Offline, Connecting or Online.</para>
+      <para>A device supporting uplinks shall support this command to retrieve the configured uplink configurations. The Status field shall signal whether a connection is Offline, Connecting or Connected.</para>
       <variablelist role="op">
         <varlistentry>
           <term>request</term>


### PR DESCRIPTION
Ref: https://github.com/onvif/wg_profile_cloud/issues/138

Uplink connection status strings not in sync with schema, hence the specification text is corrected to reflect same as schema.