### PR TITLE
Feature add close signaling

### DIFF
--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -897,6 +897,11 @@ Client -> Server: { "method": "extend", "params": {"session": "s1", "authorizati
                 "id": 4}
 Server -> Client: { "error": {"code": -32601, "message": "Method not found"}, "id": "4"}
 ...
+Client -> Server: { "method": "close", "params": {"session": "s1"}, "id": 5}
+Server -> Device: { "method": "close", "params": {"session": "s1"}, "id": 5}
+Device -> Server: { "result": {}, "id": 5}
+Server -> Client: { "result": {}, "id": 5}
+...
 Device -> Server: { "error": {"code": 1001, "message": "Insufficient resources"}}
 Server -> Client: { "error": {"code": 1001, "message": "Insufficient resources"}}
 

--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -661,6 +661,9 @@
         client and device. After the session has been established the client can terminate the
         WebSocket session to the signaling server and the peer-to-peer connection will not be
         affected. The only reason to keep the connection to the server is if the client needs to extend the session.</para>
+      <para>To actively release device resources such as ICE candidates and TURN connections, the
+        client may send the <literal>close</literal> command (see <xref linkend="section_close"/>)
+        before terminating the WebSocket session.</para>
     </section>
     <section xml:id="section_extend">
       <title>extend</title>

--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -729,7 +729,45 @@
           </varlistentry>
         </variablelist>
       </section>
-    </section>  
+    </section>
+    <section xml:id="section_close">
+      <title>close</title>
+      <para>An ONVIF compliant signaling server, device and client shall support this
+        command to actively terminate a streaming session.</para>
+      <para>A signaling server shall relay this command unaltered to the peer. Upon
+        receiving the close command the device shall stop media streaming and release
+        resources such as ICE candidates and TURN connections.</para>
+      <variablelist role="op">
+        <varlistentry>
+          <term>request</term>
+          <listitem>
+            <para role="param">session [string]</para>
+            <para role="text">The ID assigned by the signaling server to the session.</para>
+            <para role="param">reason optional [string]</para>
+            <para role="text">A short description of why the session is closed.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>response</term>
+          <listitem>
+            <para role="text">&lt;none&gt;</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>faults</term>
+          <listitem>
+            <para role="param">400 Bad Request</para>
+            <para role="text">Invalid session ID.</para>
+            <para role="param">404 Not Found</para>
+            <para role="text">The session does not exist.</para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+      <para>The close command is idempotent: if the session has already been closed, the
+        signaling server shall return a successful response rather than 404, so a client
+        can retry safely after a network interruption. The 404 fault applies only when the
+        session ID was never valid.</para>
+    </section>
     <section xml:id="section_error_notification">
       <title>error</title>
       <para>An ONVIF compliant signaling server, device and client shall support sending or receiving notifications signaling that an error has occurred.</para>

--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -770,6 +770,18 @@
         signaling server shall return a successful response rather than 404, so a client
         can retry safely after a network interruption. The 404 fault applies only when the
         session ID was never valid.</para>
+      <para>The close command is an optimization for prompt, graceful resource release and
+        explicit session-lifecycle signaling; it is not the sole mechanism by which resources
+        are reclaimed. A client may disappear at any time without sending close (for example, a
+        browser tab being closed by a user, or a network failure), in which case the close
+        command will never arrive. Devices and signaling servers shall therefore implement
+        automatic cleanup as a fallback: a signaling server shall detect a dropped WebSocket
+        connection (see the "Peer disconnected" error, <xref linkend="_Ref_possible_error_codes"
+        />), and may enforce session expiration using the expiryTimeSeconds property of the
+        connect command together with the extend command. Upon such detection, the device shall
+        stop media streaming and release resources such as ICE candidates and TURN connections
+        exactly as if a close command had been received. Implementations shall not assume that a
+        close command will always be delivered.</para>
     </section>
     <section xml:id="section_error_notification">
       <title>error</title>

--- a/doc/WebRTC.xml
+++ b/doc/WebRTC.xml
@@ -646,7 +646,8 @@
         <varlistentry>
           <term>faults</term>
           <listitem>
-            <para role="text">&lt;none&gt;</para>
+            <para role="text">No faults are defined for a malformed-but-transportable request; see
+              the handling of already-closed sessions below.</para>
           </listitem>
         </varlistentry>
       </variablelist>
@@ -657,6 +658,12 @@
       <para><emphasis role="bold">NOTE</emphasis>: Note that ICE candidates can arrive <emphasis
         role="bold">before</emphasis> the SDP offer and the implementing client needs to handle
         this.</para>
+      <para>If a trickle command is received for a session that has already been closed, the
+        signaling server shall respond successfully to the requester and shall not relay the
+        candidate to the peer. This is an exception to the relay requirement above and accounts
+        for in-flight candidates that are still in transit when a session is being torn down; it
+        is consistent with the idempotent design of the close command, under which an
+        already-closed session is not treated as an error.</para>
       <para>If everything works as it should, a peer-to-peer WebRTC session can be set up between
         client and device. After the session has been established the client can terminate the
         WebSocket session to the signaling server and the peer-to-peer connection will not be
@@ -697,9 +704,16 @@
               <para role="text">The authorization token cannot be verified. The authorization token may not include the required claims, or has expired.</para>
               <para role="param">403 Forbidden</para>
               <para role="text">The client is not authorized to connect to the provided peer.</para>
+              <para role="param">404 Not Found</para>
+              <para role="text">The session does not exist or has already been closed.</para>
             </listitem>
           </varlistentry>
         </variablelist>
+        <para>Unlike the close command, which is idempotent by design, an extend command
+          received for a session that has already been closed shall be rejected with 404, so the
+          client is not left believing a dead session is still alive. An extend for an
+          already-closed session is a state-change request with no valid target, not a retryable
+          notification.</para>
       </section>
       <section xml:id="section_extend_device">
         <title>extend - Signaling Server to Device</title>
@@ -782,6 +796,9 @@
         stop media streaming and release resources such as ICE candidates and TURN connections
         exactly as if a close command had been received. Implementations shall not assume that a
         close command will always be delivered.</para>
+      <para>Behavior for trickle and extend commands received after a session has closed is
+        defined in their respective sections; implementations shall not assume the peer has seen
+        the close before such messages arrive.</para>
     </section>
     <section xml:id="section_error_notification">
       <title>error</title>

--- a/doc/media/WebRTC/webrtc_signaling_flow.svg
+++ b/doc/media/WebRTC/webrtc_signaling_flow.svg
@@ -2,10 +2,10 @@
 <svg
    xml:space="preserve"
    width="710.979"
-   height="615.961"
+   height="631.961"
    preserveAspectRatio="xMidYMid"
    version="1.2"
-   viewBox="0 0 18811.318 16297.305"
+   viewBox="0 0 18811.318 16700"
    id="svg1524"
    sodipodi:docname="webrtc_signaling_flow.svg"
    style="fill-rule:evenodd;stroke-width:28.222;stroke-linejoin:round"
@@ -284,7 +284,7 @@
    id="path50"
    inkscape:connector-curvature="0" />
       <path
-   d="m 2587,2587 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 127"
+   d="m 2587,2587 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 527"
    style="fill:none;stroke:#000000;stroke-width:30.5638"
    transform="matrix(0.964,0,0,0.9655,-636.069,-520.01)"
    id="path52"
@@ -303,7 +303,7 @@
    id="path56"
    inkscape:connector-curvature="0" />
       <path
-   d="m 10525,2587 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 127"
+   d="m 10525,2587 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 527"
    style="fill:none;stroke:#000000;stroke-width:30.5638"
    transform="matrix(0.964,0,0,0.9655,-636.069,-520.01)"
    id="path58"
@@ -962,29 +962,115 @@
        x="10814.328"
        style="stroke-width:27.2272"><tspan
          id="tspan1086"
-         style="fill:#000000;stroke:none;stroke-width:27.2272">trickle(SessionID, ICE-Candidate)</tspan></tspan></tspan></text><path
+         style="fill:#000000;stroke:none;stroke-width:27.2272">trickle(SessionID, ICE-Candidate)</tspan></tspan></tspan></text>
+
+    <!-- close command: request Client -> Server -> Device -->
+    <path
    inkscape:connector-curvature="0"
-   id="path1082-5"
-   style="vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:27.7077;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Lstart-2)"
-   d="M 9710.6352,15741.25 H 17619.082" /><text
-   id="text1140-5"
+   id="path-close-req-cs"
+   style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:27.4025;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4.3;stroke-dashoffset:0;stroke-opacity:1"
+   stroke-dasharray="none"
+   marker-end="url(#Arrow1Lend)"
+   d="M 1857.8607,15741.25 H 9608.9719" /><text
+   id="text-close-req-cs"
    transform="scale(0.9992229,1.0007777)"
    class="TextShape"
-   x="1078.5759"
-   y="2499.5525"
-   style="font-size:11.577px;fill-rule:evenodd;stroke-width:27.2272;stroke-linejoin:round"><tspan
-     id="tspan1138-1"
+   x="373.97006"
+   y="390.47769"
+   style="font-size:11.577px;stroke-width:27.2272"><tspan
+     class="TextParagraph"
+     font-size="352"
+     font-weight="400"
+     style="font-weight:400;font-size:339.592px;font-family:'Liberation Sans', sans-serif;stroke-width:27.2272"
+     id="tspan-close-req-cs"><tspan
+       x="4507.9224"
+       y="15723.014"
+       class="TextPosition"
+       id="tspan-pos-close-req-cs"
+       style="stroke-width:27.2272"><tspan
+         style="fill:#000000;stroke:none;stroke-width:27.2272"
+         id="tspan-txt-close-req-cs">close(SessionID, <tspan
+   style="fill:#0000ff"
+   id="tspan-close-reason">Reason</tspan>)</tspan></tspan></tspan></text>
+    <path
+   inkscape:connector-curvature="0"
+   id="path-close-req-sd"
+   style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:27.7733;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4.3;stroke-dashoffset:0;stroke-opacity:1"
+   stroke-dasharray="none"
+   marker-end="url(#Arrow1Lend)"
+   d="M 9646.1217,15863.25 H 17594.061" /><text
+   id="text-close-req-sd"
+   transform="scale(0.9992229,1.0007777)"
+   class="TextShape"
+   x="-3404.5032"
+   y="953.72394"
+   style="font-size:11.577px;stroke-width:27.2272"><tspan
+     id="tspan-close-req-sd"
      style="font-weight:400;font-size:339.592px;font-family:'Liberation Sans', sans-serif;stroke-width:27.2272"
      font-weight="400"
      font-size="352"
      class="TextParagraph"><tspan
-       id="tspan1136-7"
+       id="tspan-pos-close-req-sd"
        class="TextPosition"
-       y="15667.421"
-       x="12861.063"
+       y="15845.014"
+       x="9757.5781"
        style="stroke-width:27.2272"><tspan
-         id="tspan1086-1"
-         style="fill:#000000;stroke:none;stroke-width:27.2272">closed()</tspan></tspan></tspan></text>
+         id="tspan-txt-close-req-sd"
+         style="fill:#000000;stroke:none;stroke-width:27.2272">close(SessionID, <tspan
+   style="fill:#0000ff"
+   id="tspan-close-reason-2">Reason</tspan>)</tspan></tspan></tspan></text>
+
+    <!-- close command: response Device -> Server -> Client -->
+    <path
+   inkscape:connector-curvature="0"
+   id="path-close-res-ds"
+   style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:27.7734;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4.3;stroke-dashoffset:0;stroke-opacity:1"
+   stroke-dasharray="111.093, 27.7734"
+   marker-start="url(#Arrow1Lstart)"
+   d="M 9646.1219,15985.25 H 17594.061" /><text
+   id="text-close-res-ds"
+   transform="scale(0.9992229,1.0007777)"
+   class="TextShape"
+   x="-3404.5032"
+   y="953.72394"
+   style="font-size:11.577px;stroke-width:27.2272"><tspan
+     id="tspan-close-res-ds"
+     style="font-weight:400;font-size:339.592px;font-family:'Liberation Sans', sans-serif;stroke-width:27.2272"
+     font-weight="400"
+     font-size="352"
+     class="TextParagraph"><tspan
+       id="tspan-pos-close-res-ds"
+       class="TextPosition"
+       y="15967.014"
+       x="12402.448"
+       style="stroke-width:27.2272"><tspan
+         id="tspan-txt-close-res-ds"
+         style="fill:#000000;stroke:none;stroke-width:27.2272">()</tspan></tspan></tspan></text>
+    <path
+   inkscape:connector-curvature="0"
+   id="path-close-res-sc"
+   style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:27.4025;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4.3;stroke-dashoffset:0;stroke-opacity:1"
+   stroke-dasharray="109.609, 27.4025"
+   marker-start="url(#Arrow1Lstart)"
+   d="M 1857.8607,16107.25 H 9608.9719" /><text
+   id="text-close-res-sc"
+   transform="scale(0.9992229,1.0007777)"
+   class="TextShape"
+   x="373.97006"
+   y="390.47769"
+   style="font-size:11.577px;stroke-width:27.2272"><tspan
+     class="TextParagraph"
+     font-size="352"
+     font-weight="400"
+     style="font-weight:400;font-size:339.592px;font-family:'Liberation Sans', sans-serif;stroke-width:27.2272"
+     id="tspan-close-res-sc"><tspan
+       x="4507.9224"
+       y="16089.014"
+       class="TextPosition"
+       id="tspan-pos-close-res-sc"
+       style="stroke-width:27.2272"><tspan
+         style="fill:#000000;stroke:none;stroke-width:27.2272"
+         id="tspan-txt-close-res-sc">()</tspan></tspan></tspan></text>
 
 
 
@@ -1294,7 +1380,7 @@
      transform="matrix(0.964,0,0,0.9655,-636.069,-520.01)"
      id="path56-5"
      inkscape:connector-curvature="0" /><path
-     d="m 10525,2587 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 127"
+     d="m 10525,2587 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 161 m 0,81 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,80 v 162 m 0,81 v 162 m 0,81 v 527"
      style="fill:none;stroke:#000000;stroke-width:30.5638"
      transform="matrix(0.964,0,0,0.9655,-636.069,-520.01)"
      id="path58-3"


### PR DESCRIPTION
The ONVIF WebRTC specification lacks an explicit stream close signaling mechanism, leading to resource waste, difficult state management, state inconsistency, and degraded user experience. It is recommended to add this mechanism so clients can actively notify devices to stop streaming, release resources promptly, enable platforms to accurately track session lifecycles, and improve system performance and user experience.