### PR TITLE
Storage Configuration Renewal: Align spec with OpenAPI

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -6488,7 +6488,7 @@ onvif://www.onvif.org/name/ARV-453
           <literal>AuthorizationServer</literal>. The endpoint shall respond with a JSON payload with the following structure:
           <programlisting><![CDATA[{
     "region": "string" | null,
-    "storageUri": "string" | null,
+    "storageUri": "string",
     "user": {
         "username": "string" | null,
         "password": "string" | null,


### PR DESCRIPTION
The StorageUri in OpenAPI is not optional, but the sample in the specs says it was. Since both ObjectStorage types absolutely need it, I'm removing the `null` mention to align with the yaml.

Closes onvif/wg_profile_cloud#189