### PR TITLE
Add pattern feature to PTZ service

### DIFF
--- a/doc/PTZ.xml
+++ b/doc/PTZ.xml
@@ -2295,12 +2295,8 @@ Add GeoMove</revremark>
               <para role="text">The requested profile token does not reference a PTZ configuration.</para>
               <para role="param">env:Sender - ter:InvalidArgVal - ter:<phrase>InvalidPattern</phrase></para>
               <para role="text">The requested Pattern includes invalid parameter(s).</para>
-              <para role="param">env:Sender - ter:InvalidArgVal - ter:TooManyPresets</para>
-              <para role="text">Too many TourSpots are included in the Pattern.</para>
               <para role="param">env:Sender - ter:InvalidArgVal - ter:NoToken</para>
               <para role="text">The requested pattern token does not exist.</para>
-              <para role="param">env:Sender - ter:InvalidArgVal - ter:SpaceNotSupported</para>
-              <para role="text">A space is referenced which is not supported by the PTZ node.</para>
             </listitem>
           </varlistentry>
           <varlistentry>
@@ -2311,10 +2307,89 @@ Add GeoMove</revremark>
           </varlistentry>
         </variablelist>
       </section>
-	  <!-- TODO Start and StopRecordingPattern -->
+	  <section>
+        <title>StartRecordingPattern</title>
+        <para>A device supporting patterns shall allow to start recording of a pattern through StartRecordingPattern.</para>
+        <variablelist role="op">
+          <varlistentry>
+            <term>request</term>
+            <listitem>
+              <para role="param">ProfileToken [tt:ReferenceToken]</para>
+              <para role="text">Reference to an existing media profile.</para>
+              <para role="param">Pattern [tt:PTZPattern]</para>
+              <para role="text">The pattern parameters to be set.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>response</term>
+            <listitem>
+              <para role="text">This is an empty message.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>faults</term>
+            <listitem>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoProfile</para>
+              <para role="text">The requested profile token does not exist.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoPTZProfile</para>
+              <para role="text">The requested profile token does not reference a PTZ configuration.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:<phrase>InvalidPattern</phrase></para>
+              <para role="text">The requested Pattern includes invalid parameter(s).</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoToken</para>
+              <para role="text">The requested pattern token does not exist.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>access class</term>
+            <listitem>
+              <para role="access">ACTUATE</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+      </section>
+      <section>
+        <title>StopRecordingPattern</title>
+        <para>A device supporting patterns shall allow to stop recording of a pattern through StopRecordingPattern.</para>
+        <variablelist role="op">
+          <varlistentry>
+            <term>request</term>
+            <listitem>
+              <para role="param">ProfileToken [tt:ReferenceToken]</para>
+              <para role="text">Reference to an existing media profile.</para>
+              <para role="param">Pattern [tt:PTZPattern]</para>
+              <para role="text">The pattern parameters to be set.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>response</term>
+            <listitem>
+              <para role="text">This is an empty message.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>faults</term>
+            <listitem>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoProfile</para>
+              <para role="text">The requested profile token does not exist.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoPTZProfile</para>
+              <para role="text">The requested profile token does not reference a PTZ configuration.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:<phrase>InvalidPattern</phrase></para>
+              <para role="text">The requested Pattern includes invalid parameter(s).</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoToken</para>
+              <para role="text">The requested pattern token does not exist.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>access class</term>
+            <listitem>
+              <para role="access">ACTUATE</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+      </section>
       <section>
         <title>OperatePattern</title>
-        <para>A device supporting patterns shall allow starting, stopping, or pausing a pattern through OperatePattern.</para>
+        <para>A device supporting patterns shall allow starting, stopping, or pausing a recorded pattern through OperatePattern.</para>
         <para>Pattern can be operated with the PatternOperation parameter of OperatePattern command. </para>
         <itemizedlist>
           <listitem>

--- a/doc/PTZ.xml
+++ b/doc/PTZ.xml
@@ -47,7 +47,7 @@
         <author>
           <personname>Takahiro Iwasaki</personname>
         </author>
-        <revremark>Addition of Pattern and PT Control Direction features
+        <revremark>Addition of Preset Tour and PT Control Direction features
 Change Request 648</revremark>
       </revision>
       <revision>
@@ -2118,7 +2118,7 @@ Add GeoMove</revremark>
       <title>Pattern Operations</title>
       <para>Pattern is a feature for PTZ-capable devices, enabling the PTZ unit to replay camera movements sequences.</para>
       <para>This section describes operations that manage the patterns. These operations shall be implemented when a PTZ node in the PTZ service indicates support of patterns with MaximumNumberOfPatterns&gt;0 capability value, All operations require a profile token referencing a Media Profile including a PTZConfiguration. All operations for patterns shall always be persistent.</para>
-      <para>TO BE DETERMINED - Patterns can have forward and backward directions, and in case direction is omitted, it is assumed to be forward.</para>
+      <para>Patterns can have forward and backward directions, and in case direction is omitted, it is assumed to be forward.</para>
       <section>
         <title>GetPatterns</title>
         <para>A device supporting Pattern feature shall return all available patterns through GetPatterns.</para>
@@ -2676,9 +2676,9 @@ tns1:PTZController/PTZPresets/Left
 ]]></programlisting>
       </section>
       <section>
-        <title>Preset Tours</title>
+        <title>PresetTours</title>
         <para>When a PTZ node in a device supporting the PTZ service indicates support of Preset Tour with MaximumNumberOfPresetTours greater than 0 capability value, the device shall support the following topic to inform subscribers about preset tour events. Whenever a change in Preset Tours occurs, the PTZ service shall dispatch this event:</para>
