### PR TITLE
Add format mention for the Recording Encryption KID field

### DIFF
--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -8106,7 +8106,7 @@ and sample rate. </xs:documentation>
 		<xs:sequence>
 			<xs:element name="KID" type="xs:string" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
-					<xs:documentation>Key ID of the associated key for encryption. The client shall omit this parameter when AsymmetricEncryption is configured.</xs:documentation>
+					<xs:documentation>Key ID of the associated key for encryption, formatted as a UUID according to RFC 9562 Section 4. The client shall omit this parameter when AsymmetricEncryption is configured.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Key" type="xs:hexBinary" minOccurs="0" maxOccurs="1">


### PR DESCRIPTION
To address onvif/wg_profile_cloud#185, I'm proposing standard UUID format like `f81d4fae-7dec-11d0-a765-00a0c91e6bf6
` for the KID field of the configuration, since it is defined as xs:string

The bytes, as interpreted by the UUID specification can then be used in the other places (where it is expected as binary)