### PR TITLE
Improve firmware upgrade timing description and notification.

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -4977,7 +4977,7 @@ onvif://www.onvif.org/name/ARV-453
             <term>response</term>
             <listitem>
               <para role="param">ExpectedDownTime [xs:duration]</para>
-              <para role="text">A duration that indicates how long the device expects to be unavailable after the firmware upload is complete.</para>
+              <para role="text">An indication how long the device expects to be unavailable.</para>
             </listitem>
           </varlistentry>
           <varlistentry>
@@ -4994,8 +4994,10 @@ onvif://www.onvif.org/name/ARV-453
             </listitem>
           </varlistentry>
         </variablelist>
-        <para xml:id="_Ref276040030">In case it is not possible to provide exact figures for
-          ExpectedDownTime, the device shall provide best-effort estimates.</para>
+        <para>The time needed for upgrading depends on the available network bandwidth for
+          downloading required assets. To improve client side monitoring a device should regularly
+          share the update progress by sending UpdateStatus monitoring events as defined in <xref
+            linkend="Ref_MonitoringEvents"/>.</para>
       </section>
       <section xml:id="_Ref482093370">
         <title>GetSystemLog</title>
@@ -6685,7 +6687,7 @@ onvif://www.onvif.org/name/ARV-453
         </variablelist>
       </section>
     </section>
-    <section>
+    <section xml:id="Ref_MonitoringEvents">
       <title>MonitoringEvents</title>
       <section>
         <title>Processor Usage</title>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -4977,7 +4977,7 @@ onvif://www.onvif.org/name/ARV-453
             <term>response</term>
             <listitem>
               <para role="param">ExpectedDownTime [xs:duration]</para>
-              <para role="text">An indication how long the device expects to be unavailable.</para>
+              <para role="text">An indication of how long the device expects to be unavailable.</para>
             </listitem>
           </varlistentry>
           <varlistentry>


### PR DESCRIPTION
Improve wording of downtime estimation. 
Add recommendation to send periodic update progress events.

We can see three different types of upgrade mechanism. As all of them are opaque to the client, the responses and notifications should fit to all of them:

1. Device is available while uploading assets and upgrading happens immediately without being offline at all.
2. Device is available while uploading but needs to process update and reboot when upload is completed
3. Device needs to start updater without normal functionality before starting the upgrade procedure.
