### PR TITLE
Added event for media signing key status

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -5611,8 +5611,8 @@
             provisioned key shall be triggered with 'Effective' status set to True, indicating that
             new signed streams shall use the user-provisioned key for signing immediately.</para>
           <para>When user provisioned key is configured via <emphasis role="bold"
-              >AddMediaSigningCertificateAssignment</emphasis> and If there are signed streams using
-            manufacturer key in progress, Changed property event with the KeyID set to user
+              >AddMediaSigningCertificateAssignment</emphasis> and If there are active signed
+            streams using manufacturer key, Changed property event with the KeyID set to user
             provisioned key shall be triggered with 'Effective' status set to False, indicating that
             ongoing signed streams shall continue using the manufacturer key until
             terminated.</para>
@@ -5622,8 +5622,8 @@
             manufacturer key shall be triggered with 'Effective' status set to True, indicating that
             new signed streams shall use the manufacturer key for signing immediately.</para>
           <para>When configured user provisioned key is removed via <emphasis role="bold"
-              >RemoveMediaSigningCertificateAssignment</emphasis> and If there are signed streams
-            using user provisioned key in progress, Changed property event with the KeyID set to
+              >RemoveMediaSigningCertificateAssignment</emphasis> and If there are no active signed
+            streams using user provisioned key, Changed property event with the KeyID set to
             manufacturer key shall be triggered with 'Effective' status set to False, indicating
             that ongoing signed streams shall continue using the user-provisioned key until
             terminated.</para>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -4408,7 +4408,7 @@
           certificate in the chain and its associated private key shall be used for signing media as
           described in the [Media Signing Specification]. This key and certificate are referred to
           as user provisioned key and certificate in that specification.</para>
-        <para>If a user-provisioned certification path is configured, it shall be replaced by the
+        <para>If a user provisioned certification path is configured, it shall be replaced by the
           new certification path only if it is not in use by an ongoing media streaming session;
           otherwise, the device shall return a ReferenceExists fault and shall not replace the
           certification path.</para>
@@ -4498,8 +4498,8 @@
           AddMediaSigningCertificateAssignment.</para>
         <para>A device shall support this command if the MediaSigningSupported capability is
           true.</para>
-        <para>Response list shall be ordered with factory-provisioned ID first, followed by
-          user-provisioned ID.</para>
+        <para>Response list shall be ordered with factory-provisioned ID first, followed by user
+          provisioned ID.</para>
         <variablelist role="op">
           <varlistentry>
             <term>request</term>
@@ -5609,7 +5609,7 @@
               >AddMediaSigningCertificateAssignment</emphasis> and If there are no active signed
             streams using manufacturer key, Changed property event with the KeyID set to user
             provisioned key shall be triggered with 'Effective' status set to True, indicating that
-            new signed streams shall use the user-provisioned key for signing immediately.</para>
+            new signed streams shall use the user provisioned key for signing immediately.</para>
           <para>When user provisioned key is configured via <emphasis role="bold"
               >AddMediaSigningCertificateAssignment</emphasis> and If there are active signed
             streams using manufacturer key, Changed property event with the KeyID set to user
@@ -5625,7 +5625,7 @@
               >RemoveMediaSigningCertificateAssignment</emphasis> and If there are no active signed
             streams using user provisioned key, Changed property event with the KeyID set to
             manufacturer key shall be triggered with 'Effective' status set to False, indicating
-            that ongoing signed streams shall continue using the user-provisioned key until
+            that ongoing signed streams shall continue using the user provisioned key until
             terminated.</para>
         </section>
     </section>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -5632,8 +5632,7 @@
     
     <section>
       <title>Service specific data types</title>
-      <para>The service specific data types are defined in security.wsdl. CertificationPathID -
-          [tas:CertificationPathID]</para>
+      <para>The service specific data types are defined in security.wsdl.</para>
     </section>
    </section>
   </chapter>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -5601,32 +5601,32 @@
     <tt:SimpleItemDescription Name="KeyID" Type="tas:KeyID"/>
   </tt:Source>
   <tt:Data>
