### PR TITLE
Editorial change moving SetEQPreset method to appropriate section.

### DIFF
--- a/doc/Media2.xml
+++ b/doc/Media2.xml
@@ -2672,38 +2672,41 @@
         </variablelist>
       </section>
     </section>
-    <section xml:id="SetEQPreset">
-      <title>SetEQPreset</title>
-      <para>This command configures the Audio EQPreset, provided it is supported. Refer to the <emphasis role="bold">AudioOutputConfigurationOptions</emphasis> response, associated with the audio output, to verify whether the EQPreset is supported and configurable.</para>
-      <para>When <emphasis role="bold">isFrequencyDecibelEditable</emphasis> is signaled as true, the device shall accept any decibel value provided as input, automatically adjust it within its operating range, and return the adjusted value in a subsequent get operation.</para>
-      <para>When a specific EQPreset is designated as the default, it will become active whenever the scheduler is inactive. Additionally, in the event of any conflicts within the scheduler, the default preset will remain active. Only one preset can be set as the default among the EQ presets linked to an audio output. If all presets have isDefault parameter set to false, the device may automatically select one preset as the default.</para>
-      <variablelist role="op">
-        <varlistentry>
-          <term>request</term>
-          <listitem>
-            <para role="param">Configuration  - [tt:EQPreset]</para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term>response</term>
-          <listitem>
-            <para role="text">This message is empty.</para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term>faults</term>
-          <listitem>
-            <para role="param">env:Sender - ter:InvalidArgVal - ter:NoConfig</para>
-            <para role="text">The requested configuration does not exist in the given context.</para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term>access class</term>
-          <listitem>
-            <para role="access">WRITE_SYSTEM</para>
-          </listitem>
-        </varlistentry>
-      </variablelist>
+    <section>
+      <title>EQ Presets</title>
+      <section xml:id="SetEQPreset">
+        <title>SetEQPreset</title>
+        <para>This command configures the Audio EQPreset, provided it is supported. Refer to the <emphasis role="bold">AudioOutputConfigurationOptions</emphasis> response, associated with the audio output, to verify whether the EQPreset is supported and configurable.</para>
+        <para>When <emphasis role="bold">isFrequencyDecibelEditable</emphasis> is signaled as true, the device shall accept any decibel value provided as input, automatically adjust it within its operating range, and return the adjusted value in a subsequent get operation.</para>
+        <para>When a specific EQPreset is designated as the default, it will become active whenever the scheduler is inactive. Additionally, in the event of any conflicts within the scheduler, the default preset will remain active. Only one preset can be set as the default among the EQ presets linked to an audio output. If all presets have isDefault parameter set to false, the device may automatically select one preset as the default.</para>
+        <variablelist role="op">
+          <varlistentry>
+            <term>request</term>
+            <listitem>
+              <para role="param">Configuration  - [tt:EQPreset]</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>response</term>
+            <listitem>
+              <para role="text">This message is empty.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>faults</term>
+            <listitem>
+              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoConfig</para>
+              <para role="text">The requested configuration does not exist in the given context.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>access class</term>
+            <listitem>
+              <para role="access">WRITE_SYSTEM</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+      </section>
     </section>
     <section xml:id="_Ref484170228">
       <title>GetServiceCapabilities</title>

--- a/doc/Media2.xml
+++ b/doc/Media2.xml
@@ -1139,39 +1139,6 @@
           </itemizedlist>
           <para>Acoustic echo cancellation is out of ONVIF scope.</para>
         </section>
-        <section xml:id="SetEQPreset">
-          <title>SetEQPreset</title>
-          <para>This command configures the Audio EQPreset, provided it is supported. Refer to the <emphasis role="bold">AudioOutputConfigurationOptions</emphasis> response, associated with the audio output, to verify whether the EQPreset is supported and configurable.</para>
-          <para>When <emphasis role="bold">isFrequencyDecibelEditable</emphasis> is signaled as true, the device shall accept any decibel value provided as input, automatically adjust it within its operating range, and return the adjusted value in a subsequent get operation.</para>
-          <para>When a specific EQPreset is designated as the default, it will become active whenever the scheduler is inactive. Additionally, in the event of any conflicts within the scheduler, the default preset will remain active. Only one preset can be set as the default among the EQ presets linked to an audio output. If all presets have isDefault parameter set to false, the device may automatically select one preset as the default.</para>
-          <variablelist role="op">
-          <varlistentry>
-            <term>request</term>
-            <listitem>
-              <para role="param">Configuration  - [tt:EQPreset]</para>
-            </listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>response</term>
-            <listitem>
-              <para role="text">This message is empty.</para>
-            </listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>faults</term>
-            <listitem>
-              <para role="param">env:Sender - ter:InvalidArgVal - ter:NoConfig</para>
-              <para role="text">The requested configuration does not exist in the given context.</para>
-            </listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>access class</term>
-            <listitem>
-              <para role="access">WRITE_SYSTEM</para>
-            </listitem>
-          </varlistentry>
-        </variablelist>
-        </section>
       </section>
       <section>
         <title>Audio decoder configuration</title>
@@ -2704,6 +2671,39 @@
           </varlistentry>
         </variablelist>
       </section>
+    </section>
+    <section xml:id="SetEQPreset">
+      <title>SetEQPreset</title>
+      <para>This command configures the Audio EQPreset, provided it is supported. Refer to the <emphasis role="bold">AudioOutputConfigurationOptions</emphasis> response, associated with the audio output, to verify whether the EQPreset is supported and configurable.</para>
+      <para>When <emphasis role="bold">isFrequencyDecibelEditable</emphasis> is signaled as true, the device shall accept any decibel value provided as input, automatically adjust it within its operating range, and return the adjusted value in a subsequent get operation.</para>
+      <para>When a specific EQPreset is designated as the default, it will become active whenever the scheduler is inactive. Additionally, in the event of any conflicts within the scheduler, the default preset will remain active. Only one preset can be set as the default among the EQ presets linked to an audio output. If all presets have isDefault parameter set to false, the device may automatically select one preset as the default.</para>
+      <variablelist role="op">
+        <varlistentry>
+          <term>request</term>
+          <listitem>
+            <para role="param">Configuration  - [tt:EQPreset]</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>response</term>
+          <listitem>
+            <para role="text">This message is empty.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>faults</term>
+          <listitem>
+            <para role="param">env:Sender - ter:InvalidArgVal - ter:NoConfig</para>
+            <para role="text">The requested configuration does not exist in the given context.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>access class</term>
+          <listitem>
+            <para role="access">WRITE_SYSTEM</para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
     </section>
     <section xml:id="_Ref484170228">
       <title>GetServiceCapabilities</title>


### PR DESCRIPTION
The configuration section should contain one compact paragraph per profile configuration entity.
Moved the SetEQPreset method description to the methods section. No textual changes.