### PR TITLE
Clarify cert-paths and cert-path-validation-policies

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -5279,12 +5279,12 @@
                   <para>MaximumNumberOfCertificationPaths</para>
                 </entry>
                 <entry>
-                  <para>Shall be at least two</para>
+                  <para>If supported, Shall be at least two</para>
                 </entry>
               </row>
               <row>
                 <entry><para>MaximumNumberOfCertificationPathValidationPolicies</para></entry>
-                <entry><para>Shall be at least two</para></entry>
+                <entry><para>If supported, Shall be at least two</para></entry>
               </row>
               <row>
                 <entry>


### PR DESCRIPTION
Fix for https://github.com/onvif/wg_profile_cloud/issues/200

- TLS Security add-on mandates supporting CertificationPaths
- Profile V mandates supporting CertificationPathValidationPolicy

But we cannot force mandate these features into profiles/add-ons saying 'shall be at least two' which pushes implementors into adding features/interfaces that are not really needed in add-on or profile.