### PR TITLE
Privlege level for changing multicast configuration.

### DIFF
--- a/doc/Media2.xml
+++ b/doc/Media2.xml
@@ -1186,6 +1186,13 @@
           configuration reported by GetReceivers as long as the profile doesn't include any other
           video or audio source configuration.</para>
       </section>
+      <section>
+        <title>Multicast configuration</title>
+        <para>Video and audio encoder configurations as well as metadata configuration include
+          multicast configuration to be used in conjunction with RTSP. Note that modification of
+          multicast settings may require WRITE_SYSTEM privileges as it corresponds to network
+          configuration.</para>
+      </section>
     </section>
     <section>
       <title>Media Configuration Methods</title>


### PR DESCRIPTION
Clarify  that changing multicast configuration may require higher privilege level than standard actuate as it affects device network configuration.