### PR TITLE
Add support for HTTP Basic authentication over TLS-protected connections (RFC 7617)

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -2286,9 +2286,8 @@ DATE: when response was generated
         <para>
           <itemizedlist>
             <listitem>
-              <para>accept a request that includes an Authorization header using the Basic scheme
-                without having received a prior challenge, except where HTTP is used to tunnel RTSP
-                requests;</para>
+              <para>accept a request carrying an Authorization header using the Basic scheme even if
+                no challenge was sent;</para>
             </listitem>
             <listitem>
               <para>include a Basic challenge in the WWW-Authenticate header only over TLS-protected

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -2280,7 +2280,8 @@ DATE: when response was generated
               HTTPS.</para>
           </listitem>
         </itemizedlist>
-        <para>A device that supports HTTP Basic authentication over HTTPS shall signal the HttpBasic capability as true.</para>
+        <para>A device that supports HTTP Basic authentication over TLS-protected connections shall
+          signal the HttpBasic capability as true.</para>
         <para>If server supports both digest authentication as specified in [RFC 2617] and the user name token profile as specified in WS-Security the following behavior shall be adapted: a web service request can be authenticated on the HTTP level via digest authentication [RFC 2617] or on the web service level via the WS-Security (WSS) framework. If a client does not supply authentication credentials along with a web service request, the server shall assume that the client intends to use digest authentication [RFC 2617], if required. Hence, if a client does not provide authentication credentials when requesting a service that requires authentication, it will receive an HTTP 401 error according to [RFC 2617]. Note that this behaviour on the server’s side differs from the case of supporting only username token profile, which requires for this case an HTTP 400 error on the HTTP level and a SOAP:Fault env:Sender ter:NotAuthorized error on the WS level.</para>
         <para>A client should not simultaneously supply authentication credentials on both the HTTP level and the WS level. If a server receives a web service request that contains authentication credentials on both the HTTP level and the WS level, it shall first validate the credentials provided on the HTTP layer. If this validation was successful, the server shall finally validate the authentication credentials provided on the WS layer.</para>
         <para><xref linkend="AuthenticationFlow"/> summarizes the authentication of a web service request by a server over HTTP and HTTPS.</para>
@@ -3308,7 +3309,7 @@ onvif://www.onvif.org/name/ARV-453
                   </entry>
                   <entry>
                     <para>Indication if the device supports HTTP Basic authentication according to
-                      [RFC 7617], only over HTTPS.</para>
+                      [RFC 7617], only over TLS-protected connections.</para>
                   </entry>
                 </row>
                 <row>
@@ -9745,10 +9746,11 @@ http://www.onvif.org/ver10/tev/topicExpression/ConcreteSet
       </section>
   </appendix>
   <appendix xml:id="basic_auth_https_example">
-    <title>HTTP Basic authentication over HTTPS example</title>
-    <para>The following exchange between client and device over HTTPS demonstrates a device
-      supporting HTTP Basic authentication according to [RFC 7617] in addition to digest
-      authentication. HTTP Basic authentication shall only be used over HTTPS.</para>
+    <title>HTTP Basic authentication over TLS-protected connection</title>
+    <para>The following exchange between client and device over TLS-protected connection
+      demonstrates a device supporting HTTP Basic authentication according to [RFC 7617] in addition
+      to digest authentication. A device shall accept the request from the client that includes an
+      Authorization header using the Basic scheme without having received a prior challenge.</para>
     <para>Unauthenticated request from the client:</para>
     <programlisting><![CDATA[POST /onvif/device_service HTTP/1.1
 Host: 10.XX.XX.XX
@@ -9767,8 +9769,7 @@ WWW-Authenticate: Basic realm="onvif"
 WWW-Authenticate: Digest algorithm=MD5, realm="onvif", qop="auth",
 nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"
 WWW-Authenticate: Digest algorithm=SHA-256, realm="onvif", qop="auth",
-nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"
-X-Frame-Options: SAMEORIGIN]]></programlisting>
+nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"]]></programlisting>
     <para>Authenticated request from the client, using HTTP Basic authentication</para>
     <programlisting><![CDATA[POST /onvif/device_service HTTP/1.1
 Host: 10.XX.XX.XX
@@ -9788,8 +9789,7 @@ WWW-Authenticate: Basic realm="onvif"
 WWW-Authenticate: Digest algorithm=MD5, realm="onvif", qop="auth",
 nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"
 WWW-Authenticate: Digest algorithm=SHA-256, realm="onvif", qop="auth",
-nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"
-X-Frame-Options: SAMEORIGIN]]></programlisting>
+nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"]]></programlisting>
   </appendix>
   <appendix role="revhistory">
     <title>Revision History</title>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -2312,7 +2312,13 @@ DATE: when response was generated
         <para>JWT client authorization should only be used over TLS secured connections, in order to
           protect bearer tokens against replay attacks.</para>
         <para>An ONVIF compliant device should authenticate an RTSP request at the RTSP level. If HTTP is used to tunnel the RTSP request the device shall not authenticate on the HTTP level.</para>
