### PR TITLE
Add ID for PKCS12 key derivation to be used in capabilities.

### DIFF
--- a/doc/SecurityBaseline.xml
+++ b/doc/SecurityBaseline.xml
@@ -584,19 +584,19 @@
     <table xml:id="certTable">
       <title>Baseline for Encrypting Private Key</title>
       <tgroup cols="3">
-        <colspec colname="c1" colwidth="2*"/>
-        <colspec colname="c2" colwidth="1*"/>
-        <colspec colname="newCol3" colwidth="2*"/>
+        <colspec colname="c1" colwidth="15*"/>
+        <colspec colname="c2" colwidth="12*"/>
+        <colspec colname="newCol3" colwidth="12*"/>
         <thead>
           <row>
             <entry>
               <para>Name</para>
             </entry>
             <entry>
-              <para>Reference</para>
+              <para>Key</para>
             </entry>
             <entry>
-              <para>Capability</para>
+              <para>Reference</para>
             </entry>
           </row>
         </thead>
@@ -605,19 +605,17 @@
             <entry>
               <para>PBKDF2</para>
             </entry>
-            <entry>
-              <para>RFC 8018</para>
-            </entry>
-            <entry><para>PasswordBasedEncryptionAlgorithms</para></entry>
+            <entry><para>id-pkcs12-pbmac1-2023</para></entry>
+            <entry><para>RFC 8018, RFC 9579</para></entry>
           </row>
           <row>
             <entry>
               <para>AES-128-CBC</para>
             </entry>
+            <entry/>
             <entry>
               <para>RFC 7292</para>
             </entry>
-            <entry/>
           </row>
         </tbody>
       </tgroup>


### PR DESCRIPTION
Add key including reference to RFC.
Move RFC reference to last column as with most tables above and align columns spacing.
