### PR TITLE
fix docbook validation errors

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -3114,7 +3114,7 @@ onvif://www.onvif.org/name/ARV-453
                   </entry>
                 </row>
                 <row>
-                  <entry morerows="18">
+                  <entry morerows="17">
                     <para>System</para>
                   </entry>
                   <entry>
@@ -9420,6 +9420,9 @@ http://www.onvif.org/ver10/tev/topicExpression/ConcreteSet
           <title>ONVIF XML to JSON conversion</title>
 
           <tgroup cols="3">
+            <colspec colname="c1" colwidth="33*" />
+            <colspec colname="c2" colwidth="33*" />
+            <colspec colname="c3" colwidth="34*" />
             <thead>
               <row>
                 <entry align="center"><para>ONVIF XML Element</para></entry>

--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -201,6 +201,8 @@ Change Request 2061, 2063, 2065, 2109</revremark>
         <date>Jun-2026</date>
         <author>
           <personname>Jean-Francois Levesque</personname>
+        </author>
+        <author>
           <personname>Jose Melancon</personname>
         </author>
         <revremark>Add support for listing and export of segments to an Object Storage.</revremark>

--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -896,14 +896,14 @@ Server -> Client: { "error": {"code": 1001, "message": "Insufficient resources"}
     <section xml:id="section_vyt_v12_v5b">
       <title>Video</title>
       <para>RFC 7742, required by RFC 8825, defines "WebRTC Video Processing and Codec Requirements". This
-        specification removes the requirements in sections 5 "Mandatory-to-Implement Video Codec".
+        specification removes the requirements in sections 5 "Mandatory-to-Implement Video Codec".</para>
       <para>When using WebRTC with a web browser only certain codecs will work. Because of this
         ONVIF recommends to use the h.264 codec.</para>
     </section>
     <section xml:id="section_wyt_v12_v5b">
       <title>Audio</title>
       <para>RFC 7874, required by RFC 8825, defines "WebRTC Audio Codec and Processing Requirements". This
-        specification removes the requirements in sections 3 "Codec requirements".
+        specification removes the requirements in sections 3 "Codec requirements".</para>
       <para>When using WebRTC with a web browser only certain codecs will work. Because of this
         ONVIF recommends to use the Opus or PCMU codec.</para>
       <para>If the selected media profile contains an AudioDecoder, the device shall include an


### PR DESCRIPTION
This update fixes DocBook validation issues in active specification files.

- Fixed Core table layout validation issues:
  - Corrected the `System` capability category row span in the `GetServiceCapabilities` capabilities table so it no longer overlaps the following `Security` category.
  - Added explicit column specifications to the `ONVIF XML to JSON conversion` table to match its declared three-column layout.

- Fixed Recording Control revision history author markup:
  - Split the June 2026 revision entry into two separate `<author>` elements for Jean-Francois Levesque and Jose Melancon, which matches the DocBook content model.

- Fixed WebRTC malformed paragraph markup:
  - Added missing closing `</para>` tags in the Video and Audio sections so the following paragraphs are no longer nested incorrectly.