### PR TITLE
Add error code to signal that deletion cannot proceed.

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -6682,6 +6682,8 @@ onvif://www.onvif.org/name/ARV-453
             <listitem>
               <para role="param">env:Sender - ter:InvalidArgVal - ter:NoConfig</para>
               <para role="text">The requested storage configuration does not exist.</para>
+              <para role="param">env:Receiver - ter:Action - ter:ConfigurationConflict</para>
+              <para role="text">The device cannot delete the configuration because it is in use.</para>
             </listitem>
           </varlistentry>
           <varlistentry>


### PR DESCRIPTION
Fix for #792: 

- add error code when a storage cannot be deleted because it is in use.