### PR TITLE
MaximumNumberOfKeys - Issue #778 clarification

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -4857,7 +4857,7 @@
                   <para>MaximumNumberOfKeys</para>
                 </entry>
                 <entry>
-                  <para>Indicates the maximum number of private keys that the device is able to store
+                  <para>Indicates the minimum supported number of private keys that the device is able to store
                     simultaneously.</para>
                 </entry>
               </row>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -4857,8 +4857,7 @@
                   <para>MaximumNumberOfKeys</para>
                 </entry>
                 <entry>
-                  <para>Indicates the minimum supported number of private keys that the device is able to store
-                    simultaneously.</para>
+                  <para>Indicates the guaranteed number of private keys the device supports storing simultaneously.</para>
                 </entry>
               </row>
               <row>


### PR DESCRIPTION
MaximumNumberOfKeys - Since it is not able to test maximum capability with RSA and ECC Keys simultaneously, this parameter  description is changed to minimum supported number of private keys that the device is able to store simultaneously.