-        <programlisting><![CDATA[Topic: tns1:PTZController/PTZPresetTour/Configuration
+        <programlisting><![CDATA[Topic: tns1:PTZController/PTZPresetTours/Configuration
 <tt:MessageDescription isProperty=True>
   <tt:Source>
     <tt:SimpleItemDescriptionName="ProfileToken" Type="tt:ReferenceToken"/>
@@ -2690,7 +2690,7 @@ tns1:PTZController/PTZPresets/Left
   </tt:Data>
 </tt:MessageDescription>
 ]]></programlisting>
-        <para>Note, the StateChange flag in the data part becomes true when the mentioned Pattern includes any changes of its State.</para>
+        <para>Note, the StateChange flag in the data part becomes true when the mentioned Preset Tour includes any changes of its State.</para>
       </section>
       <section>
         <title>Patterns</title>

--- a/doc/PTZ.xml
+++ b/doc/PTZ.xml
@@ -2501,12 +2501,12 @@ Add GeoMove</revremark>
                 <para>Touring: Pattern is activated and now under touring.</para>
               </listitem>
               <listitem>
-                <para>Paused: Pattern is under pause at the middle of the tour by client. This status requires Start operation from a client to re-start.</para>
+                <para>Paused: Pattern is under pause at the middle of the recording by client. This status requires Start operation from a client to re-start.</para>
               </listitem>
             </itemizedlist>
           </listitem>
           <listitem>
-            <para>AutoStart: Flag to enable the pattern activated always. When this flag is set to True in a pattern, the device shall set the flags of all other patterns referring to the same PTZNode to False, so that only one tour on the device is marked as AutoStart. Starting and stopping the pattern by OperatePattern shall change this flag to False. Pausing and resuming the pattern by OperatePattern shall not change this flag.</para>
+            <para>AutoStart: Flag to enable the pattern activated always. When this flag is set to True in a pattern, the device shall set the flags of all other patterns referring to the same PTZNode to False, so that only one pattern on the device is marked as AutoStart. Starting and stopping the pattern by OperatePattern shall change this flag to False. Pausing and resuming the pattern by OperatePattern shall not change this flag.</para>
           </listitem>
           <listitem>
             <para>PatternStartingCondition: Configuration of the starting pattern. </para>

--- a/doc/PTZ.xml
+++ b/doc/PTZ.xml
@@ -47,7 +47,7 @@
         <author>
           <personname>Takahiro Iwasaki</personname>
         </author>
-        <revremark>Addition of Preset Tour and PT Control Direction features
+        <revremark>Addition of Pattern and PT Control Direction features
 Change Request 648</revremark>
       </revision>
       <revision>
@@ -420,6 +420,9 @@ Add GeoMove</revremark>
           <listitem>
             <para>MaximumNumberOfPresetTours – Indicates number of preset tours that can be created. Required preset tour operations shall be available for this PTZ node if one or more preset tours are supported.</para>
           </listitem>
+		  <listitem>
+            <para>MaximumNumberOfPatterns – Indicates number of patterns that can be created. Required pattern operations shall be available for this PTZ node if one or more patterns are supported.</para>
+          </listitem>
         </itemizedlist>
       </section>
       <section>
@@ -538,6 +541,9 @@ Add GeoMove</revremark>
           </listitem>
           <listitem>
             <para>PresetTourRamp – The optional acceleration ramp used by the device when executing PresetTours.</para>
+          </listitem>
+		  <listitem>
+            <para>PatternRamp – The optional acceleration ramp used by the device when executing patterns.</para>
           </listitem>
         </itemizedlist>
         <para>The default position/translation/velocity spaces are introduced to allow clients sending move requests without the need to specify a certain coordinate system. The default speeds are introduced to control the speed of move requests (absolute, relative, preset), where no explicit speed has been set.</para>
@@ -1734,7 +1740,7 @@ Add GeoMove</revremark>
     </section>
     <section>
       <title>Preset Tour Operations</title>
-      <para>Preset tour is a feature for PTZ-capable devices, enabling the PTZ unit to move on specified presets sequentially at some  interval.</para>
+      <para>Preset tour is a feature for PTZ-capable devices, enabling the PTZ unit to move on specified presets sequentially at some interval.</para>
       <para>This section describes operations that manage the preset tours. These operations shall be implemented when a PTZ node in the PTZ service indicates support of preset tours with MaximumNumberOfPresetTours&gt;0 capability value, All operations require a profile token referencing a Media Profile including a PTZConfiguration. All operations for preset tours shall always be persistent.</para>
       <para>PresetTours can have forward and backward directions, and in case direction is omitted, it is assumed to be forward. However, it is possible to specify random execution by setting the RandomPresetOrder attribute. In case RandomPresetOrder is set to true and Direction is also present, Direction will be ignored and presets of the Tour will be recalled randomly.</para>
       <section>
@@ -1941,7 +1947,7 @@ Add GeoMove</revremark>
             <para>Stop: indicates stopping the preset tour.</para>
           </listitem>
           <listitem>
-            <para>Pause:iIndicates pausing the preset tour.</para>
+            <para>Pause: indicates pausing the preset tour.</para>
           </listitem>
         </itemizedlist>
         <para>When receiving another OperatePresetTour command of Start operation for a preset tour which has already been started, the preset tour shall be restarted with the newly requested parameter.</para>
@@ -1988,7 +1994,7 @@ Add GeoMove</revremark>
       </section>
       <section>
         <title>RemovePresetTour</title>
-        <para>A device supporting preset tours shall support removing preset tours through RemoevPresetTour.</para>
+        <para>A device supporting preset tours shall support removing preset tours through RemovePresetTour.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>
@@ -2109,6 +2115,358 @@ Add GeoMove</revremark>
       </section>
     </section>
     <section>
+      <title>Pattern Operations</title>
+      <para>Pattern is a feature for PTZ-capable devices, enabling the PTZ unit to replay camera movements sequences.</para>
+      <para>This section describes operations that manage the patterns. These operations shall be implemented when a PTZ node in the PTZ service indicates support of patterns with MaximumNumberOfPatterns&gt;0 capability value, All operations require a profile token referencing a Media Profile including a PTZConfiguration. All operations for patterns shall always be persistent.</para>
+      <para>TO BE DETERMINED - Patterns can have forward and backward directions, and in case direction is omitted, it is assumed to be forward.</para>
+      <section>
+        <title>GetPatterns</title>
+        <para>A device supporting Pattern feature shall return all available patterns through GetPatterns.</para>
+        <variablelist role="op">
+          <varlistentry>
+            <term>request</term>
+            <listitem>
+              <para role="param">ProfileToken [tt:ReferenceToken]</para>
+              <para role="text">Reference to an existing media profile.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>response</term>
+            <listitem>
+              <para role="param">Pattern - optional, unbounded [tt:PTZPattern]</para>
+              <para role="text">List of patterns defined for the requested MediaProfile.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>faults</term>
+            <listitem>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoProfile</para>
+              <para role="text">The requested profile token ProfileToken does not exist.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoPTZProfile</para>
+              <para role="text">The requested profile token does not reference a PTZ configuration.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>access class</term>
+            <listitem>
+              <para role="access">READ_MEDIA</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+      </section>
+      <section>
+        <title>GetPattern</title>
+        <para>A device supporting patterns shall return the requested pattern through GetPattern.</para>
+        <variablelist role="op">
+          <varlistentry>
+            <term>request</term>
+            <listitem>
+              <para role="param">ProfileToken [tt:ReferenceToken]</para>
+              <para role="text">Reference to an existing media profile.</para>
+              <para role="param">PatternToken [tt:ReferenceToken]</para>
+              <para role="text">Reference to an existing pattern.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>response</term>
+            <listitem>
+              <para role="param">Pattern [tt:PTZPattern]</para>
+              <para role="text">The requested pattern.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>faults</term>
+            <listitem>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoProfile</para>
+              <para role="text">The requested profile token does not exist.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoPTZProfile</para>
+              <para role="text">The requested profile token does not reference a PTZ configuration.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoToken</para>
+              <para role="text">The requested pattern token does not exist.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>access class</term>
+            <listitem>
+              <para role="access">READ_MEDIA</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+      </section>
+      <section>
+        <title>GetPatternOptions</title>
+        <para>A device supporting patterns shall provide options for how patterns can be configured through GetPatternOptions.</para>
+        <variablelist role="op">
+          <varlistentry>
+            <term>request</term>
+            <listitem>
+              <para role="param">ProfileToken [tt:ReferenceToken]</para>
+              <para role="text">Reference to an existing media profile.</para>
+              <para role="param">PatternToken - optional [tt:ReferenceToken]</para>
+              <para role="text">Optional reference to an existing pattern.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>response</term>
+            <listitem>
+              <para role="param">Pattern [tt:PTZPatternOptions]</para>
+              <para role="text">The requested pattern options.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>faults</term>
+            <listitem>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoProfile</para>
+              <para role="text">The requested profile token does not exist.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoPTZProfile</para>
+              <para role="text">The requested profile token does not reference a PTZ configuration.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>access class</term>
+            <listitem>
+              <para role="access">READ_MEDIA</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+      </section>
+      <section>
+        <title>CreatePattern</title>
+        <para>A device supporting Pattern feature shall allow creating a new Pattern through the CreatePattern.</para>
+        <variablelist role="op">
+          <varlistentry>
+            <term>request</term>
+            <listitem>
+              <para role="param">ProfileToken [tt:ReferenceToken]</para>
+              <para role="text">Reference to an existing media profile.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>response</term>
+            <listitem>
+              <para role="param">PatternToken [tt:ReferenceToken]</para>
+              <para role="text">Reference to an existing pattern.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>faults</term>
+            <listitem>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoProfile</para>
+              <para role="text">The requested profile token ProfileToken does not exist.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoPTZProfile</para>
+              <para role="text">The requested profile token does not reference a PTZ configuration.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:TooManyPatterns</para>
+              <para role="text">There is not enough space in the device to create the new pattern for the profile</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>access class</term>
+            <listitem>
+              <para role="access">ACTUATE</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+      </section>
+      <section>
+        <title>ModifyPattern</title>
+        <para>A device supporting patterns shall allow modifying a pattern through ModifyPattern.</para>
+        <variablelist role="op">
+          <varlistentry>
+            <term>request</term>
+            <listitem>
+              <para role="param">ProfileToken [tt:ReferenceToken]</para>
+              <para role="text">Reference to an existing media profile.</para>
+              <para role="param">Pattern [tt:PTZPattern]</para>
+              <para role="text">The pattern parameters to be set.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>response</term>
+            <listitem>
+              <para role="text">This is an empty message.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>faults</term>
+            <listitem>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoProfile</para>
+              <para role="text">The requested profile token does not exist.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoPTZProfile</para>
+              <para role="text">The requested profile token does not reference a PTZ configuration.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:<phrase>InvalidPattern</phrase></para>
+              <para role="text">The requested Pattern includes invalid parameter(s).</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:TooManyPresets</para>
+              <para role="text">Too many TourSpots are included in the Pattern.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoToken</para>
+              <para role="text">The requested pattern token does not exist.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:SpaceNotSupported</para>
+              <para role="text">A space is referenced which is not supported by the PTZ node.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>access class</term>
+            <listitem>
+              <para role="access">ACTUATE</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+      </section>
+	  <!-- TODO Start and StopRecordingPattern -->
+      <section>
+        <title>OperatePattern</title>
+        <para>A device supporting patterns shall allow starting, stopping, or pausing a pattern through OperatePattern.</para>
+        <para>Pattern can be operated with the PatternOperation parameter of OperatePattern command. </para>
+        <itemizedlist>
+          <listitem>
+            <para>Start: indicates starting the pattern or re-starting the paused pattern. </para>
+          </listitem>
+          <listitem>
+            <para>Stop: indicates stopping the pattern.</para>
+          </listitem>
+          <listitem>
+            <para>Pause: indicates pausing the pattern.</para>
+          </listitem>
+        </itemizedlist>
+        <para>When receiving another OperatePattern command of Start operation for a pattern which has already been started, the pattern shall be restarted with the newly requested parameter.</para>
+        <variablelist role="op">
+          <varlistentry>
+            <term>request</term>
+            <listitem>
+              <para role="param">ProfileToken [tt:ReferenceToken]</para>
+              <para role="text">Reference to an existing media profile.</para>
+              <para role="param">PatternToken [tt:PTZPatternToken]</para>
+              <para role="text">Reference to an existing pattern.</para>
+              <para role="param">Operation [tt:PTZPatternOperation]</para>
+              <para role="text">Operation information.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>response</term>
+            <listitem>
+              <para role="text">This is an empty message.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>faults</term>
+            <listitem>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoProfile</para>
+              <para role="text">The requested profile token does not exist.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoPTZProfile</para>
+              <para role="text">The requested profile token does not reference a PTZ configuration.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoToken</para>
+              <para role="text">The requested pattern token does not exist.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:<phrase>InvalidPattern</phrase></para>
+              <para role="text">The requested Pattern includes invalid parameter(s).</para>
+              <para role="param">env:Receiver - ter:InvalidArgVal - ter:ActivationFailed</para>
+              <para role="text">The requested pattern cannot be activated while PTZ unit is moving or another pattern is now activated.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>access class</term>
+            <listitem>
+              <para role="access">ACTUATE</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+      </section>
+      <section>
+        <title>RemovePattern</title>
+        <para>A device supporting patterns shall support removing patterns through RemovePattern.</para>
+        <variablelist role="op">
+          <varlistentry>
+            <term>request</term>
+            <listitem>
+              <para role="param">ProfileToken [tt:ReferenceToken]</para>
+              <para role="text">Reference to an existing media profile.</para>
+              <para role="param">PatternToken [tt:PTZPatternToken]</para>
+              <para role="text">Reference to an existing pattern.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>response</term>
+            <listitem>
+              <para role="text">This is an empty message.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>faults</term>
+            <listitem>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoProfile</para>
+              <para role="text">The requested profile token ProfileToken does not exist.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoPTZProfile</para>
+              <para role="text">The requested profile token does not reference a PTZ configuration.</para>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoToken</para>
+              <para role="text">The requested pattern token does not exist.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>access class</term>
+            <listitem>
+              <para role="access">ACTUATE</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+      </section>
+      <section>
+        <title>Pattern parameters</title>
+        <para>A pattern is composed of following parameters:</para>
+        <para>
+          <emphasis role="bold">Pattern</emphasis>: Configuration of a pattern.</para>
+        <itemizedlist>
+          <listitem>
+            <para>Name: Name of the pattern [Optional]</para>
+          </listitem>
+          <listitem>
+            <para>Status: Indicates the current status of the pattern. This parameter in the argument of the ModifyPattern command shall be ignored.</para>
+            <itemizedlist>
+              <listitem>
+                <para>Idle: Pattern is not activated.</para>
+              </listitem>
+              <listitem>
+                <para>Touring: Pattern is activated and now under touring.</para>
+              </listitem>
+              <listitem>
+                <para>Paused: Pattern is under pause at the middle of the tour by client. This status requires Start operation from a client to re-start.</para>
+              </listitem>
+            </itemizedlist>
+          </listitem>
+          <listitem>
+            <para>AutoStart: Flag to enable the pattern activated always. When this flag is set to True in a pattern, the device shall set the flags of all other patterns referring to the same PTZNode to False, so that only one tour on the device is marked as AutoStart. Starting and stopping the pattern by OperatePattern shall change this flag to False. Pausing and resuming the pattern by OperatePattern shall not change this flag.</para>
+          </listitem>
+          <listitem>
+            <para>PatternStartingCondition: Configuration of the starting pattern. </para>
+            <itemizedlist>
+              <listitem>
+                <para>RecurringTime: Parameter to specify how many times the pattern is recurred. [Optional]</para>
+              </listitem>
+              <listitem>
+                <para>RecurringDuration: Parameter to specify how long duration time the pattern is recurred [Optional]</para>
+                <itemizedlist>
+                  <listitem>
+                    <para>If both conditions RecurringTime and RecurringDuration are configured, the pattern shall finish with one of the conditions satisfied earlier. If both are omitted, Pattern shall be recurred without limitation.</para>
+                  </listitem>
+                </itemizedlist>
+              </listitem>
+              <listitem>
+                <para>PatternDirection: A device refers this flag to choose which direction the pattern goes. It is omissible parameter and Forward shall be chosen in case it is omitted. [Optional] </para>
+                <itemizedlist>
+                  <listitem>
+                    <para>Forward: Pattern goes in forward order.</para>
+                  </listitem>
+                  <listitem>
+                    <para>Backward: Pattern goes in backward order.</para>
+                  </listitem>
+                </itemizedlist>
+              </listitem>
+            </itemizedlist>
+          </listitem>
+          <listitem>
+            <para>Token: Unique identifier of the pattern</para>
+          </listitem>
+        </itemizedlist>
+      </section>
+    </section>
+	<section>
       <title>Pan/tilt control direction configuration</title>
       <para>Pan/tilt control direction configuration is one set of parameters in PTZ configuration used to configure the movement directions of pan and tilt in the two following ways:</para>
       <orderedlist>
@@ -2243,9 +2601,9 @@ tns1:PTZController/PTZPresets/Left
 ]]></programlisting>
       </section>
       <section>
