### PR TITLE
Separate public/private key requirements.

### DIFF
--- a/doc/SecurityBaseline.xml
+++ b/doc/SecurityBaseline.xml
@@ -274,7 +274,7 @@
               <entry><para>RFC 8017</para></entry>
             </row>
             <row>
-              <entry><para>RSA</para></entry>
+              <entry><para>RSA*</para></entry>
               <entry><para>4096 Bit</para></entry>
               <entry><para>1.2.840.113549.1.1.1</para></entry>
               <entry><para>RFC 8017</para></entry>
@@ -292,7 +292,7 @@
               <entry><para>RFC 5480</para></entry>
             </row>
             <row>
-              <entry><para>secp521r1</para></entry>
+              <entry><para>secp521r1*</para></entry>
               <entry><para>521 Bit</para></entry>
               <entry><para>1.3.132.0.35</para></entry>
               <entry><para>RFC 5480</para></entry>
@@ -300,6 +300,8 @@
           </tbody>
         </tgroup>
       </table>
+      <para>Items marked with asterisk relate to public key usage in order to e.g. support signature
+        verification.</para>
     </section>
     <section>
       <title>Digital Signatures</title>
@@ -650,7 +652,7 @@
           <row>
             <entry><para>Media signing</para></entry>
             <entry><para>Media Signing</para></entry>
-            <entry><para>Digital Signatures (ECDSA), Hash Functions</para></entry>
+            <entry><para>Digital Signatures, Hash Functions</para></entry>
             <entry><para>—</para></entry>
           </row>
           <row>


### PR DESCRIPTION
Remove restriction for media signing to elliptic curves.