### PR TITLE
Added optional qualifier for ABR element

### DIFF
--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -1144,7 +1144,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<xs:documentation>the maximum output bitrate in kbps</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="AverageBitRate" type="xs:int">
+			<xs:element name="AverageBitRate" type="xs:int" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>The target average output bitrate in kbps. If this parameter is set to 0, AverageBitRate shall be ignored.</xs:documentation>
 					<xs:documentation>If this parameter is configured beyond BitrateLimit, device adapts to BitrateLimit.</xs:documentation>


### PR DESCRIPTION
Fix for #742 
- added **minOccurs="0"** for the AverageBitRate element added under VideoRateControl2 structure.