-        <para>When authenticating RTSP or HTTP methods, an ONVIF compliant device shall use digest authentication [RFC 2617], HTTP Basic authentication [RFC 7617] over TLS-protected connections or JWT-based authorization. The credentials shall be managed with the GetUsers, CreateUsers, DeleteUsers and SetUser methods. If the device also supports WS-Security, the same set of credentials shall be used.</para>
+        <para>When authenticating RTSP or HTTP methods, an ONVIF compliant device shall use digest
+          authentication [RFC 2617], HTTP Basic authentication [RFC 7617] over TLS-protected
+          connections or JWT-based authorization. The credentials for digest and HTTP Basic
+          authentication shall be managed with the GetUsers, CreateUsers, DeleteUsers and SetUser
+          methods. If the device also supports WS-Security, the same set of credentials shall be
+          used. The parameters used to validate JWT-based authorization shall be in accordance to
+          the ONVIF Security Service Specification.</para>
       </section>
       <section>
         <title>Authentication over SCTP</title>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -553,6 +553,8 @@
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc2617.txt"></link>&gt;</para>
     <para>RFC 7616, HTTP Digest Access Authentication</para>
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc7616.txt"></link>&gt;</para>
+    <para>RFC 7617, The 'Basic' HTTP Authentication Scheme</para>
+    <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc7617.txt"></link>&gt;</para>
     <para>RFC 3315, Dynamic Host Configuration Protocol for IPv6 (DHCPv6)</para>
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc3315.txt"></link>&gt;</para>
     <para>RFC 3548, The Base16, Base32, and Base64 Data Encodings</para>
@@ -2271,10 +2273,14 @@ DATE: when response was generated
             <para>TLS client authorization and</para>
           </listitem>
           <listitem>
+            <para>Devices supporting HTTP Basic authentication according to [RFC 7617], only over HTTPS, and</para>
+          </listitem>
+          <listitem>
             <para>Devices supporting JWT client authorization based on [RFC 6750], only over
               HTTPS.</para>
           </listitem>
         </itemizedlist>
+        <para>A device that supports HTTP Basic authentication over HTTPS shall signal the HttpBasic capability as true.</para>
         <para>If server supports both digest authentication as specified in [RFC 2617] and the user name token profile as specified in WS-Security the following behavior shall be adapted: a web service request can be authenticated on the HTTP level via digest authentication [RFC 2617] or on the web service level via the WS-Security (WSS) framework. If a client does not supply authentication credentials along with a web service request, the server shall assume that the client intends to use digest authentication [RFC 2617], if required. Hence, if a client does not provide authentication credentials when requesting a service that requires authentication, it will receive an HTTP 401 error according to [RFC 2617]. Note that this behaviour on the server’s side differs from the case of supporting only username token profile, which requires for this case an HTTP 400 error on the HTTP level and a SOAP:Fault env:Sender ter:NotAuthorized error on the WS level.</para>
         <para>A client should not simultaneously supply authentication credentials on both the HTTP level and the WS level. If a server receives a web service request that contains authentication credentials on both the HTTP level and the WS level, it shall first validate the credentials provided on the HTTP layer. If this validation was successful, the server shall finally validate the authentication credentials provided on the WS layer.</para>
         <para><xref linkend="AuthenticationFlow"/> summarizes the authentication of a web service request by a server over HTTP and HTTPS.</para>
