### PR TITLE
Clarifications in Media Signing specification

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -412,12 +412,11 @@ Change Request 2061, 2063, 2065, 2109</revremark>
           The target interface allows configuration for devices that support recording to external storage targets.
           For authentication configuration see the related storage configuration APIs of the core specification.
         </para>
-        <para>
-          The target API defines for each recording a path on the storage device where the related recordings should be stored.
-          In order to keep reasonably sized files the recordings are split into segments.
-          This specification defines a date and time based index.
-          Indexing according to events and video content is outside of the scope of this specification.
-        </para>
+        <para> The target format structure defines for each recording a path on the storage target
+          where the related recordings should be stored. In order to keep reasonably sized files the
+          recordings are split into segments. This specification defines a date and time based
+          index. Indexing according to events and video content is outside of the scope of this
+          specification. </para>
         <para>An encryption configuration interface allows to encrypt the content according to well defined standards.</para>
       </section>
     </section>
@@ -1713,6 +1712,14 @@ Change Request 2061, 2063, 2065, 2109</revremark>
           <term>AsymmetricEncryptionSupported</term>
           <listitem>
             <para>Indicates that the device supports asymmetric encryption.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>OnboardStorage</term>
+          <listitem>
+            <para>Indicates if the device supports recording to onboard storage, default value is
+              true. </para>
+            <para>If false, device shall support recording to an external target.</para>
           </listitem>
         </varlistentry>
       </variablelist>

--- a/doc/SecurityBaseline.xml
+++ b/doc/SecurityBaseline.xml
@@ -75,6 +75,8 @@
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="http://www.ietf.org/rfc/rfc5280.txt"
       >http://www.ietf.org/rfc/rfc5280.txt</link>&gt;</para>
+    <para>RFC 5480 - Elliptic Curve Cryptography Subject Public Key Information</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc5480"/>&gt;</para>
     <para>RFC 5758 - Internet X.509 Public Key Infrastructure: Additional Algorithms and Identifiers for DSA and ECDSA</para>
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc5758"/>&gt;</para>
     <para>RFC 5869 - HMAC-based Extract-and-Expand Key Derivation Function (HKDF)</para>
@@ -83,6 +85,8 @@
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc7292"/>&gt;</para>
     <para>RFC 7714 - AES-GCM Authenticated Encryption in the Secure Real-time Transport Protocol (SRTP)</para>
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc7714"/>&gt;</para>
+    <para>RFC 7519 - JSON Web Token (JWT)</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc7519"/>&gt;</para>
     <para>RFC 8017 - PKCS #1: RSA Cryptography Specifications Version 2.2</para>
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc8017"/>&gt;</para>
     <para>RFC 8018 - PKCS #5: Password-Based Cryptography Specification Version 2.1</para>
@@ -91,6 +95,8 @@
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc8439"/>&gt;</para>
     <para>RFC 9579 - Use of Password-Based Message Authentication Code 1 (PBMAC1) in PKCS #12 Syntax</para>
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc9579"/>&gt;</para>
+    <para>ANSI X9.62 - Public Key Cryptography for the Financial Services Industry: The Elliptic Curve Digital Signature Algorithm (ECDSA)</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://webstore.ansi.org/standards/ascx9/ansix9622005"/>&gt;</para>
   </chapter>
   <chapter>
     <title>Definitions</title>
@@ -132,7 +138,7 @@
     <title>Overview</title>
     <para>The content of this document is based on state of the art technology as published by the American institute NIST and the German department BSI. 
       Note, that any updates to this specification require a review of implications on technical, profile and addon specifications.</para>
-    <para>Publication of updates must synchronized with ONVIF Technical and Technical Service Committee</para>
+    <para>Publication of updates must be synchronized with ONVIF Technical and Technical Service Committee</para>
   </chapter>
   <chapter>
     <title>Asymmetric Encryption Schemes and Key Agreement</title>
@@ -177,6 +183,62 @@
             <entry><para>secp384r1</para></entry>
             <entry><para>384 Bit</para></entry>
             <entry/>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+    <table xml:id="curveTable">
