### PR TITLE
Fix CurrentTime descriptions in event operations (#826)

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -7164,7 +7164,7 @@ Event description:
               <para role="param">SubscriptionReference [wsa:EndpointReferenceType]</para>
               <para role="text">Endpoint reference of the subscription to be used for pulling the messages.</para>
               <para role="param">CurrentTime [xs:dateTime]</para>
-              <para role="text">Current time of the server for synchronization purposes.</para>
+              <para role="text">Current time of the device for synchronization purposes.</para>
               <para role="param">TerminationTime [xs:dateTime]</para>
               <para role="text">Date time when the PullPoint will be shut down without further pull requests.</para>
             </listitem>
@@ -7217,7 +7217,7 @@ Event description:
             <term>response</term>
             <listitem>
               <para role="param">CurrentTime [xs:dateTime]</para>
-              <para role="text">The date and time when the messages have been delivered by the web server to the client.</para>
+              <para role="text">Current time of the device for synchronization purposes.</para>
               <para role="param">TerminationTime [xs:dateTime]</para>
               <para role="text">Date time when the PullPoint will be shut down without further pull requests.</para>
               <para role="param">NotificationMessage - optional, unbounded [wsnt:NotificationMessageHolderType]</para>
@@ -7263,7 +7263,7 @@ Event description:
             <term>response</term>
             <listitem>
               <para role="param">CurrentTime [xs:dateTime]</para>
-              <para role="text">The current server time.</para>
+              <para role="text">Current time of the device for synchronization purposes.</para>
               <para role="param">TerminationTime [xs:dateTime]</para>
               <para role="text">The updated TerminationTime for the SubscriptionManager.</para>
             </listitem>

--- a/wsdl/ver10/events/wsdl/event-vs.wsdl
+++ b/wsdl/ver10/events/wsdl/event-vs.wsdl
@@ -121,7 +121,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						</xs:element>
 						<xs:element ref="wsnt:CurrentTime">
 							<xs:annotation>
-								<xs:documentation>Current time of the server for synchronization purposes.</xs:documentation>
+								<xs:documentation>Current time of the device for synchronization purposes.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element ref="wsnt:TerminationTime">
@@ -156,7 +156,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<xs:sequence>
 						<xs:element name="CurrentTime" type="xs:dateTime">
 							<xs:annotation>
-								<xs:documentation>The date and time when the messages have been delivered by the web server to the client.</xs:documentation>
+								<xs:documentation>Current time of the device for synchronization purposes.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="TerminationTime" type="xs:dateTime">

--- a/wsdl/ver10/events/wsdl/event.wsdl
+++ b/wsdl/ver10/events/wsdl/event.wsdl
@@ -121,7 +121,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						</xs:element>
 						<xs:element ref="wsnt:CurrentTime">
 							<xs:annotation>
-								<xs:documentation>Current time of the server for synchronization purposes.</xs:documentation>
+								<xs:documentation>Current time of the device for synchronization purposes.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element ref="wsnt:TerminationTime">
@@ -156,7 +156,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<xs:sequence>
 						<xs:element name="CurrentTime" type="xs:dateTime">
 							<xs:annotation>
-								<xs:documentation>The date and time when the messages have been delivered by the web server to the client.</xs:documentation>
+								<xs:documentation>Current time of the device for synchronization purposes.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="TerminationTime" type="xs:dateTime">


### PR DESCRIPTION
Reason: the CurrentTime descriptions in PullMessagesResponse, RenewResponse and CreatePullPointSubscriptionResponse contradict each other; harmonized on a single device wording.

Compatibility: documentation only, no schema or behavior change.

Fixes #826