-        <title>PresetTours</title>
+        <title>Preset Tours</title>
         <para>When a PTZ node in a device supporting the PTZ service indicates support of Preset Tour with MaximumNumberOfPresetTours greater than 0 capability value, the device shall support the following topic to inform subscribers about preset tour events. Whenever a change in Preset Tours occurs, the PTZ service shall dispatch this event:</para>
-        <programlisting><![CDATA[Topic: tns1:PTZController/PTZPresetTours/Configuration
+        <programlisting><![CDATA[Topic: tns1:PTZController/PTZPresetTour/Configuration
 <tt:MessageDescription isProperty=True>
   <tt:Source>
     <tt:SimpleItemDescriptionName="ProfileToken" Type="tt:ReferenceToken"/>
@@ -2257,7 +2615,24 @@ tns1:PTZController/PTZPresets/Left
   </tt:Data>
 </tt:MessageDescription>
 ]]></programlisting>
-        <para>Note, the StateChange flag in the data part becomes true when the mentioned Preset Tour includes any changes of its State.</para>
+        <para>Note, the StateChange flag in the data part becomes true when the mentioned Pattern includes any changes of its State.</para>
+      </section>
+      <section>
+        <title>Patterns</title>
+        <para>When a PTZ node in a device supporting the PTZ service indicates support of Pattern with MaximumNumberOfPatterns greater than 0 capability value, the device shall support the following topic to inform subscribers about pattern events. Whenever a change in Patterns occurs, the PTZ service shall dispatch this event:</para>
+        <programlisting><![CDATA[Topic: tns1:PTZController/PTZPatterns/Configuration
+<tt:MessageDescription isProperty=True>
+  <tt:Source>
+    <tt:SimpleItemDescriptionName="ProfileToken" Type="tt:ReferenceToken"/>
+    <tt:SimpleItemDescriptionName="PatternToken" Type="tt:ReferenceToken"/>
+  </tt:Source>
+  <tt:Data>
+    <tt:SimpleItemDescriptionName="StateChange" Type="xs:boolean"/>
+    <tt:ElementItemDescription Name="Pattern" Type="tt:PTZPattern"/>
+  </tt:Data>
+</tt:MessageDescription>
+]]></programlisting>
+        <para>Note, the StateChange flag in the data part becomes true when the mentioned Pattern includes any changes of its State.</para>
       </section>
     </section>
   </chapter>

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -4554,7 +4554,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			<xs:element name="SupportedPattern" type="tt:PTZPatternSupported" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>
-						Detail of supported Preset Tour feature.
+						Detail of supported Pattern feature.
 					</xs:documentation>
 				</xs:annotation>
 			</xs:element>
@@ -4593,7 +4593,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 	<!--===============================-->
 	<xs:complexType name="PTZPatternSupported">
 		<xs:sequence>
-			<xs:element name="MaximumNumberOfPattern" type="xs:int">
+			<xs:element name="MaximumNumberOfPatterns" type="xs:int">
 				<xs:annotation>
 					<xs:documentation>Indicates number of patterns that can be created. Required pattern operations shall be available for this PTZ Node if one or more pattern is supported.</xs:documentation>
 				</xs:annotation>

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -4551,6 +4551,13 @@ decoding .A decoder shall decode every data it receives (according to its capabi
           </xs:documentation>
 				</xs:annotation>
 			</xs:element>
+			<xs:element name="SupportedPattern" type="tt:PTZPatternSupported" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						Detail of supported Preset Tour feature.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="Extension" type="tt:PTZNodeExtension2" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
@@ -4579,6 +4586,29 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 	</xs:complexType>
 	<!--===============================-->
 	<xs:complexType name="PTZPresetTourSupportedExtension">
+		<xs:sequence>
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
+		</xs:sequence>
+	</xs:complexType>
+	<!--===============================-->
+	<xs:complexType name="PTZPatternSupported">
+		<xs:sequence>
+			<xs:element name="MaximumNumberOfPattern" type="xs:int">
+				<xs:annotation>
+					<xs:documentation>Indicates number of patterns that can be created. Required pattern operations shall be available for this PTZ Node if one or more pattern is supported.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PTZPatternOperation" type="tt:PTZPatternOperation" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Indicates which pattern operations are available for this PTZ Node.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Extension" type="tt:PTZPatternSupportedExtension" minOccurs="0"/>
+		</xs:sequence>
+		<xs:anyAttribute processContents="lax"/>
+	</xs:complexType>
+	<!--===============================-->
+	<xs:complexType name="PTZPatternSupportedExtension">
 		<xs:sequence>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
 		</xs:sequence>
@@ -5368,6 +5398,161 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			<xs:enumeration value="ObjectID"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<!--===============================-->
+	<xs:simpleType name="PTZPatternState">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Idle"/>
+			<xs:enumeration value="Touring"/>
+			<xs:enumeration value="Paused"/>
+			<xs:enumeration value="Extended"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--===============================-->
+	<xs:simpleType name="PTZPatternDirection">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Forward"/>
+			<xs:enumeration value="Backward"/>
+			<xs:enumeration value="Extended"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--===============================-->
+	<xs:simpleType name="PTZPatternOperation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Start"/>
+			<xs:enumeration value="Stop"/>
+			<xs:enumeration value="Pause"/>
+			<xs:enumeration value="Extended"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--===============================-->
+	<xs:complexType name="PTZPattern">
+		<xs:sequence>
+			<xs:element name="Name" type="tt:Name" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Readable name of the pattern.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Status" type="tt:PTZPatternStatus">
+				<xs:annotation>
+					<xs:documentation>Read only parameters to indicate the status of the pattern.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AutoStart" type="xs:boolean">
+				<xs:annotation>
+					<xs:documentation>Auto Start flag of the pattern. True allows the pattern to be activated always.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="StartingCondition" type="tt:PTZPatternStartingCondition">
+				<xs:annotation>
+					<xs:documentation>Parameters to specify the detail behavior of the pattern.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Extension" type="tt:PTZPatternExtension" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="token" type="tt:ReferenceToken">
+			<xs:annotation>
+				<xs:documentation>Unique identifier of this pattern.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:anyAttribute processContents="lax"/>
+	</xs:complexType>
+	<!--===============================-->
+	<xs:complexType name="PTZPatternExtension">
+		<xs:sequence>
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
+		</xs:sequence>
+	</xs:complexType>
+	<!--===============================-->
+	<xs:complexType name="PTZPatternStatus">
+		<xs:sequence>
+			<xs:element name="State" type="tt:PTZPatternState">
+				<xs:annotation>
+					<xs:documentation>Indicates state of this pattern by Idle/Touring/Paused.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Extension" type="tt:PTZPatternStatusExtension" minOccurs="0"/>
+		</xs:sequence>
+		<xs:anyAttribute processContents="lax"/>
+	</xs:complexType>
+	<!--===============================-->
+	<xs:complexType name="PTZPatternStatusExtension">
+		<xs:sequence>
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
+		</xs:sequence>
+	</xs:complexType>
+	<!--===============================-->
+	<xs:complexType name="PTZPatternStartingCondition">
+		<xs:sequence>
+			<xs:element name="RecurringTime" type="xs:int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Optional parameter to specify how many times the pattern is recurred.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="RecurringDuration" type="xs:duration" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Optional parameter to specify how long time duration the pattern is recurred.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Direction" type="tt:PTZPatternDirection" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Optional parameter to choose which direction the pattern goes. Forward shall be chosen in case it is omitted.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Extension" type="tt:PTZPatternStartingConditionExtension" minOccurs="0"/>
+		</xs:sequence>
+		<xs:anyAttribute processContents="lax"/>
+	</xs:complexType>
+	<!--===============================-->
+	<xs:complexType name="PTZPatternStartingConditionExtension">
+		<xs:sequence>
+			<xs:any namespace="##targetNamespace" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--===============================-->
+	<xs:complexType name="PTZPatternOptions">
+		<xs:sequence>
+			<xs:element name="AutoStart" type="xs:boolean">
+				<xs:annotation>
+					<xs:documentation>Indicates whether or not the AutoStart is supported.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="StartingCondition" type="tt:PTZPatternStartingConditionOptions">
+				<xs:annotation>
+					<xs:documentation>Supported options for Pattern Starting Condition.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
+		</xs:sequence>
+		<xs:anyAttribute processContents="lax"/>
+	</xs:complexType>
+	<!--===============================-->
+	<xs:complexType name="PTZPatternStartingConditionOptions">
+		<xs:sequence>
+			<xs:element name="RecurringTime" type="tt:IntRange" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Supported range of Recurring Time.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="RecurringDuration" type="tt:DurationRange" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Supported range of Recurring Duration.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Direction" type="tt:PTZPatternDirection" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Supported options for Direction of Pattern.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Extension" type="tt:PTZPatternStartingConditionOptionsExtension" minOccurs="0"/>
+		</xs:sequence>
+		<xs:anyAttribute processContents="lax"/>
+	</xs:complexType>
+	<!--===============================-->
+	<xs:complexType name="PTZPatternStartingConditionOptionsExtension">
+		<xs:sequence>
+			<xs:any namespace="##targetNamespace" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
 	<!--===============================-->
 	<!--     End, PTZ Related Types    -->
 	<!--===============================-->

--- a/wsdl/ver20/ptz/wsdl/ptz.wsdl
+++ b/wsdl/ver20/ptz/wsdl/ptz.wsdl
@@ -677,6 +677,139 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:complexType>
 			</xs:element>
 			<!--===============================-->
+			<xs:element name="GetPatterns">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ProfileToken" type="tt:ReferenceToken"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="GetPatternsResponse">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Pattern" type="tt:PTZPattern" minOccurs="0" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<!--===============================-->
+			<xs:element name="GetPattern">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ProfileToken" type="tt:ReferenceToken"/>
+						<xs:element name="PatternToken" type="tt:ReferenceToken"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="GetPatternResponse">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Pattern" type="tt:PTZPattern"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<!--===============================-->
+			<xs:element name="GetPatternOptions">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ProfileToken" type="tt:ReferenceToken"/>
+						<xs:element name="PatternToken" type="tt:ReferenceToken" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="GetPatternOptionsResponse">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Options" type="tt:PTZPatternOptions"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<!--===============================-->
+			<xs:element name="CreatePattern">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ProfileToken" type="tt:ReferenceToken"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="CreatePatternResponse">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="PatternToken" type="tt:ReferenceToken"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<!--===============================-->
+			<xs:element name="ModifyPattern">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ProfileToken" type="tt:ReferenceToken"/>
+						<xs:element name="Pattern" type="tt:PTZPattern"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ModifyPatternResponse">
+				<xs:complexType>
+					<xs:sequence/>
+				</xs:complexType>
+			</xs:element>
+			<!--===============================-->
+			<xs:element name="StartRecordingPattern">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ProfileToken" type="tt:ReferenceToken"/>
+						<xs:element name="PatternToken" type="tt:ReferenceToken"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="StartRecordingPatternResponse">
+				<xs:complexType>
+					<xs:sequence/>
+				</xs:complexType>
+			</xs:element>
+			<!--===============================-->
+			<xs:element name="StopRecordingPatternPattern">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ProfileToken" type="tt:ReferenceToken"/>
+						<xs:element name="PatternToken" type="tt:ReferenceToken"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="StopRecordingPatternResponse">
+				<xs:complexType>
+					<xs:sequence/>
+				</xs:complexType>
+			</xs:element>
+			<!--===============================-->
+			<xs:element name="OperatePattern">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ProfileToken" type="tt:ReferenceToken"/>
+						<xs:element name="PatternToken" type="tt:ReferenceToken"/>
+						<xs:element name="Operation" type="tt:PTZPatternOperation"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="OperatePatternResponse">
+				<xs:complexType>
+					<xs:sequence/>
+				</xs:complexType>
+			</xs:element>
+			<!--===============================-->
+			<xs:element name="RemovePattern">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ProfileToken" type="tt:ReferenceToken"/>
+						<xs:element name="PatternToken" type="tt:ReferenceToken"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="RemovePatternResponse">
+				<xs:complexType>
+					<xs:sequence/>
+				</xs:complexType>
+			</xs:element>
+			<!--===============================-->
 			<xs:element name="GetCompatibleConfigurations">
 				<xs:complexType>
 					<xs:sequence>
@@ -913,6 +1046,60 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	</wsdl:message>
 	<wsdl:message name="RemovePresetTourResponse">
 		<wsdl:part name="parameters" element="tptz:RemovePresetTourResponse"/>
+	</wsdl:message>
+	<wsdl:message name="GetPatternsRequest">
+		<wsdl:part name="parameters" element="tptz:GetPatterns"/>
+	</wsdl:message>
+	<wsdl:message name="GetPatternsResponse">
+		<wsdl:part name="parameters" element="tptz:GetPatternsResponse"/>
+	</wsdl:message>
+	<wsdl:message name="GetPatternRequest">
+		<wsdl:part name="parameters" element="tptz:GetPattern"/>
+	</wsdl:message>
+	<wsdl:message name="GetPatternResponse">
+		<wsdl:part name="parameters" element="tptz:GetPatternResponse"/>
+	</wsdl:message>
+	<wsdl:message name="GetPatternOptionsRequest">
+		<wsdl:part name="parameters" element="tptz:GetPatternOptions"/>
+	</wsdl:message>
+	<wsdl:message name="GetPatternOptionsResponse">
+		<wsdl:part name="parameters" element="tptz:GetPatternOptionsResponse"/>
+	</wsdl:message>
+	<wsdl:message name="CreatePatternRequest">
+		<wsdl:part name="parameters" element="tptz:CreatePattern"/>
+	</wsdl:message>
+	<wsdl:message name="CreatePatternResponse">
+		<wsdl:part name="parameters" element="tptz:CreatePatternResponse"/>
+	</wsdl:message>
+	<wsdl:message name="ModifyPatternRequest">
+		<wsdl:part name="parameters" element="tptz:ModifyPattern"/>
+	</wsdl:message>
+	<wsdl:message name="ModifyPatternResponse">
+		<wsdl:part name="parameters" element="tptz:ModifyPatternResponse"/>
+	</wsdl:message>
+	<wsdl:message name="StartRecordingPatternRequest">
+		<wsdl:part name="parameters" element="tptz:StartRecordingPattern"/>
+	</wsdl:message>
+	<wsdl:message name="StartRecordingPatternResponse">
+		<wsdl:part name="parameters" element="tptz:StartRecordingPatternResponse"/>
+	</wsdl:message>
+	<wsdl:message name="StopRecordingPatternRequest">
+		<wsdl:part name="parameters" element="tptz:StopRecordingPattern"/>
+	</wsdl:message>
+	<wsdl:message name="StopRecordingPatternResponse">
+		<wsdl:part name="parameters" element="tptz:StopRecordingPatternResponse"/>
+	</wsdl:message>
+	<wsdl:message name="OperatePatternRequest">
+		<wsdl:part name="parameters" element="tptz:OperatePattern"/>
+	</wsdl:message>
+	<wsdl:message name="OperatePatternResponse">
+		<wsdl:part name="parameters" element="tptz:OperatePatternResponse"/>
+	</wsdl:message>
+	<wsdl:message name="RemovePatternRequest">
+		<wsdl:part name="parameters" element="tptz:RemovePattern"/>
+	</wsdl:message>
+	<wsdl:message name="RemovePatternResponse">
+		<wsdl:part name="parameters" element="tptz:RemovePatternResponse"/>
 	</wsdl:message>
 	<wsdl:message name="GetCompatibleConfigurationsRequest">
 		<wsdl:part name="parameters" element="tptz:GetCompatibleConfigurations"/>
@@ -1160,6 +1347,51 @@ If no stop argument for pan, tilt or zoom is set, the device will stop all ongoi
 			<wsdl:documentation>Operation to delete a specific preset tour from the media profile.</wsdl:documentation>
 			<wsdl:input message="tptz:RemovePresetTourRequest"/>
 			<wsdl:output message="tptz:RemovePresetTourResponse"/>
+		</wsdl:operation>
+		<wsdl:operation name="GetPatterns">
+			<wsdl:documentation>Operation to request PTZ patterns in the selected media profiles.</wsdl:documentation>
+			<wsdl:input message="tptz:GetPatternsRequest"/>
+			<wsdl:output message="tptz:GetPatternsResponse"/>
+		</wsdl:operation>
+		<wsdl:operation name="GetPattern">
+			<wsdl:documentation>Operation to request a specific PTZ pattern in the selected media profile.</wsdl:documentation>
+			<wsdl:input message="tptz:GetPatternRequest"/>
+			<wsdl:output message="tptz:GetPatternResponse"/>
+		</wsdl:operation>
+		<wsdl:operation name="GetPatternOptions">
+			<wsdl:documentation>Operation to request available options to configure PTZ patterns.</wsdl:documentation>
+			<wsdl:input message="tptz:GetPatternOptionsRequest"/>
+			<wsdl:output message="tptz:GetPatternOptionsResponse"/>
+		</wsdl:operation>
+		<wsdl:operation name="CreatePattern">
+			<wsdl:documentation>Operation to create a pattern for the selected media profile.</wsdl:documentation>
+			<wsdl:input message="tptz:CreatePatternRequest"/>
+			<wsdl:output message="tptz:CreatePatternResponse"/>
+		</wsdl:operation>
+		<wsdl:operation name="ModifyPattern">
+			<wsdl:documentation>Operation to modify a pattern for the selected media profile.</wsdl:documentation>
+			<wsdl:input message="tptz:ModifyPatternRequest"/>
+			<wsdl:output message="tptz:ModifyPatternResponse"/>
+		</wsdl:operation>
+		<wsdl:operation name="StartRecordingPattern">
+			<wsdl:documentation>Operation to start the recording of a pattern for the selected media profile.</wsdl:documentation>
+			<wsdl:input message="tptz:StartRecordingPatternRequest"/>
+			<wsdl:output message="tptz:StartRecordingPatternResponse"/>
+		</wsdl:operation>
+		<wsdl:operation name="StopRecordingPattern">
+			<wsdl:documentation>Operation to stop the recording of a pattern for the selected media profile.</wsdl:documentation>
+			<wsdl:input message="tptz:StopRecordingPatternRequest"/>
+			<wsdl:output message="tptz:StopRecordingPatternResponse"/>
+		</wsdl:operation>
+		<wsdl:operation name="OperatePattern">
+			<wsdl:documentation>Operation to perform specific operation on the pattern in selected media profile.</wsdl:documentation>
+			<wsdl:input message="tptz:OperatePatternRequest"/>
+			<wsdl:output message="tptz:OperatePatternResponse"/>
+		</wsdl:operation>
+		<wsdl:operation name="RemovePattern">
+			<wsdl:documentation>Operation to delete a specific pattern from the media profile.</wsdl:documentation>
+			<wsdl:input message="tptz:RemovePatternRequest"/>
+			<wsdl:output message="tptz:RemovePatternResponse"/>
 		</wsdl:operation>
 		<wsdl:operation name="GetCompatibleConfigurations">
 			<wsdl:documentation>Operation to get all available PTZConfigurations that can be added to the referenced media profile. <br/>
@@ -1419,6 +1651,87 @@ If no stop argument for pan, tilt or zoom is set, the device will stop all ongoi
 		</wsdl:operation>
 		<wsdl:operation name="RemovePresetTour">
 			<soap:operation soapAction="http://www.onvif.org/ver20/ptz/wsdl/RemovePresetTour"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="GetPatterns">
+			<soap:operation soapAction="http://www.onvif.org/ver20/ptz/wsdl/GetPatterns"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="GetPattern">
+			<soap:operation soapAction="http://www.onvif.org/ver20/ptz/wsdl/GetPattern"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="GetPatternOptions">
+			<soap:operation soapAction="http://www.onvif.org/ver20/ptz/wsdl/GetPatternOptions"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="CreatePattern">
+			<soap:operation soapAction="http://www.onvif.org/ver20/ptz/wsdl/CreatePattern"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="ModifyPattern">
+			<soap:operation soapAction="http://www.onvif.org/ver20/ptz/wsdl/ModifyPattern"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="StartRecordingPattern">
+			<soap:operation soapAction="http://www.onvif.org/ver20/ptz/wsdl/StartRecordingPattern"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="StopRecordingPattern">
+			<soap:operation soapAction="http://www.onvif.org/ver20/ptz/wsdl/StopRecordingPattern"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="OperatePattern">
+			<soap:operation soapAction="http://www.onvif.org/ver20/ptz/wsdl/OperatePattern"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="RemovePattern">
+			<soap:operation soapAction="http://www.onvif.org/ver20/ptz/wsdl/RemovePattern"/>
 			<wsdl:input>
 				<soap:body use="literal"/>
 			</wsdl:input>


### PR DESCRIPTION
Pattern is similar as preset tour but instead of a sequence of preset (fixed PTZ position), it records any PTZ moves.
In other words, it replays the PTZ commands that were executed by the client between the StartRecordingPattern and the StopRecordingPattern requests.