+      <title>Asymmetric Encryption Algorithm OIDs</title>
+      <tgroup cols="3">
+        <colspec colname="c1" colwidth="40*"/>
+        <colspec colname="c2" colwidth="30*"/>
+        <colspec colname="c3" colwidth="30*"/>
+        <thead>
+          <row>
+            <entry>
+              <para>Name</para>
+            </entry>
+            <entry>
+              <para>OID</para>
+            </entry>
+            <entry>
+              <para>Reference</para>
+            </entry>
+          </row>
+        </thead>
+        <tbody valign="top">
+          <row>
+            <entry>
+              <para>rsaEncryption</para>
+            </entry>
+            <entry>
+              <para>1.2.840.113549.1.1.1</para>
+            </entry>
+            <entry>
+              <para>RFC 8017</para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>secp256r1</para>
+            </entry>
+            <entry>
+              <para>1.2.840.10045.3.1.7</para>
+            </entry>
+            <entry>
+              <para>RFC 5480</para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>secp384r1</para>
+            </entry>
+            <entry>
+              <para>1.3.132.0.34</para>
+            </entry>
+            <entry>
+              <para>RFC 5480</para>
+            </entry>
           </row>
         </tbody>
       </tgroup>
@@ -246,15 +308,89 @@
             </entry>
             <entry><para>FIPS 180-4</para></entry>
           </row>
+          <row>
+            <entry>
+              <para>SHA-2</para>
+            </entry>
+            <entry>
+              <para>384 Bit</para>
+            </entry>
+            <entry><para>FIPS 180-4</para></entry>
+          </row>
+          <row>
+            <entry>
+              <para>SHA-2</para>
+            </entry>
+            <entry>
+              <para>512 Bit</para>
+            </entry>
+            <entry><para>FIPS 180-4</para></entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+    <table xml:id="hashOidTable">
+      <title>Standalone Hash Algorithm OIDs</title>
+      <tgroup cols="3">
+        <colspec colname="c1" colwidth="40*"/>
+        <colspec colname="c2" colwidth="30*"/>
+        <colspec colname="c3" colwidth="30*"/>
+        <thead>
+          <row>
+            <entry>
+              <para>Name</para>
+            </entry>
+            <entry>
+              <para>OID</para>
+            </entry>
+            <entry>
+              <para>Reference</para>
+            </entry>
+          </row>
+        </thead>
+        <tbody valign="top">
+          <row>
+            <entry>
+              <para>id-sha256</para>
+            </entry>
+            <entry>
+              <para>2.16.840.1.101.3.4.2.1</para>
+            </entry>
+            <entry>
+              <para>FIPS 180-4</para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>id-sha384</para>
+            </entry>
+            <entry>
+              <para>2.16.840.1.101.3.4.2.2</para>
+            </entry>
+            <entry>
+              <para>FIPS 180-4</para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>id-sha512</para>
+            </entry>
+            <entry>
+              <para>2.16.840.1.101.3.4.2.3</para>
+            </entry>
+            <entry>
+              <para>FIPS 180-4</para>
+            </entry>
+          </row>
         </tbody>
       </tgroup>
     </table>
   </chapter>
   <chapter>
     <title>Signatures</title>
-    <para/>
+    <para>This chapter defines the signature schemes and their corresponding algorithm OIDs that devices shall support.</para>
     <table xml:id="sigTable">
-      <title>Signatures</title>
+      <title>Signature Schemes</title>
       <tgroup cols="3">
         <colspec colname="c1" colwidth="52*"/>
         <colspec colname="c2" colwidth="12*"/>
@@ -291,52 +427,9 @@
         </tbody>
       </tgroup>
     </table>