@@ -2290,7 +2296,7 @@ DATE: when response was generated
         <para>JWT client authorization should only be used over TLS secured connections, in order to
           protect bearer tokens against replay attacks.</para>
         <para>An ONVIF compliant device should authenticate an RTSP request at the RTSP level. If HTTP is used to tunnel the RTSP request the device shall not authenticate on the HTTP level.</para>
-        <para>When authenticating RTSP or HTTP methods, an ONVIF compliant device shall use digest authentication [RFC 2617] or JWT-based authorization. The credentials shall be managed with the GetUsers, CreateUsers, DeleteUsers and SetUser methods. If the device also supports WS-Security, the same set of credentials shall be used.</para>
+        <para>When authenticating RTSP or HTTP methods, an ONVIF compliant device shall use digest authentication [RFC 2617], HTTP Basic authentication [RFC 7617] or JWT-based authorization. The credentials shall be managed with the GetUsers, CreateUsers, DeleteUsers and SetUser methods. If the device also supports WS-Security, the same set of credentials shall be used.</para>
       </section>
       <section>
         <title>Authentication over SCTP</title>
@@ -3262,7 +3268,7 @@ onvif://www.onvif.org/name/ARV-453
                   </entry>
                 </row>
                 <row>
-                  <entry morerows="17">
+                  <entry morerows="18">
                     <para>Security</para>
                   </entry>
                   <entry>
@@ -3294,6 +3300,16 @@ onvif://www.onvif.org/name/ARV-453
                   </entry>
                   <entry>
                     <para>Indication if the device supports the HTTP digest authentication. </para>
+                  </entry>
+                </row>
+                <row>
+                  <entry>
+                    <para>HttpBasic</para>
+                  </entry>
+                  <entry>
+                    <para>Indication if the device supports HTTP Basic authentication according to
+                      [RFC 7617], only over HTTPS. For backward compatibility this feature is
+                      disabled by default.</para>
                   </entry>
                 </row>
                 <row>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -2283,7 +2283,6 @@ DATE: when response was generated
         </itemizedlist>
         <para>A device that supports HTTP Basic authentication shall signal the HttpBasic capability
           as true and shall:</para>
-        <para>
           <itemizedlist>
             <listitem>
               <para>accept a request carrying an Authorization header using the Basic scheme even if
@@ -2298,7 +2297,6 @@ DATE: when response was generated
                 WWW-Authenticate header of each 401 response.</para>
             </listitem>
           </itemizedlist>
-        </para>
         <para>If server supports both digest authentication as specified in [RFC 2617] and the user name token profile as specified in WS-Security the following behavior shall be adapted: a web service request can be authenticated on the HTTP level via digest authentication [RFC 2617] or on the web service level via the WS-Security (WSS) framework. If a client does not supply authentication credentials along with a web service request, the server shall assume that the client intends to use digest authentication [RFC 2617], if required. Hence, if a client does not provide authentication credentials when requesting a service that requires authentication, it will receive an HTTP 401 error according to [RFC 2617]. Note that this behaviour on the server’s side differs from the case of supporting only username token profile, which requires for this case an HTTP 400 error on the HTTP level and a SOAP:Fault env:Sender ter:NotAuthorized error on the WS level.</para>
         <para>A client should not simultaneously supply authentication credentials on both the HTTP level and the WS level. If a server receives a web service request that contains authentication credentials on both the HTTP level and the WS level, it shall first validate the credentials provided on the HTTP layer. If this validation was successful, the server shall finally validate the authentication credentials provided on the WS layer.</para>
         <para><xref linkend="AuthenticationFlow"/> summarizes the authentication of a web service request by a server over HTTP and HTTPS.</para>
@@ -9766,12 +9764,14 @@ http://www.onvif.org/ver10/tev/topicExpression/ConcreteSet
     <title>HTTP Basic authentication over TLS-protected connection</title>
     <para>The following exchange between client and device over TLS-protected connection
       demonstrates a device supporting HTTP Basic authentication according to [RFC 7617] in addition
