### PR TITLE
Clarify that the MaximumNumberOfKeys capability relates to private keys.

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -4825,7 +4825,7 @@
                   <para>MaximumNumberOfKeys</para>
                 </entry>
                 <entry>
-                  <para>Indicates the maximum number of keys that the device is able store
+                  <para>Indicates the maximum number of private keys that the device is able store
                     simultaneously.</para>
                 </entry>
               </row>


### PR DESCRIPTION
It wasn't clearly stated to which type of keys the capability MaximumNumberOfKeys refers to.
In the security specification the capability is only used as requirement for the ```GetKeyStatus``` method which is needed for private key generation. The related error ```ter:MaximumNumberOfKeysReached``` is only defined for methods creating or importing private keys

The above usage clearly indicates that the capability was intended for private keys.

Only usage found outside of the security configuration specification is the TLS Configuration Addon which requires support for both 16 certificates and 16 keys. 