-  </chapter>
-  <chapter>
-    <title>Key Derivation</title>
-    <table xml:id="keyTable">
-      <title>Key Derivation Functions</title>
-      <tgroup cols="3">
-        <colspec colname="c1" colwidth="15*"/>
-        <colspec colname="c2" colwidth="12*"/>
-        <colspec colname="c3" colwidth="12*"/>
-        <thead>
-          <row>
-            <entry>
-              <para>Name</para>
-            </entry>
-            <entry>
-              <para>Reference</para>
-            </entry>
-            <entry>
-              <para>Comment</para>
-            </entry>
-          </row>
-        </thead>
-        <tbody valign="top">
-          <row>
-            <entry>
-              <para>PBKDF2</para>
-            </entry>
-            <entry><para>RFC 8018 &amp; RFC 9579</para></entry>
-            <entry><para>for passwords</para></entry>
-          </row>
-          <row>
-            <entry>
-              <para>HKDF</para>
-            </entry>
-            <entry><para>RFC 5869</para></entry>
-            <entry><para>for random keys</para></entry>
-          </row>
-        </tbody>
-      </tgroup>
-    </table>
-  </chapter>
-  <chapter>
-    <title>Certificates</title>
-    <para>Requirements for certificate upload and creation.</para>
+    <para>The signature algorithm OIDs listed below are applicable to certificate signatures as well as other cryptographic operations such as media signing and general-purpose digital signatures.</para>
     <table xml:id="signaturesTable">
-      <title>Signature Baseline</title>
+      <title>Signature Algorithm OIDs</title>
       <tgroup cols="3">
         <colspec colname="c1" colwidth="40*"/>
         <colspec colname="c2" colwidth="30*"/>
@@ -421,9 +514,65 @@
               <para>RFC 5758, X9.62</para>
             </entry>
           </row>
+          <row>
+            <entry>
+              <para>rsassa-pss</para>
+            </entry>
+            <entry>
+              <para>1.2.840.113549.1.1.10</para>
+            </entry>
+            <entry>
+              <para>RFC 8017</para>
+            </entry>
+          </row>
         </tbody>
       </tgroup>
     </table>
+  </chapter>
+  <chapter>
+    <title>Key Derivation</title>
+    <para/>
+    <table xml:id="keyTable">
+      <title>Key Derivation Functions</title>
+      <tgroup cols="3">
+        <colspec colname="c1" colwidth="15*"/>
+        <colspec colname="c2" colwidth="12*"/>
+        <colspec colname="c3" colwidth="12*"/>
+        <thead>
+          <row>
+            <entry>
+              <para>Name</para>
+            </entry>
+            <entry>
+              <para>Reference</para>
+            </entry>
+            <entry>
+              <para>Comment</para>
+            </entry>
+          </row>
+        </thead>
+        <tbody valign="top">
+          <row>
+            <entry>
+              <para>PBKDF2</para>
+            </entry>
+            <entry><para>RFC 8018 &amp; RFC 9579</para></entry>
+            <entry><para>for passwords</para></entry>
+          </row>
+          <row>
+            <entry>
+              <para>HKDF</para>
+            </entry>
+            <entry><para>RFC 5869</para></entry>
+            <entry><para>for random keys</para></entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </chapter>
+  <chapter>
+    <title>Private Key Encryption</title>
+    <para>Requirements for encrypting private keys during certificate upload and creation.</para>
     <table xml:id="certTable">
       <title>Baseline for Encrypting Private Key</title>
       <tgroup cols="3">

--- a/wsdl/ver10/recording.wsdl
+++ b/wsdl/ver10/recording.wsdl
@@ -153,6 +153,13 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
+				<xs:attribute name="OnboardStorage" type="xs:boolean" default="true">
+					<xs:annotation>
+						<xs:documentation>
+							Indicates if the device supports recording to onboard storage, default value is true. If false, device shall support recording to an external target.
+						</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:complexType>
 			<xs:element name="Capabilities" type="trc:Capabilities"/>

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -1144,7 +1144,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<xs:documentation>the maximum output bitrate in kbps</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="AverageBitRate" type="xs:int">
+			<xs:element name="AverageBitRate" type="xs:int" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>The target average output bitrate in kbps. If this parameter is set to 0, AverageBitRate shall be ignored.</xs:documentation>
 					<xs:documentation>If this parameter is configured beyond BitrateLimit, device adapts to BitrateLimit.</xs:documentation>


### PR DESCRIPTION
- Changed to use "shall" wording where appropriate.
- Put the use of "certificate SEI" in a separate section together with the subsection on how to create it.
- Highlighted that hashing of NAL units excludes the start code by putting it in the list of "Basic rules".
- Corrected a missing size information in the cryptographic TLV tag.
