### PR TITLE
Add ter:MaxUplinksReached error code

### DIFF
--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -510,7 +510,7 @@
             <para role="text">CertificateID and AuthorizationServerConfigurationToken are mutually exclusive.</para>
             <para role="param">env:Sender - ter:InvalidArgs - ter:ProtocolNotSupported</para>
             <para role="text">The provided protocol is not supported by the device.</para>
-            <para role="param">ter:Receiver - ter:Action - ter:MaxUplinksReached</para>
+            <para role="param">env:Receiver - ter:Action - ter:MaxUplinksReached</para>
             <para>The maximum number of  Uplinks supported by the device has been reached.</para>
           </listitem>
         </varlistentry>

--- a/doc/Uplink.xml
+++ b/doc/Uplink.xml
@@ -510,6 +510,8 @@
             <para role="text">CertificateID and AuthorizationServerConfigurationToken are mutually exclusive.</para>
             <para role="param">env:Sender - ter:InvalidArgs - ter:ProtocolNotSupported</para>
             <para role="text">The provided protocol is not supported by the device.</para>
+            <para role="param">ter:Receiver - ter:Action - ter:MaxUplinksReached</para>
+            <para>The maximum number of  Uplinks supported by the device has been reached.</para>
           </listitem>
         </varlistentry>
         <varlistentry>


### PR DESCRIPTION
This is a fix for the issue raised in cloud profile wg https://github.com/onvif/wg_profile_cloud/issues/213

Added a new error code that device shall return when SetUplink is called when device already has MaxUplinks created/reached.