### PR TITLE
add capability to signal internal storage support

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -412,12 +412,11 @@ Change Request 2061, 2063, 2065, 2109</revremark>
           The target interface allows configuration for devices that support recording to external storage targets.
           For authentication configuration see the related storage configuration APIs of the core specification.
         </para>
-        <para>
-          The target API defines for each recording a path on the storage device where the related recordings should be stored.
-          In order to keep reasonably sized files the recordings are split into segments.
-          This specification defines a date and time based index.
-          Indexing according to events and video content is outside of the scope of this specification.
-        </para>
+        <para> The target format structure defines for each recording a path on the storage target
+          where the related recordings should be stored. In order to keep reasonably sized files the
+          recordings are split into segments. This specification defines a date and time based
+          index. Indexing according to events and video content is outside of the scope of this
+          specification. </para>
         <para>An encryption configuration interface allows to encrypt the content according to well defined standards.</para>
       </section>
     </section>
@@ -1713,6 +1712,12 @@ Change Request 2061, 2063, 2065, 2109</revremark>
           <term>AsymmetricEncryptionSupported</term>
           <listitem>
             <para>Indicates that the device supports asymmetric encryption.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>NoInternalStorage</term>
+          <listitem>
+            <para>Indicates that the device does not support local storage recording.</para>
           </listitem>
         </varlistentry>
       </variablelist>

--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -1715,9 +1715,9 @@ Change Request 2061, 2063, 2065, 2109</revremark>
           </listitem>
         </varlistentry>
         <varlistentry>
-          <term>NoInternalStorage</term>
+          <term>OnboardStorage</term>
           <listitem>
-            <para>Indicates that the device does not support local storage recording.</para>
+            <para>Indicates if the device supports recording to onboard storage, default value is true.</para>
           </listitem>
         </varlistentry>
       </variablelist>

--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -1717,7 +1717,9 @@ Change Request 2061, 2063, 2065, 2109</revremark>
         <varlistentry>
           <term>OnboardStorage</term>
           <listitem>
-            <para>Indicates if the device supports recording to onboard storage, default value is true.</para>
+            <para>Indicates if the device supports recording to onboard storage, default value is
+              true. </para>
+            <para>If false, device shall support recording to an external target.</para>
           </listitem>
         </varlistentry>
       </variablelist>

--- a/wsdl/ver10/recording.wsdl
+++ b/wsdl/ver10/recording.wsdl
@@ -153,10 +153,10 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
-				<xs:attribute name="NoInternalStorage" type="xs:boolean">
+				<xs:attribute name="OnboardStorage" type="xs:boolean" default="true">
 					<xs:annotation>
 						<xs:documentation>
-							Indicates if the device does not support local storage recording.
+							Indicates if the device supports recording to onboard storage, default value is true. If false, device shall support recording to an external target.
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>

--- a/wsdl/ver10/recording.wsdl
+++ b/wsdl/ver10/recording.wsdl
@@ -153,6 +153,13 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
+				<xs:attribute name="NoInternalStorage" type="xs:boolean">
+					<xs:annotation>
+						<xs:documentation>
+							Indicates if the device does not support local storage recording.
+						</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:complexType>
 			<xs:element name="Capabilities" type="trc:Capabilities"/>


### PR DESCRIPTION
https://github.com/onvif/wg_profile_cloud/issues/141

Added capability to signal NoInternalStorage to be able to differentiate below products

- Local-only recording
  - NoInternalStorage = false or absent, and SupportedTargetFormats absent/empty
- Local + external recording
  - NoInternalStorage = false or absent, and SupportedTargetFormats contains ≥ 1 value
- External-only recording
  - NoInternalStorage = true, and SupportedTargetFormats contains ≥ 1 value
- Invalid / inconsistent reporting
  - NoInternalStorage = true, and SupportedTargetFormats absent/empty
    - A device shall not report this combination.
   
I have only added capability for now, we should discuss further if we need to add any error codes or additional clarifications to be able to support Profile G + V devices, Profile G only, Profile V only devices.