### PR TITLE
Adapt explanatory text of firmware upgrade.

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -1310,10 +1310,11 @@
           stage process; first the client sends the StartFirmwareUpgrade command to instruct the
           device to prepare for upgrade, then it sends the firmware image using HTTP POST.</para>
         <para>The HTTP method is designed for resource-limited devices that may not be capable of receiving a new firmware image in its normal operating state.</para>
-        <para>The second method applies to cloud connected devices and involves an interaction
-          between the Operational Cloud Service (OCS), the Manufacturer Cloud Service (MCS) and the
-          device, in order to trigger the firmware upgrade. For the complete description of the
-          roles of the cloud clients, please refer to the Cloud Integration Specification.</para>
+        <para>The second method applies to cloud connected devices. A simple interface allows
+          upgrading firmware by providing a requested version. The device interacts via propriatary
+          means with its manufacturer cloud to perform the requested update. Available options can
+          be retrieved via the method GetAvailableFirmwares or the Manufacturer Cloud Service
+          (MCS).</para>
       </section>
       <section>
         <title>System Restore</title>
@@ -4953,7 +4954,8 @@ onvif://www.onvif.org/name/ARV-453
         <para>Cloud firmware upgrade  may be achieved using the following steps:</para>
         <orderedlist>
           <listitem>
-            <para>Client retrieves the list of available firmware versions from the MCS.</para>
+            <para>Client retrieves the list of available firmware versions via GetAvailableFirmwares
+              or from the MCS.</para>
           </listitem>
           <listitem>
             <para>Client calls StartCloudFirmwareUpgrade, selecting the desired FW version.</para>


### PR DESCRIPTION
Update non-normative description in overview and UpgradeFirmware command to clarify how to use the method with either MCS or GetAvailableFirmwares.

Remove notion of OCS as the mechanism is independent of client.
This is a PR against Hanwha's proposal as it only makes sense in combination.