### PR TITLE
App Management: Fix capabilities name in spec text to match WSDL

### DIFF
--- a/doc/AppMgmt.xml
+++ b/doc/AppMgmt.xml
@@ -251,7 +251,7 @@
       <section xml:id="_Ref4595104">
         <title>Install</title>
         <para>Applications are deployed to a device via http POST to the URI provided by GetServiceCapabilities. The same URI shall be used for updating an application.</para>
-        <para>A device supporting this service shall support the POST operation to the upload URI provided by the UploadUri capability.</para>
+        <para>A device supporting this service shall support the POST operation to the upload URI provided by the UploadPath capability.</para>
         <para>When posting an image to one of the URIs, the following HTML status codes may be returned, depending on success or failure:</para>
         <itemizedlist>
           <listitem>
@@ -632,7 +632,7 @@
       <para>The following capabilities are available:</para>
       <variablelist>
         <varlistentry>
-          <term>UploadUri</term>
+          <term>UploadPath</term>
           <listitem>
             <para>Mandatory upload URI for applications.</para>
           </listitem>
@@ -642,7 +642,7 @@
           <listitem><para>Signals support for licensing of applications.</para></listitem>
         </varlistentry>
         <varlistentry>
-          <term>SupportedFormat</term>
+          <term>FormatsSupported</term>
           <listitem><para>List of application formats supported by the device.</para></listitem>
         </varlistentry>
          <varlistentry>


### PR DESCRIPTION
Caught during a review of those specs, the WSDL had a different naming than the XML. I'm aligning the XML names to match the WSDL (Since the opposite would be a breaking change)

UploadUri -> UploadPath
SupportedFormat  -> FormatsSupported