### PR TITLE
Fix the issue 815, seteqpreset method name updated to fix the WSI Bas…

### DIFF
--- a/doc/Media2.xml
+++ b/doc/Media2.xml
@@ -2682,8 +2682,8 @@
     </section>
     <section>
       <title>EQ Presets</title>
-      <section xml:id="SetEQPreset">
-        <title>SetEQPreset</title>
+      <section xml:id="SetEQPresetConfiguration">
+        <title>SetEQPresetConfiguration</title>
         <para>This command configures the Audio EQPreset, provided it is supported. Refer to the <emphasis role="bold">AudioOutputConfigurationOptions</emphasis> response, associated with the audio output, to verify whether the EQPreset is supported and configurable.</para>
         <para>When <emphasis role="bold">isFrequencyDecibelEditable</emphasis> is signaled as true, the device shall accept any decibel value provided as input, automatically adjust it within its operating range, and return the adjusted value in a subsequent get operation.</para>
         <para>When a specific EQPreset is designated as the default, it will become active whenever the scheduler is inactive. Additionally, in the event of any conflicts within the scheduler, the default preset will remain active. Only one preset can be set as the default among the EQ presets linked to an audio output. If all presets have isDefault parameter set to false, the device may automatically select one preset as the default.</para>

--- a/wsdl/ver20/media/wsdl/media.wsdl
+++ b/wsdl/ver20/media/wsdl/media.wsdl
@@ -1924,10 +1924,10 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	<wsdl:message name="SetAudioDecoderConfigurationResponse">
 		<wsdl:part name="parameters" element="tr2:SetAudioDecoderConfigurationResponse"/>
 	</wsdl:message>
-	<wsdl:message name="SetEQPresetRequest">
+	<wsdl:message name="SetEQPresetConfigurationRequest">
     	<wsdl:part name="parameters" element="tr2:SetEQPresetConfiguration"/>
     </wsdl:message>
-	<wsdl:message name="SetEQPresetResponse">
+	<wsdl:message name="SetEQPresetConfigurationResponse">
     	<wsdl:part name="parameters" element="tr2:SetEQPresetConfigurationResponse"/>
     </wsdl:message>
 	<!--===============================-->
@@ -2341,10 +2341,10 @@ support streaming video data of such a profile.<br/>
 			<wsdl:input message="tr2:GetAudioDecoderConfigurationOptionsRequest"/>
 			<wsdl:output message="tr2:GetAudioDecoderConfigurationOptionsResponse"/>
 		</wsdl:operation>
-		<wsdl:operation name="SetEQPreset">
+		<wsdl:operation name="SetEQPresetConfiguration">
 			<wsdl:documentation>This command is to configure Audio EQPreset.</wsdl:documentation>
-    		<wsdl:input message="tr2:SetEQPresetRequest"/>
-    		<wsdl:output message="tr2:SetEQPresetResponse"/>
+    		<wsdl:input message="tr2:SetEQPresetConfigurationRequest"/>
+    		<wsdl:output message="tr2:SetEQPresetConfigurationResponse"/>
 		</wsdl:operation>
 		<!--===============================-->
 		<wsdl:operation name="GetVideoEncoderInstances">
@@ -2758,8 +2758,8 @@ image will be updated automatically and independent from calls to GetSnapshotUri
 				<soap:body parts="parameters" use="literal"/>
 			</wsdl:output>
 		</wsdl:operation>
-		<wsdl:operation name="SetEQPreset">
-			<soap:operation soapAction="http://www.onvif.org/ver20/media/wsdl/SetEQPreset"/>
+		<wsdl:operation name="SetEQPresetConfiguration">
+			<soap:operation soapAction="http://www.onvif.org/ver20/media/wsdl/SetEQPresetConfiguration"/>
 			<wsdl:input>
 				<soap:body parts="parameters" use="literal"/>
 			</wsdl:input>


### PR DESCRIPTION
Fixes #815. 

Updated the WSDL operation name, messages, SOAP action, and documentation to `SetEQPresetConfiguration` to match the parameter element name (`tr2:SetEQPresetConfiguration`) in accordance with WS-I Basic Profile guidelines.