-      to digest authentication.</para>
+      to digest authentication.The initial unauthenticated request and challenge are shown for
+      completeness. A client is not required to wait for a challenge before supplying Basic
+      credentials; it may include the Authorization header in its first request.</para>
     <para>Unauthenticated request from the client:</para>
     <programlisting><![CDATA[POST /onvif/device_service HTTP/1.1
 Host: 10.XX.XX.XX
 Content-Type: application/soap+xml; charset=utf-8
-Content-Length: 299
+Content-Length: 308
 
 <?xml version="1.0" encoding="utf-8"?>
 <s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
@@ -9791,7 +9791,7 @@ nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"]]></programlisting>
 Host: 10.XX.XX.XX
 Authorization: Basic dXNlcjpwYXNzd29yZA==
 Content-Type: application/soap+xml; charset=utf-8
-Content-Length: 299
+Content-Length: 308
 
 <?xml version="1.0" encoding="utf-8"?>
 <s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -9744,6 +9744,53 @@ http://www.onvif.org/ver10/tev/topicExpression/ConcreteSet
         better understanding.</para>
       </section>
   </appendix>
+  <appendix xml:id="basic_auth_https_example">
+    <title>HTTP Basic authentication over HTTPS example</title>
+    <para>The following exchange between client and device over HTTPS demonstrates a device
+      supporting HTTP Basic authentication according to [RFC 7617] in addition to digest
+      authentication. HTTP Basic authentication shall only be used over HTTPS.</para>
+    <para>Unauthenticated request from the client:</para>
+    <programlisting><![CDATA[POST /onvif/device_service HTTP/1.1
+Host: 10.XX.XX.XX
+Content-Type: application/soap+xml; charset=utf-8
+Content-Length: 299
+
+<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+<s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<GetDeviceInformation xmlns="http://www.onvif.org/ver10/device/wsdl"/>
+</s:Body></s:Envelope>]]></programlisting>
+    <para>Response from the device challenging for authentication</para>
+    <programlisting><![CDATA[HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Basic realm="onvif"
+WWW-Authenticate: Digest algorithm=MD5, realm="onvif", qop="auth",
+nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"
+WWW-Authenticate: Digest algorithm=SHA-256, realm="onvif", qop="auth",
+nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"
+X-Frame-Options: SAMEORIGIN]]></programlisting>
+    <para>Authenticated request from the client, using HTTP Basic authentication</para>
+    <programlisting><![CDATA[POST /onvif/device_service HTTP/1.1
+Host: 10.XX.XX.XX
+Authorization: Basic dXNlcjpwYXNzd29yZA==
+Content-Type: application/soap+xml; charset=utf-8
+Content-Length: 299
+
+<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+<s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<GetDeviceInformation xmlns="http://www.onvif.org/ver10/device/wsdl"/>
+</s:Body></s:Envelope>]]></programlisting>
+    <para>Response from the device, rejecting invalid credentials</para>
+    <programlisting><![CDATA[HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Basic realm="onvif"
+WWW-Authenticate: Digest algorithm=MD5, realm="onvif", qop="auth",
+nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"
+WWW-Authenticate: Digest algorithm=SHA-256, realm="onvif", qop="auth",
+nonce="62d82aa9ca59e3a04cd1", opaque="5b6ea228"
+X-Frame-Options: SAMEORIGIN]]></programlisting>
+  </appendix>
   <appendix role="revhistory">
     <title>Revision History</title>
     <para/>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -2273,7 +2273,8 @@ DATE: when response was generated
             <para>TLS client authorization and</para>
           </listitem>
           <listitem>
-            <para>Devices supporting HTTP Basic authentication according to [RFC 7617], only over HTTPS, and</para>
+            <para>Devices supporting HTTP Basic authentication according to [RFC 7617], only over
+              TLS-protected connections, and</para>
           </listitem>
           <listitem>
             <para>Devices supporting JWT client authorization based on [RFC 6750], only over
@@ -2281,7 +2282,9 @@ DATE: when response was generated
           </listitem>
         </itemizedlist>
         <para>A device that supports HTTP Basic authentication over TLS-protected connections shall
-          signal the HttpBasic capability as true.</para>
+          signal the HttpBasic capability as true, such a device shall accept the request from the
+          client that includes an Authorization header using the Basic scheme without having
+          received a prior challenge.</para>
         <para>If server supports both digest authentication as specified in [RFC 2617] and the user name token profile as specified in WS-Security the following behavior shall be adapted: a web service request can be authenticated on the HTTP level via digest authentication [RFC 2617] or on the web service level via the WS-Security (WSS) framework. If a client does not supply authentication credentials along with a web service request, the server shall assume that the client intends to use digest authentication [RFC 2617], if required. Hence, if a client does not provide authentication credentials when requesting a service that requires authentication, it will receive an HTTP 401 error according to [RFC 2617]. Note that this behaviour on the server’s side differs from the case of supporting only username token profile, which requires for this case an HTTP 400 error on the HTTP level and a SOAP:Fault env:Sender ter:NotAuthorized error on the WS level.</para>
         <para>A client should not simultaneously supply authentication credentials on both the HTTP level and the WS level. If a server receives a web service request that contains authentication credentials on both the HTTP level and the WS level, it shall first validate the credentials provided on the HTTP layer. If this validation was successful, the server shall finally validate the authentication credentials provided on the WS layer.</para>
         <para><xref linkend="AuthenticationFlow"/> summarizes the authentication of a web service request by a server over HTTP and HTTPS.</para>
@@ -2297,7 +2300,7 @@ DATE: when response was generated
         <para>JWT client authorization should only be used over TLS secured connections, in order to
           protect bearer tokens against replay attacks.</para>
         <para>An ONVIF compliant device should authenticate an RTSP request at the RTSP level. If HTTP is used to tunnel the RTSP request the device shall not authenticate on the HTTP level.</para>
-        <para>When authenticating RTSP or HTTP methods, an ONVIF compliant device shall use digest authentication [RFC 2617], HTTP Basic authentication [RFC 7617] or JWT-based authorization. The credentials shall be managed with the GetUsers, CreateUsers, DeleteUsers and SetUser methods. If the device also supports WS-Security, the same set of credentials shall be used.</para>
+        <para>When authenticating RTSP or HTTP methods, an ONVIF compliant device shall use digest authentication [RFC 2617], HTTP Basic authentication [RFC 7617] over TLS-protected connections or JWT-based authorization. The credentials shall be managed with the GetUsers, CreateUsers, DeleteUsers and SetUser methods. If the device also supports WS-Security, the same set of credentials shall be used.</para>
       </section>
       <section>
         <title>Authentication over SCTP</title>
@@ -9749,8 +9752,7 @@ http://www.onvif.org/ver10/tev/topicExpression/ConcreteSet
     <title>HTTP Basic authentication over TLS-protected connection</title>
     <para>The following exchange between client and device over TLS-protected connection
       demonstrates a device supporting HTTP Basic authentication according to [RFC 7617] in addition
-      to digest authentication. A device shall accept the request from the client that includes an
-      Authorization header using the Basic scheme without having received a prior challenge.</para>
+      to digest authentication.</para>
     <para>Unauthenticated request from the client:</para>
     <programlisting><![CDATA[POST /onvif/device_service HTTP/1.1
 Host: 10.XX.XX.XX

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -3308,8 +3308,7 @@ onvif://www.onvif.org/name/ARV-453
                   </entry>
                   <entry>
                     <para>Indication if the device supports HTTP Basic authentication according to
-                      [RFC 7617], only over HTTPS. For backward compatibility this feature is
-                      disabled by default.</para>
+                      [RFC 7617], only over HTTPS.</para>
                   </entry>
                 </row>
                 <row>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -2281,10 +2281,25 @@ DATE: when response was generated
               HTTPS.</para>
           </listitem>
         </itemizedlist>
-        <para>A device that supports HTTP Basic authentication over TLS-protected connections shall
-          signal the HttpBasic capability as true, such a device shall accept the request from the
-          client that includes an Authorization header using the Basic scheme without having
-          received a prior challenge.</para>
+        <para>A device that supports HTTP Basic authentication shall signal the HttpBasic capability
+          as true and shall:</para>
+        <para>
+          <itemizedlist>
+            <listitem>
+              <para>accept a request that includes an Authorization header using the Basic scheme
+                without having received a prior challenge, except where HTTP is used to tunnel RTSP
+                requests;</para>
+            </listitem>
+            <listitem>
+              <para>include a Basic challenge in the WWW-Authenticate header only over TLS-protected
+                connections;</para>
+            </listitem>
+            <listitem>
+              <para>support digest authentication and include a Digest challenge in the
+                WWW-Authenticate header of each 401 response.</para>
+            </listitem>
+          </itemizedlist>
+        </para>
         <para>If server supports both digest authentication as specified in [RFC 2617] and the user name token profile as specified in WS-Security the following behavior shall be adapted: a web service request can be authenticated on the HTTP level via digest authentication [RFC 2617] or on the web service level via the WS-Security (WSS) framework. If a client does not supply authentication credentials along with a web service request, the server shall assume that the client intends to use digest authentication [RFC 2617], if required. Hence, if a client does not provide authentication credentials when requesting a service that requires authentication, it will receive an HTTP 401 error according to [RFC 2617]. Note that this behaviour on the server’s side differs from the case of supporting only username token profile, which requires for this case an HTTP 400 error on the HTTP level and a SOAP:Fault env:Sender ter:NotAuthorized error on the WS level.</para>
         <para>A client should not simultaneously supply authentication credentials on both the HTTP level and the WS level. If a server receives a web service request that contains authentication credentials on both the HTTP level and the WS level, it shall first validate the credentials provided on the HTTP layer. If this validation was successful, the server shall finally validate the authentication credentials provided on the WS layer.</para>
         <para><xref linkend="AuthenticationFlow"/> summarizes the authentication of a web service request by a server over HTTP and HTTPS.</para>

--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -2285,13 +2285,17 @@ DATE: when response was generated
           as true and shall:</para>
           <itemizedlist>
             <listitem>
-              <para>accept a request carrying an Authorization header using the Basic scheme even if
-                no challenge was sent;</para>
+              <para>accept a request carrying an Authorization header using the Basic scheme over a
+              TLS-protected connection, even if no challenge was sent;</para>
             </listitem>
             <listitem>
-              <para>include a Basic challenge in the WWW-Authenticate header only over TLS-protected
-                connections;</para>
+              <para>include a Basic challenge in the WWW-Authenticate header of each 401 response
+              sent over a TLS-protected connection;</para>
             </listitem>
+          <listitem>
+            <para>respond with 401 and a WWW-Authenticate header offering only digest authentication
+              when Basic credentials are received over an unprotected connection;</para>
+          </listitem>
             <listitem>
               <para>support digest authentication and include a Digest challenge in the
                 WWW-Authenticate header of each 401 response.</para>

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -229,7 +229,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:attribute>
 				<xs:attribute name="HttpBasic" type="xs:boolean">
 					<xs:annotation>
-						<xs:documentation>Indicates support for WS over HTTPS basic authenticated communication layer according to RFC 7617. For backward compatibility this capability is disabled by default.</xs:documentation>
+						<xs:documentation>Indicates support for WS over HTTPS basic authenticated communication layer according to RFC 7617.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:attribute name="RELToken" type="xs:boolean">

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -229,7 +229,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:attribute>
 				<xs:attribute name="HttpBasic" type="xs:boolean">
 					<xs:annotation>
-						<xs:documentation>Indicates support for WS over HTTP basic authenticated communication layer according to RFC 7617.</xs:documentation>
+						<xs:documentation>Indicates support for WS over HTTP basic authenticated communication layer according to RFC 7617 for TLS-protected connections.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:attribute name="RELToken" type="xs:boolean">

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -227,6 +227,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:documentation>Indicates support for WS over HTTP digest authenticated communication layer.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
+				<xs:attribute name="HttpBasic" type="xs:boolean">
+					<xs:annotation>
+						<xs:documentation>Indicates support for WS over HTTPS basic authenticated communication layer according to RFC 7617. For backward compatibility this capability is disabled by default.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:attribute name="RELToken" type="xs:boolean">
 					<xs:annotation>
 						<xs:documentation>Indicates support for WS-Security REL token.</xs:documentation>

--- a/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -229,7 +229,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:attribute>
 				<xs:attribute name="HttpBasic" type="xs:boolean">
 					<xs:annotation>
-						<xs:documentation>Indicates support for WS over HTTPS basic authenticated communication layer according to RFC 7617.</xs:documentation>
+						<xs:documentation>Indicates support for WS over HTTP basic authenticated communication layer according to RFC 7617.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:attribute name="RELToken" type="xs:boolean">


### PR DESCRIPTION
## Add support for HTTP Basic authentication only over TLS-protected connections (RFC 7617)

### Motivation

As ONVIF devices increasingly operate in cloud-connected and TLS-only deployments, the current specification's exclusive reliance on HTTP Digest authentication creates friction for modern integration patterns:

- **Cloud and proxy architectures**: - Digest binds its response hash to the request URI, so it breaks whenever a gateway rewrites paths. A cloud service addressing cameras as `/devices/cam-42/onvif/device_service` and forwarding to `/onvif/device_service` invalidates every Digest response. The gateway must then authenticate to each device itself, which means storing an `HA1` per device. Basic is stateless and path-independent, so it forwards unchanged. The trade-off is that it requires TLS with validated certificates.

- **Regulatory direction**: The EU Cyber Resilience Act and NIS2 push deployments toward encrypted-by-default transport, making TLS-everywhere a common baseline.

- **Interoperability with standard HTTP clients and tooling**: HTTP Basic works out of the box in every HTTP client library, browser, and automation tool. Digest needs custom handling and is missing from many stacks.

This change introduces HTTP Basic authentication as an **optional, TLS-only** feature with an explicit capability signal (`HttpBasic`).

### Compatibility Analysis

| Aspect | Impact |
| --- | --- |
| Backward compatible | A device supporting Basic shall also support digest and include a Digest challenge in every 401 response. Existing Digest-only clients see unchanged behaviour and need not be aware of Basic. |
| Capability signalling | `HttpBasic` is optional; per existing Core convention, an omitted capability indicates the device does not support it. |
| Profiles | No profile requirements change. HTTP digest remains mandatory wherever profile specifications require it; this PR does not amend any profile document. |
| Discovery | Clients negotiate via the `WWW-Authenticate` challenge as HTTP requires; the capability is for configuration and planning, not negotiation. |
| Schema | New optional `HttpBasic` boolean attribute in `devicemgmt.wsdl` (GetServiceCapabilities path). |
| Security Service | No changes. All edits are scoped to Core and the Device Management WSDL. |

### Normative Requirements

A device that supports HTTP Basic authentication shall signal the `HttpBasic` capability as true and shall:

1. accept a request carrying an `Authorization` header using the Basic scheme over a TLS-protected connection, even if no challenge was sent;
2. include a Basic challenge in the `WWW-Authenticate` header of each 401 response sent over a TLS-protected connection;
3. respond with 401 and a `WWW-Authenticate` header offering only digest authentication when Basic credentials are received over a connection that is not TLS-protected;
4. support digest authentication and include a Digest challenge in the `WWW-Authenticate` header of each 401 response.

Each requirement maps to a conformance assertion:

| Requirement | A device fails it by |
| --- | --- |
| 2 | advertising a Basic challenge over plain HTTP |
| 3 | accepting Basic credentials over plain HTTP |
| 4 | supporting Basic without digest |

### Summary of Changes

#### `doc/Core.xml`

| Section | Change |
| --- | --- |
| Normative references | Added RFC 7617 |
| Authentication over HTTP and HTTPS | Added HTTP Basic over TLS-protected connections as an authentication exception alongside existing exceptions (WS-UsernameToken, TLS client auth, JWT) |
| Authentication over HTTP and HTTPS | Added four normative requirements for devices supporting Basic (see above) |
| Authentication over HTTP and HTTPS | Scoped the credential-management sentence to digest and HTTP Basic |
| Authentication over HTTP and HTTPS | Listed HTTP Basic over TLS-protected connections as an accepted authentication method for RTSP and HTTP methods |
| GetServiceCapabilities table | Added `HttpBasic` row to Security capabilities (updated `morerows` count) |
| Appendix (new) | HTTP Basic challenge-response example over a TLS-protected connection |
| Revision history | Added entry |

#### `wsdl/ver10/device/wsdl/devicemgmt.wsdl`

| Section | Change |
| --- | --- |
| `SecurityCapabilities` | Added `HttpBasic` boolean attribute |

### References

- [RFC 7617 - The 'Basic' HTTP Authentication Scheme](https://www.ietf.org/rfc/rfc7617.txt)
- [RFC 7616 - HTTP Digest Access Authentication](https://www.ietf.org/rfc/rfc7616.txt) (existing reference)
- [RFC 2617 - HTTP Authentication: Basic and Digest Access Authentication](https://www.ietf.org/rfc/rfc2617.txt) (existing reference)
