### PR TITLE
Metadata track clarification added based on issue number 816

### DIFF
--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -2326,7 +2326,7 @@ secfrac = "." 1*6DIGIT</programlisting>
       <para>
         If a recording contains a metadata track, independent of the <literal>Format</literal> configured for the recording, the device shall describe the metadata track with an <literal>XMLMetaDataSampleEntry</literal> ('metx') sample entry, as defined for timed metadata tracks in the ONVIF Export File Format Specification.
         The device shall set the <literal>namespace</literal> field of the sample entry to <literal>'http://www.onvif.org/ver10/schema'</literal>.
-        The device shall set the <literal>content_encoding</literal> field of the sample entry according to the compression, if any, applied to the metadata samples.
+        The device shall set <literal>content_encoding</literal> to the applied compression, or leave it empty if none is applied.
       </para>
     </section>
     <section xml:id="_refCloudRecordingEncryption">

--- a/doc/RecordingControl.xml
+++ b/doc/RecordingControl.xml
@@ -2321,6 +2321,14 @@ secfrac = "." 1*6DIGIT</programlisting>
         </mediaobject>
       </figure>
     </section>
+    <section xml:id="_refCloudRecordingMetadataTrack">
+      <title>Metadata track</title>
+      <para>
+        If a recording contains a metadata track, independent of the <literal>Format</literal> configured for the recording, the device shall describe the metadata track with an <literal>XMLMetaDataSampleEntry</literal> ('metx') sample entry, as defined for timed metadata tracks in the ONVIF Export File Format Specification.
+        The device shall set the <literal>namespace</literal> field of the sample entry to <literal>'http://www.onvif.org/ver10/schema'</literal>.
+        The device shall set the <literal>content_encoding</literal> field of the sample entry according to the compression, if any, applied to the metadata samples.
+      </para>
+    </section>
     <section xml:id="_refCloudRecordingEncryption">
       <title>Encryption</title>
       <para>


### PR DESCRIPTION
# Fix for Issue
   #816
# Changes
- Added requirement to use `XMLMetaDataSampleEntry` (`'metx'`) for metadata tracks regardless of the configured recording `Format`.