### PR TITLE
Fix documentation comments in onvif.xsd

### DIFF
--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -791,7 +791,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:element name="BitrateLimit" type="xs:int">
 				<xs:annotation>
-					<xs:documentation>the maximum output bitrate in kbps</xs:documentation>
+					<xs:documentation>The maximum output bitrate in kbps.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
@@ -1269,7 +1269,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				<xs:sequence>
 					<xs:element name="Encoding" type="tt:AudioEncoding">
 						<xs:annotation>
-							<xs:documentation>Audio codec used for encoding the audio input (either G.711, G.726 or AAC)</xs:documentation>
+							<xs:documentation>Audio codec used for encoding the audio input (either G.711, G.726 or AAC).</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="Bitrate" type="xs:int">
@@ -1322,17 +1322,17 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:sequence>
 			<xs:element name="Encoding" type="tt:AudioEncoding">
 				<xs:annotation>
-					<xs:documentation>The enoding used for audio data (either G.711, G.726 or AAC)</xs:documentation>
+					<xs:documentation>The enoding used for audio data (either G.711, G.726 or AAC).</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="BitrateList" type="tt:IntItems">
 				<xs:annotation>
-					<xs:documentation>List of supported bitrates in kbps for the specified Encoding</xs:documentation>
+					<xs:documentation>List of supported bitrates in kbps for the specified Encoding.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="SampleRateList" type="tt:IntItems">
 				<xs:annotation>
-					<xs:documentation>List of supported Sample Rates in kHz for the specified Encoding</xs:documentation>
+					<xs:documentation>List of supported Sample Rates in kHz for the specified Encoding.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
@@ -1397,7 +1397,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:element name="BitrateList" type="tt:IntItems">
 				<xs:annotation>
-					<xs:documentation>List of supported bitrates in kbps for the specified Encoding</xs:documentation>
+					<xs:documentation>List of supported bitrates in kbps for the specified Encoding.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="SampleRateList" type="tt:IntItems">
@@ -1717,12 +1717,12 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:element name="SupportedH264Profiles" type="tt:H264Profile" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>List of supported H264 Profiles (either baseline, main, extended or high) </xs:documentation>
+					<xs:documentation>List of supported H264 Profiles (either baseline, main, extended or high).</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="SupportedInputBitrate" type="tt:IntRange">
 				<xs:annotation>
-					<xs:documentation>Supported H.264 bitrate range in kbps</xs:documentation>
+					<xs:documentation>Supported H.264 bitrate range in kbps.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="SupportedFrameRate" type="tt:IntRange">
@@ -1744,7 +1744,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:element name="SupportedInputBitrate" type="tt:IntRange">
 				<xs:annotation>
-					<xs:documentation>Supported Jpeg bitrate range in kbps</xs:documentation>
+					<xs:documentation>Supported Jpeg bitrate range in kbps.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="SupportedFrameRate" type="tt:IntRange">
@@ -1771,7 +1771,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:element name="SupportedInputBitrate" type="tt:IntRange">
 				<xs:annotation>
-					<xs:documentation>Supported Mpeg4 bitrate range in kbps</xs:documentation>
+					<xs:documentation>Supported Mpeg4 bitrate range in kbps.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="SupportedFrameRate" type="tt:IntRange">
@@ -2009,7 +2009,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 		<xs:sequence>
 			<xs:element name="Bitrate" type="tt:IntItems">
 				<xs:annotation>
-					<xs:documentation>List of supported bitrates in kbps</xs:documentation>
+					<xs:documentation>List of supported bitrates in kbps.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="SampleRateRange" type="tt:IntItems">
@@ -2026,7 +2026,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 		<xs:sequence>
 			<xs:element name="Bitrate" type="tt:IntItems">
 				<xs:annotation>
-					<xs:documentation>List of supported bitrates in kbps</xs:documentation>
+					<xs:documentation>List of supported bitrates in kbps.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="SampleRateRange" type="tt:IntItems">
@@ -2043,7 +2043,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 		<xs:sequence>
 			<xs:element name="Bitrate" type="tt:IntItems">
 				<xs:annotation>
-					<xs:documentation>List of supported bitrates in kbps</xs:documentation>
+					<xs:documentation>List of supported bitrates in kbps.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="SampleRateRange" type="tt:IntItems">
@@ -2265,7 +2265,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			</xs:element>
 			<xs:element name="BitrateList" type="tt:IntItems">
 				<xs:annotation>
-					<xs:documentation>List of supported bitrates in kbps for the specified Encoding</xs:documentation>
+					<xs:documentation>List of supported bitrates in kbps for the specified Encoding.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="SampleRateList" type="tt:IntItems">


### PR DESCRIPTION
Some periods missing and capitalizations