### PR TITLE
Profile configuration in connect can affect invite response subprotocols list

### DIFF
--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -595,7 +595,7 @@
       <para>The dynamics and the format of the SDP records shall be according to RFC 8829 section 5.2 and 5.3.</para>
       <para>Note that since supporting trickle is mandatory the SDP offer / answer shall include the SDP attribute "ice-options:trickle".</para>
       <para>Usage of WebRTC data channels is specified in section <xref linkend="section_data_channels"/>.</para>
-        <para>'subprotocols' list included in Invite response from the device may vary depending on
+      <para>'subprotocols' list included in Invite response from the device may vary depending on
           the Profile configuration identified via profile token sent in <xref
             linkend="section_connect_device"/> request.</para>
       <variablelist role="op">

--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -595,6 +595,9 @@
       <para>The dynamics and the format of the SDP records shall be according to RFC 8829 section 5.2 and 5.3.</para>
       <para>Note that since supporting trickle is mandatory the SDP offer / answer shall include the SDP attribute "ice-options:trickle".</para>
       <para>Usage of WebRTC data channels is specified in section <xref linkend="section_data_channels"/>.</para>
+        <para>'subprotocols' list included in Invite response from the device may vary depending on
+          the Profile configuration identified via profile token sent in <xref
+            linkend="section_connect_device"/> request.</para>
       <variablelist role="op">
         <varlistentry>
           <term>request</term>


### PR DESCRIPTION
Ref: https://github.com/onvif/wg_profile_cloud/issues/136
  - Ref: https://github.com/onvif/wg_profile_cloud/issues/136#issuecomment-3890035571
 
Based on the discussion, added a clarification that profile token sent in the connect request can affect the invite response subprotocols list

**Examples**

- If connect includes profile token that does not include metadata configuration, subprotocols list in invite response may be empty.

- If connect includes profile token that include metadata configuration and subprotocols list in invite response may be include 'vnd.onvif.metadata+gzip' 