-    <tt:SimpleItemDescription Name="Assigned" Type="xs:boolean"/>
-    <tt:SimpleItemDescription Name="ActiveStream" Type="xs:boolean"/>
+    <tt:SimpleItemDescription Name="Effective" Type="xs:boolean"/>
   </tt:Data>
 </tt:MessageDescription>
 ]]></programlisting>
-          <para>The Assigned status shall indicate key assignment for future signed media streams
-            while ActiveStream shall is indicate key actively in use for the signed media
-            streaming.</para>
-          <para>If client configures the user provisioned key via <emphasis role="bold"
-              >AddMediaSigningCertificateAssignment</emphasis>, Changed property event with the
-            KeyID set to user provisioned key shall be triggered with 'Assigned' status set to True.
-            During this operation, If there are active signed media streams using manufactuter
-            provisioned key are in progress, ActiveStream status in the event payload for user
-            provisioned key shall be set to False.</para>
-          <para>If client removes the user provisioned key <emphasis role="bold"
-              >RemoveMediaSigningCertificateAssignment</emphasis>, Changed property event with the
-            KeyID falling back to manufacturer provisioned key shall be triggered with 'Assigned'
-            status set to True. During this operation, If there are active signed media streams
-            using user provisioned key are in progress, ActiveStream status in the event payload for
-            manufactuter provisioned key shall be set to False.</para>
-          <para>When client starts the first signed media stream, irrespective of user or
-            manufacturer provisioned key assignment, Changed property event gets triggered with
-            'ActiveStream' status set to True along with the Assigned key status.</para>
-          <para>When client stops the last signed media stream, irrespective of user or manufacturer
-            provisioned key assignment,  Changed property event gets triggered with 'ActiveStream'
-            status set to False along with the Assigned key status.</para>
+          <para>When user provisioned key is configured via <emphasis role="bold"
+              >AddMediaSigningCertificateAssignment</emphasis> and If there are no active signed
+            streams using manufacturer key, Changed property event with the KeyID set to user
+            provisioned key shall be triggered with 'Effective' status set to True, indicating that
+            new signed streams shall use the user-provisioned key for signing immediately.</para>
+          <para>When user provisioned key is configured via <emphasis role="bold"
+              >AddMediaSigningCertificateAssignment</emphasis> and If there are signed streams using
+            manufacturer key in progress, Changed property event with the KeyID set to user
+            provisioned key shall be triggered with 'Effective' status set to False, indicating that
+            ongoing signed streams shall continue using the manufacturer key until
+            terminated.</para>
+          <para>When configured user provisioned key is removed via <emphasis role="bold"
+              >RemoveMediaSigningCertificateAssignment</emphasis> and If there are no active signed
+            streams using user provisioned key, Changed property event with the KeyID set to
+            manufacturer key shall be triggered with 'Effective' status set to True, indicating that
+            new signed streams shall use the manufacturer key for signing immediately.</para>
+          <para>When configured user provisioned key is removed via <emphasis role="bold"
+              >RemoveMediaSigningCertificateAssignment</emphasis> and If there are signed streams
+            using user provisioned key in progress, Changed property event with the KeyID set to
+            manufacturer key shall be triggered with 'Effective' status set to False, indicating
+            that ongoing signed streams shall continue using the user-provisioned key until
+            terminated.</para>
         </section>
     </section>
     

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -5590,10 +5590,50 @@
 </tt:MessageDescription>
 ]]></programlisting>
       </section>
