### PR TITLE
Optional analytics rule filter for object properties.

### DIFF
--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -4147,6 +4147,34 @@
 </tt:RuleDescription>]]></programlisting>
         <para>Note that the order of parameters is arbitrary as long as the simple items are listed before the complex element items.</para>
       </section>
+      <section>
+        <title>Object properties</title>
+        <para>This optional parameter allows filtering against arbitrary object properties using
+            XPath. <variablelist role="op">
+              <varlistentry>
+                <term>Parameter</term>
+                <listitem>
+                  <para role="param">ObjectProperties - optional [xs:string]</para>
+                  <para role="text">XPath 1.0 expression describing object property
+                    constraints.</para>
+                </listitem>
+              </varlistentry>
+            </variablelist>
+          </para>
+        <para>Example specifying object property conditions for matching persons wearing shorts or no
+          hat:</para>
+        <programlisting><![CDATA[<tt:Rule Type=“tt:ObjectDetection" Name="TrousersAndHat>
+  <tt:Parameters>
+    <tt:SimpleItem Name="ClassFilter" Value="Person"/>
+    <tt:SimpleItem Name=“ObjectProperties" Value="//Bottoms[Category='Shorts'] or not(//Hat)"/>
+  </tt:Parameters>
+  <tt:Messages>
+    ...
+  </tt:Messages>
+</tt:RuleDescription>
+]]></programlisting>
+        
+      </section>
     </section>
       <section xml:id="Annex-Rules-PTZ">
         <title>Moving cameras</title>
@@ -4477,8 +4505,6 @@
             <para role="text">Minimum confidence level for accepting a classification.</para>
             <para role="param">DwellTime - optional [xs:duration]</para>
             <para role="text">Duration an object must be visible before accepting a classification.</para>
-            <para role="param">ObjectProperties - optional [xs:string]</para>
-            <para role="text">XPath 1.0 expression describing object property constraints.</para>
           </listitem>
         </varlistentry>
         <varlistentry>
@@ -4538,19 +4564,6 @@
   </tan:RuleOptions>
 </tan:GetRuleOptionsResponse>
 ]]></programlisting>
-      <para>Example specifying object property conditions for matching persons wearing shorts or no
-        hat:</para>
-      <programlisting><![CDATA[<tt:Rule Type=“tt:ObjectDetection" Name="TrousersAndHat>
-  <tt:Parameters>
-    <tt:SimpleItem Name="ClassFilter" Value="Person"/>
-    <tt:SimpleItem Name=“ObjectProperties" Value="//Bottoms[Category='Shorts'] or not(//Hat)"/>
-  </tt:Parameters>
-  <tt:Messages>
-    ...
-  </tt:Messages>
-</tt:RuleDescription>
-]]></programlisting>
-      
     </section>
 	<section>
       <title>Object Abandoned</title>

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -4477,6 +4477,8 @@
             <para role="text">Minimum confidence level for accepting a classification.</para>
             <para role="param">DwellTime - optional [xs:duration]</para>
             <para role="text">Duration an object must be visible before accepting a classification.</para>
+            <para role="param">ObjectProperties - optional [xs:string]</para>
+            <para role="text">XPath 1.0 expression describing object propertiy constraints.</para>
           </listitem>
         </varlistentry>
         <varlistentry>
@@ -4536,6 +4538,19 @@
   </tan:RuleOptions>
 </tan:GetRuleOptionsResponse>
 ]]></programlisting>
+      <para>Example specifying object property conditions for matching persons wearing shorts or no
+        hat:</para>
+      <programlisting><![CDATA[<tt:Rule Type=“tt:ObjectDetection" Name="TrousersAndHat>
+  <tt:Parameters>
+    <tt:SimpleItem Name="ClassFilter" Value="Person"/>
+    <tt:SimpleItem Name=“ObjectProperties" Value="//Bottoms[Category='Shorts'] or not(//Hat)"/>
+  </tt:Parameters>
+  <tt:Messages>
+    ...
+  </tt:Messages>
+</tt:RuleDescription>
+]]></programlisting>
+      
     </section>
 	<section>
       <title>Object Abandoned</title>

--- a/doc/Analytics.xml
+++ b/doc/Analytics.xml
@@ -4478,7 +4478,7 @@
             <para role="param">DwellTime - optional [xs:duration]</para>
             <para role="text">Duration an object must be visible before accepting a classification.</para>
             <para role="param">ObjectProperties - optional [xs:string]</para>
-            <para role="text">XPath 1.0 expression describing object propertiy constraints.</para>
+            <para role="text">XPath 1.0 expression describing object property constraints.</para>
           </listitem>
         </varlistentry>
         <varlistentry>


### PR DESCRIPTION
The proposal allows expressing filtering for arbitrary object properties.

By purpose no requirements on supported filtering is included as implementations typically do not implement filtering on the XML DOM tree.