### PR TITLE
clarify NetworkConfigNotSupported for NTP functionality

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -3459,7 +3459,10 @@ onvif://www.onvif.org/name/ARV-453
     </section>
     <section xml:id="_Toc278964059">
       <title>Network</title>
-	  <para> A device shall support the commands defined in this section unless the NetworkConfigNotSupported capability is signalled as 'True' confirming it doesn’t support network configuration. </para>
+	  <para>A device shall support the commands defined in this section unless the
+        NetworkConfigNotSupported capability is signalled as 'True' indicating that general network
+        configuration is not supported. Feature-specific capabilities shall determine interface
+        support, regardless of NetworkConfigNotSupported, for e.g. NTP.</para>
       <section>
         <title>GetHostname</title>
         <para>This operation is used by an endpoint to get the hostname from a device. The device shall return its hostname configurations through the GetHostname command. 


### PR DESCRIPTION
Fix for the issue https://github.com/onvif/wg_profile_cloud/issues/195

NetworkConfigNotSupported can be overridden by individual feature capabilities if they are supported for e.g. NTP

