### PR TITLE
SecurityBaseline 26.06 review fixes

### DIFF
--- a/doc/SecurityBaseline.xml
+++ b/doc/SecurityBaseline.xml
@@ -70,7 +70,7 @@
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf"/>&gt; </para>
     <para>NIST FIPS 186-5 Digital Signature Standard (DSS) - February 3, 2023</para>
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf"/>&gt;</para>
-    <para>BSI – Technical Guideline, Cryptographic Mechanisms: Recommendations and Key Length- January 31, 2025</para>
+    <para>BSI – Technical Guideline, Cryptographic Mechanisms: Recommendations and Key Lengths - January 31, 2025</para>
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-1.pdf?__blob=publicationFile&amp;v=9"/>&gt;</para>
     <para>RFC 4055 - Additional Algorithms and Identifiers for RSA Cryptography for use in the Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile</para>
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://datatracker.ietf.org/doc/html/rfc4055"/>&gt;</para>
@@ -667,7 +667,7 @@
     
     <para>This Annex is advocating a small subset of Ciphers as part of the ONVIF standard that readers of this specification can use as an informative guide. </para>
     <para>The following small subset of ciphers covering TLS 1.2 / 1.3 are based on the baseline defined in this document and match common practise by Cloudflare, Mozilla, and ciphersuite.info.</para>
-    <para>While TLS 1.2 and 1.3 are both currently viable, we would suggest that TLS 1.3 is preferred. Do note that the table is not ordered by the strength of the cipher.</para>
+    <para>While TLS 1.2 and 1.3 are both currently viable, TLS 1.3 is preferred. Do note that the table is not ordered by the strength of the cipher.</para>
     
     <table>
       <title>TLS 1.3 / 1.2 Cipher list</title>
@@ -722,7 +722,7 @@
           <thead>
             <row>
               <entry>IANA Registry</entry>
-              <entry>Reference</entry>
+              <entry>Algorithm</entry>
             </row>
           </thead>
           <tbody>
@@ -741,7 +741,7 @@
           <thead>
             <row>
               <entry>IANA Registry</entry>
-              <entry>Reference</entry>
+              <entry>Algorithm</entry>
             </row>
           </thead>
           <tbody>
@@ -760,7 +760,7 @@
           <thead>
             <row>
               <entry>IANA Registry</entry>
-              <entry>Reference</entry>
+              <entry>Algorithm</entry>
             </row>
           </thead>
           <tbody>

--- a/doc/SecurityBaseline.xml
+++ b/doc/SecurityBaseline.xml
@@ -721,8 +721,8 @@
           <colspec colname="c2" colnum="2" colwidth="1.0*"/>
           <thead>
             <row>
-              <entry>IANA Registry</entry>
-              <entry>Algorithm</entry>
+              <entry><para>IANA Registry</para></entry>
+              <entry><para>Algorithm</para></entry>
             </row>
           </thead>
           <tbody>
@@ -740,8 +740,8 @@
           <colspec colname="c2" colnum="2" colwidth="1.0*"/>
           <thead>
             <row>
-              <entry>IANA Registry</entry>
-              <entry>Algorithm</entry>
+              <entry><para>IANA Registry</para></entry>
+              <entry><para>Algorithm</para></entry>
             </row>
           </thead>
           <tbody>
@@ -759,8 +759,8 @@
           <colspec colname="c2" colnum="2" colwidth="1.0*"/>
           <thead>
             <row>
-              <entry>IANA Registry</entry>
-              <entry>Algorithm</entry>
+              <entry><para>IANA Registry</para></entry>
+              <entry><para>Algorithm</para></entry>
             </row>
           </thead>
           <tbody>
@@ -785,8 +785,8 @@
           <colspec colname="c2" colnum="2" colwidth="1.0*"/>
           <thead>
             <row>
-              <entry>Algorithm</entry>
-              <entry>Reference</entry>
+              <entry><para>Algorithm</para></entry>
+              <entry><para>Reference</para></entry>
             </row>
           </thead>
           <tbody>


### PR DESCRIPTION
- Annex B, Table B1,B2 & B3 Renaming the column Reference to Algorithm
- Normative Reference: BSI TR-02102-1 document title uses "Key Lengths" (plural)
- Annex A rephrase TLS 1.3 recommendation