### PR TITLE
Fix security service chapter numbers

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -4540,6 +4540,7 @@
           assigned media signing certificates by invoking GetCertificationPath with the
           CertificationPathID, followed by GetCertificates.</para>
       </section>
+    </section>
     <section xml:id="section_hd2_5r4_rwb">
       <title>Authorization Server Configuration</title>
       <para>This chapter describes configuration of external authorization servers. For an overview
@@ -5605,7 +5606,6 @@
       <title>Service specific data types</title>
       <para>The service specific data types are defined in security.wsdl.</para>
     </section>
-   </section>
   </chapter>
   <chapter>
     <title>Security Considerations</title>


### PR DESCRIPTION
While working on OAuth 2.1 I realized that 26.06 by mistake changes the numbers of chapters.

25.12 looks like this:

<img width="877" height="721" alt="image" src="https://github.com/user-attachments/assets/4e880dcd-8bac-4221-801a-9249dab783c5" />

26.06 looks like this:

<img width="895" height="543" alt="image" src="https://github.com/user-attachments/assets/58a3ff97-7d5b-44e3-aa62-e6f3bf056041" />

There is a `</section>` in the wrong place. 