### PR TITLE
Clarify renewal configuration not limited to credentials.

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -6482,10 +6482,7 @@ onvif://www.onvif.org/name/ARV-453
       </section>
       <section>
         <title>Configuration Renewal</title>
-        <para>
-          The configuration allows for a renewal endpoint to be set. If the device supports this feature, it shall automatically renew the credentials 
-          when they are about to expire.
-        </para>
+        <para> The configuration allows for a renewal endpoint to be set.</para>
         <para>
           The device shall do a GET request to the configured <literal>RenewalEndpoint</literal> with the access token retrieved from the configured 
           <literal>AuthorizationServer</literal>. The endpoint shall respond with a JSON payload with the following structure:
@@ -6501,11 +6498,10 @@ onvif://www.onvif.org/name/ARV-453
 }]]></programlisting>
           Any null value in the response shall clear the corresponding optional parameter in the configuration used by the device.
         </para>
-        <para>
-          When the device receives a configuration with the <literal>ConfigurationRenewal</literal> set, it shall immediately contact
-          the renewal endpoint to get up-to-date credentials. The device may use the credentials available in the configuration in the
-          meantime to avoid service disruption.
-        </para>
+        <para> When the device receives a configuration with the
+            <literal>ConfigurationRenewal</literal> set, it shall immediately contact the renewal
+          endpoint to get up-to-date renewal confguration payload. The device may use the current
+          credentials available in the configuration in the meantime to avoid service disruption. </para>
         <para>
           The device shall ensure to renew the configuration before the expiration provided by the <literal>expiresAt</literal> field.
           If the renewal endpoint fails to provide a valid response, the device shall continue to use the existing configuration and retry

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -6500,7 +6500,7 @@ onvif://www.onvif.org/name/ARV-453
         </para>
         <para> When the device receives a configuration with the
             <literal>ConfigurationRenewal</literal> set, it shall immediately contact the renewal
-          endpoint to get up-to-date renewal confguration payload. The device may use the current
+          endpoint to get up-to-date renewal configuration payload. The device may use the current
           credentials available in the configuration in the meantime to avoid service disruption. </para>
         <para>
           The device shall ensure to renew the configuration before the expiration provided by the <literal>expiresAt</literal> field.

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -6500,13 +6500,13 @@ onvif://www.onvif.org/name/ARV-453
         </para>
         <para> When the device receives a configuration with the
             <literal>ConfigurationRenewal</literal> set, it shall immediately contact the renewal
-          endpoint to get up-to-date renewal configuration payload. The device may use the current
-          credentials available in the configuration in the meantime to avoid service disruption. </para>
-        <para>
-          The device shall ensure to renew the configuration before the expiration provided by the <literal>expiresAt</literal> field.
-          If the renewal endpoint fails to provide a valid response, the device shall continue to use the existing configuration and retry
-          later using an exponential backoff strategy.
-        </para>
+          endpoint to get up-to-date renewal configuration payload including credentials. The device
+          may use the current credentials available in the configuration in the meantime to avoid
+          service disruption. </para>
+        <para> The device shall ensure to renew the configuration including credentials before the
+          expiration provided by the <literal>expiresAt</literal> field. If the renewal endpoint
+          fails to provide a valid response, the device shall continue to use the existing
+          configuration and retry later using an exponential backoff strategy. </para>
       </section>
       <section>
         <title>GetStorageConfigurations</title>

--- a/wsdl/ver10/actionengine.wsdl
+++ b/wsdl/ver10/actionengine.wsdl
@@ -809,7 +809,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					</xs:element>
 					<xs:element name="FtpAuthentication" type="tae:FtpAuthenticationConfiguration">
 						<xs:annotation>
-							<xs:documentation>User credentials confguration for target FTP Server</xs:documentation>
+							<xs:documentation>User credentials configuration for target FTP Server</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="Extension" type="tae:FtpDestinationConfigurationExtension" minOccurs="0"/>


### PR DESCRIPTION
Ref: https://github.com/onvif/wg_profile_cloud/issues/134

1. Current text in Renewal configuration is stressing on credentials though the response from renewal endpoint includes more data like region and storage uri, hence the requirement text is clarified a bit.
2. Removed a sentence that is causing ambiguity while similar requirement is already explained as quoted below
>The device shall ensure to renew the configuration before the expiration provided by the expiresAt field.