### PR TITLE
Deprecated PKCS8 and PasswordBasedMACAlgorithms cleanup

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -5924,6 +5924,14 @@ Accept: application/sdp]]></programlisting>
             </row>
             <row>
               <entry>
+                <para>PKCS8</para>
+              </entry>
+              <entry>
+                <para>deprecated</para>
+              </entry>
+            </row>
+            <row>
+              <entry>
                 <para>PKCS8RSAKeyPairUpload</para>
               </entry>
               <entry>
@@ -5956,7 +5964,9 @@ Accept: application/sdp]]></programlisting>
             </row>
             <row>
               <entry><para>PasswordBasedMACAlgorithms</para></entry>
-              <entry/>
+              <entry>
+                <para>deprecated</para>
+              </entry>
             </row>
           </tbody>
         </tgroup>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -5927,7 +5927,7 @@ Accept: application/sdp]]></programlisting>
                 <para>PKCS8</para>
               </entry>
               <entry>
-                <para>deprecated</para>
+                <para>None</para>
               </entry>
             </row>
             <row>
@@ -5935,7 +5935,7 @@ Accept: application/sdp]]></programlisting>
                 <para>PKCS8RSAKeyPairUpload</para>
               </entry>
               <entry>
-                <para>deprecated</para>
+                <para>None</para>
               </entry>
             </row>
             <row>
@@ -5965,7 +5965,7 @@ Accept: application/sdp]]></programlisting>
             <row>
               <entry><para>PasswordBasedMACAlgorithms</para></entry>
               <entry>
-                <para>deprecated</para>
+                <para>None</para>
               </entry>
             </row>
           </tbody>

--- a/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
+++ b/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
@@ -805,7 +805,7 @@
 				</xs:attribute>
 				<xs:attribute name="PKCS8" type="xs:boolean">
 					<xs:annotation>
-						<xs:documentation>Indicates support for uploading a key pair in a PKCS#8 data structure.</xs:documentation>
+						<xs:documentation>Deprecated - Indicates support for uploading a key pair in a PKCS#8 data structure.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:attribute name="PKCS12CertificateWithRSAPrivateKeyUpload" type="xs:boolean">
@@ -825,7 +825,7 @@
 				</xs:attribute>
 				<xs:attribute name="PasswordBasedMACAlgorithms" type="tas:PasswordBasedMACAlgorithms">
 					<xs:annotation>
-						<xs:documentation>Indicates which password-based MAC algorithms are supported by the device.</xs:documentation>
+						<xs:documentation>Deprecated - Indicates which password-based MAC algorithms are supported by the device.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<!-- ========================================= -->


### PR DESCRIPTION
- Feature missed to be marked deprecated, though its related feature and associated interfaces are deprecated.
  - PKCS8RSAKeyPairUpload- capability deprecated
  - UploadKeyPairInPKCS8 - interface deprecated
  - PKCS8 capability **- NOT marked deprecated**

-PasswordBasedMACAlgorithms
  - **Not marked** deprecated in WSDL
  - Marked deprecated in spec