### PR TITLE
Clarify RecordingConfiguration mutually exclusive KID/Key and AsymmetricEncryption

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -648,6 +648,8 @@ Change Request 2061, 2063, 2065, 2109</revremark>
             <para role="text">The RecordConfiguration is invalid.</para>
             <para role="param">env:Receiver - ter:ActionNotSupported - ter:NotImplemented</para>
             <para role="text">This optional method is not implemented.</para>
+            <para role="param">env:Sender - ter:InvalidArgVal - ter:AmbiguousConfiguration</para>
+            <para role="text">Key/KID and AsymmetricEncryption are mutually exclusive configuration parameters</para>
           </listitem>
         </varlistentry>
         <varlistentry>

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -8061,13 +8061,13 @@ and sample rate. </xs:documentation>
 		<xs:sequence>
 			<xs:element name="KID" type="xs:string" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
-					<xs:documentation>Key ID of the associated key for encryption. This parameter is ignored when AsymmetricEncryption is configured.</xs:documentation>
+					<xs:documentation>Key ID of the associated key for encryption. The client shall omit this parameter when AsymmetricEncryption is configured.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Key" type="xs:hexBinary" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>
-						Key for encrypting content. This parameter is ignored when AsymmetricEncryption is configured.
+						Key for encrypting content. The client shall omit this parameter when AsymmetricEncryption is configured.
 						The device shall not include this parameter when reading.
 					</xs:documentation>
 				</xs:annotation>


### PR DESCRIPTION
Adjust the contradictory statement in onvif.xsd about KID/Key being ignored if AsymmetricEncryption, aligns with the RecordingControl spec to enforce that they shall be omitted if AsymmetricEncryption si set.

Also document the AmbiguousConfiguration fault type in CreateRecording

Resolves onvif/wg_profile_cloud#179