+      <section xml:id="section_lhd_zp3_hjc">
+          <title>Media signing key assignment status</title>
+          <para>A device that indicates support for signing of media using a user provisioned key
+            via the UserMediaSigningKeySupported capability shall provide information about assigned
+            key changes via the below specified event</para>
+          <programlisting><![CDATA[Topic: tns1:Advancedsecurity/MediaSigning/KeyStatus
+<tt:MessageDescription IsProperty="true">
+  <tt:Source>
+    <tt:SimpleItemDescription Name="KeyID" Type="tas:KeyID"/>
+  </tt:Source>
+  <tt:Data>
+    <tt:SimpleItemDescription Name="Assigned" Type="xs:boolean"/>
+    <tt:SimpleItemDescription Name="ActiveStream" Type="xs:boolean"/>
+  </tt:Data>
+</tt:MessageDescription>
+]]></programlisting>
+          <para>The Assigned status shall indicate key assignment for future signed media streams
+            while ActiveStream shall is indicate key actively in use for the signed media
+            streaming.</para>
+          <para>If client configures the user provisioned key via <emphasis role="bold"
+              >AddMediaSigningCertificateAssignment</emphasis>, Changed property event with the
+            KeyID set to user provisioned key shall be triggered with 'Assigned' status set to True.
+            During this operation, If there are active signed media streams using manufactuter
+            provisioned key are in progress, ActiveStream status in the event payload for user
+            provisioned key shall be set to False.</para>
+          <para>If client removes the user provisioned key <emphasis role="bold"
+              >RemoveMediaSigningCertificateAssignment</emphasis>, Changed property event with the
+            KeyID falling back to manufacturer provisioned key shall be triggered with 'Assigned'
+            status set to True. During this operation, If there are active signed media streams
+            using user provisioned key are in progress, ActiveStream status in the event payload for
+            manufactuter provisioned key shall be set to False.</para>
+          <para>When client starts the first signed media stream, irrespective of user or
+            manufacturer provisioned key assignment, Changed property event gets triggered with
+            'ActiveStream' status set to True along with the Assigned key status.</para>
+          <para>When client stops the last signed media stream, irrespective of user or manufacturer
+            provisioned key assignment,  Changed property event gets triggered with 'ActiveStream'
+            status set to False along with the Assigned key status.</para>
+        </section>
     </section>
+    
     <section>
       <title>Service specific data types</title>
-      <para>The service specific data types are defined in security.wsdl.</para>
+      <para>The service specific data types are defined in security.wsdl. CertificationPathID -
+          [tas:CertificationPathID]</para>
     </section>
    </section>
   </chapter>


### PR DESCRIPTION
| Condition | Operation | Event Source (`KeyID`) | `Effective` | Clarification |
|---|---|---|---|---|
| No signed streams using the manufacturer-provisioned key are active | `AddMediaSigningCertificateAssignment` with a user-provisioned key | User-provisioned key | `True` | The user-provisioned key becomes immediately effective for newly established signed streams. |
| Signed streams using the manufacturer-provisioned key are active | `AddMediaSigningCertificateAssignment` with a user-provisioned key | User-provisioned key | `False` | Existing signed streams shall continue using the manufacturer-provisioned key until terminated. The user-provisioned key is not yet effective for newly established signed streams. |
| No signed streams using the user-provisioned key are active | `RemoveMediaSigningCertificateAssignment` | Manufacturer-provisioned key | `True` | The manufacturer-provisioned key becomes immediately effective for newly established signed streams. |
| Signed streams using the user-provisioned key are active | `RemoveMediaSigningCertificateAssignment` | Manufacturer-provisioned key | `False` | Existing signed streams shall continue using the user-provisioned key until terminated. The manufacturer-provisioned key is not yet effective for newly established signed streams. |

### Behavioral Clarification

- `Effective=True` indicates that the event source key is effective for newly established signed media streams.
- `Effective=False` indicates that the event source key has been selected but is not yet effective because existing signed streams are still using the previously effective key.
- A key transition becomes effective only when no signed streams using the previously effective key remain active.
- At any point in time, only one key shall be effective for newly established signed media streams.