### PR TITLE
Move capability FirmwareUpgrade related to MTOM to deprecation section.

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -3154,15 +3154,6 @@ onvif://www.onvif.org/name/ARV-453
                 </row>
                 <row>
                   <entry>
-                    <para>FirmwareUpgrade</para>
-                  </entry>
-                  <entry>
-                    <para>Indication if the device supports firmware upgrade using
-                      UpgradeSystemFirmware (deprecated).</para>
-                  </entry>
-                </row>
-                <row>
-                  <entry>
                     <para>CloudFirmwareUpgrade</para>
                   </entry>
                   <entry>
@@ -9398,6 +9389,12 @@ http://www.onvif.org/ver10/tev/topicExpression/ConcreteSet
     <section>
       <title>System</title>
       <para>The definition and interfaces for MTOM firmware upgrade have been deprecated with release 25.06. The following interfaces have been removed from the specification:</para>
+      <itemizedlist>
+        <listitem>
+          <para>UpgradeSystemFirmware</para>
+        </listitem>
+      </itemizedlist>
+      <para>The following GetServiceCapabilities have been deprecated:</para>
       <itemizedlist>
         <listitem>
           <para>UpgradeSystemFirmware</para>

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -306,11 +306,6 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:documentation>Indicates support for retrieval of system logging through MTOM.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
-				<xs:attribute name="FirmwareUpgrade" type="xs:boolean">
-					<xs:annotation>
-						<xs:documentation>Indicates support for firmware upgrade through MTOM.</xs:documentation>
-					</xs:annotation>
-				</xs:attribute>
 				<xs:attribute name="CloudFirmwareUpgrade" type="xs:boolean">
 					<xs:annotation>
 						<xs:documentation>Indicates support for firmware upgrade through the cloud.</xs:documentation>


### PR DESCRIPTION
The method itself has been moved sometime ago to the deprecated section. This PR purpose is to just cleanup the related capability.

Removing the attribute is fine as the xs:anyAttribute ensures backward compatibility.