### PR TITLE
Fix spelling and grammar errors in schema files

### DIFF
--- a/wsdl/ver10/pacs/types.xsd
+++ b/wsdl/ver10/pacs/types.xsd
@@ -46,7 +46,7 @@ CERTAIN WRITTEN POLICIES OF THE CORPORATION.
 	<!--===============================-->
 	<xs:complexType name="DataEntity">
 		<xs:annotation>
-			<xs:documentation>General datastructure referenced by a token.
+			<xs:documentation>General data structure referenced by a token.
 				Should be used as extension base.
 			</xs:documentation>
 		</xs:annotation>
@@ -109,7 +109,7 @@ CERTAIN WRITTEN POLICIES OF THE CORPORATION.
 		</xs:attribute>
 		<xs:attribute name="Value" type="xs:string">
 			<xs:annotation>
-				<xs:documentation>Value of attribute</xs:documentation>
+				<xs:documentation>Value of attribute.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:anyAttribute processContents="lax"/>

--- a/wsdl/ver10/schema/common.xsd
+++ b/wsdl/ver10/schema/common.xsd
@@ -295,7 +295,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		</xs:attribute>
 		<xs:attribute name="elevation" type="xs:float">
 			<xs:annotation>
-				<xs:documentation>Hight in meters above sea level.</xs:documentation>
+				<xs:documentation>Height in meters above sea level.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:anyAttribute/>

--- a/wsdl/ver10/schema/metadatastream.xsd
+++ b/wsdl/ver10/schema/metadatastream.xsd
@@ -74,7 +74,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:enumeration value="DataMatrix"/>
 			<xs:enumeration value="Maxicode"/>
 			<xs:enumeration value="Postnet"/>
-			<xs:enumeration value="RM4SCC"/> <!--RoyalMail-->
+			<xs:enumeration value="RM4SCC"/> <!-- Royal Mail -->
 			<xs:enumeration value="ISBN-13"/>
 			<xs:enumeration value="ISBN-13-Dual"/>
 			<xs:enumeration value="ISBN-10"/>
@@ -98,17 +98,17 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:sequence>
 			<xs:element name="Data" type="tt:StringLikelihood">
 			<xs:annotation> 
-				<xs:documentation>Information encoded in barcode</xs:documentation> 
+				<xs:documentation>Information encoded in the barcode.</xs:documentation>
 			</xs:annotation>
 			</xs:element> 
-			<xs:element name="Type" type="tt:StringLikelihood" minOccurs="0">  <!-- refer tt:BarcodeType for supported values  Optional " --> 
+			<xs:element name="Type" type="tt:StringLikelihood" minOccurs="0">  <!-- Refer to tt:BarcodeType for supported values. Optional. -->
 			<xs:annotation> 
-				<xs:documentation>Acceptable values are defined in tt:BarcodeType</xs:documentation> 
+				<xs:documentation>Acceptable values are defined in tt:BarcodeType.</xs:documentation>
 			</xs:annotation> 
 			</xs:element> 
 			<xs:element name="PPM" type="xs:float" minOccurs="0"> 
 			<xs:annotation> 
-				<xs:documentation>Refers to the pixels per module</xs:documentation> 
+				<xs:documentation>Refers to the pixels per module.</xs:documentation>
 			</xs:annotation>
 			</xs:element> 
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>       <!-- first ONVIF then vendor --> 
@@ -147,7 +147,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:sequence>
 			<xs:element name="PlateNumber" type="tt:StringLikelihood"> 
 			<xs:annotation> 
-				<xs:documentation>A string of vehicle license plate number.</xs:documentation> 
+				<xs:documentation>A string of vehicle license plate number.</xs:documentation>
 			</xs:annotation> 
 			</xs:element> 
 			<xs:element name="PlateType" type="tt:StringLikelihood" minOccurs="0" maxOccurs="1">  <!-- tt:PlateType lists the acceptable values" -->
@@ -162,7 +162,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element> 
 			<xs:element name="IssuingEntity" type="tt:StringLikelihood" minOccurs="0" maxOccurs="1"> 
 			<xs:annotation> 
-			   <xs:documentation>State province or authority that issue the license plate.</xs:documentation> 
+				<xs:documentation>State, province or authority that issues the license plate.</xs:documentation>
 			</xs:annotation> 
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>      <!-- first ONVIF then vendor -->  
@@ -192,7 +192,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:enumeration value="Bicycle"/>
 			<xs:enumeration value="Vehicle"/>
 			<xs:enumeration value="LicensePlate"/>
-			<xs:enumeration value="Bike"/>	<!-- any of bicycle, motorcycle, motorbike -->
+			<xs:enumeration value="Bike"/>	<!-- Any of bicycle, motorcycle, motorbike. -->
 			<xs:enumeration value="Barcode"/>
 			<xs:enumeration value="Fire"/>
 			<xs:enumeration value="Smoke"/>
@@ -221,7 +221,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:element name="Extension" type="tt:ClassDescriptorExtension" minOccurs="0"/>  <!-- Deprecated --> 
 			<xs:element name="Type" type="tt:StringLikelihood" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>For well-defined values see tt:ObjectType. Other type definitions like tt:VehicleType may be applied as well.</xs:documentation>
+					<xs:documentation>For well-defined values, see tt:ObjectType. Other type definitions like tt:VehicleType may be applied as well.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- reserved for ONVIF -->
@@ -249,7 +249,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:element name="Likelihood" type="xs:float">
 				<xs:annotation>
-					<xs:documentation>A likelihood/probability that the corresponding object belongs to this class. The sum of the likelihoods shall NOT exceed 1</xs:documentation>
+					<xs:documentation>A likelihood/probability that the corresponding object belongs to this class. The sum of the likelihoods shall NOT exceed 1.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- first Vendor then ONVIF -->
@@ -267,12 +267,12 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:sequence>
 				<xs:attribute name="Parent" type="xs:integer">
 					<xs:annotation>
-						<xs:documentation>Object ID of the parent object. eg: License plate object has Vehicle object as parent.</xs:documentation>
+						<xs:documentation>Object ID of the parent object. E.g. a license plate object has a vehicle object as parent.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:attribute name="ParentUUID" type="xs:string">
 					<xs:annotation>
-						<xs:documentation>Object UUID of the parent object. eg: License plate object has Vehicle object as parent.</xs:documentation>
+						<xs:documentation>Object UUID of the parent object. E.g. a license plate object has a vehicle object as parent.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
@@ -407,7 +407,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		</xs:attribute>
 		<xs:attribute name="Cells" type="xs:base64Binary" use="required">
 			<xs:annotation>
-				<xs:documentation>A "1" denotes a cell where motion is detected and a "0" an empty cell. The first cell is in the upper left corner. Then the cell order goes first from left to right and then from up to down.  If the number of cells is not a multiple of 8 the last byte is filled with zeros. The information is run length encoded according to Packbit coding in ISO 12369 (TIFF, Revision 6.0).</xs:documentation>
+				<xs:documentation>A "1" denotes a cell where motion is detected and a "0" denotes an empty cell. The first cell is in the upper-left corner. Then the cell order goes first from left to right and then from up to down. If the number of cells is not a multiple of 8, the last byte is filled with zeros. The information is run-length encoded according to PackBits coding in ISO 12369 (TIFF, Revision 6.0).</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:anyAttribute processContents="lax"/>
@@ -415,7 +415,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	
 	<xs:complexType name="ObjectTrack">
 		<xs:annotation>
-			<xs:documentation>An Object track includes a sequence of object states representing how an object's state changes over time.</xs:documentation>
+			<xs:documentation>An object track includes a sequence of object states representing how an object's state changes over time.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="ObjectState" type="tt:ObjectState" minOccurs="1" maxOccurs="unbounded"/>
@@ -425,7 +425,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	
 	<xs:complexType name="ObjectState">
 		<xs:annotation>
-			<xs:documentation>An object state describes an object's condition, for e.g position, speed and appearance, at a certain time instance.</xs:documentation>
+			<xs:documentation>An object state describes an object's condition, e.g position, speed and appearance, at a certain time instance.</xs:documentation>
 		</xs:annotation>
 		<xs:complexContent>
 			<xs:extension base="tt:Object">

--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -903,7 +903,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:element name="EncodingIntervalRange" type="tt:IntRange">
 				<xs:annotation>
-					<xs:documentation>Supported encoding interval range. The encoding interval corresponds to the number of frames devided by the encoded frames. An encoding interval value of "1" means that all frames are encoded.</xs:documentation>
+					<xs:documentation>Supported encoding interval range. The encoding interval corresponds to the number of frames divided by the encoded frames. An encoding interval value of "1" means that all frames are encoded.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
@@ -944,7 +944,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:element name="EncodingIntervalRange" type="tt:IntRange">
 				<xs:annotation>
-					<xs:documentation>Supported encoding interval range. The encoding interval corresponds to the number of frames devided by the encoded frames. An encoding interval value of "1" means that all frames are encoded.</xs:documentation>
+					<xs:documentation>Supported encoding interval range. The encoding interval corresponds to the number of frames divided by the encoded frames. An encoding interval value of "1" means that all frames are encoded.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Mpeg4ProfilesSupported" type="tt:Mpeg4Profile" maxOccurs="unbounded">
@@ -990,7 +990,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:element name="EncodingIntervalRange" type="tt:IntRange">
 				<xs:annotation>
-					<xs:documentation>Supported encoding interval range. The encoding interval corresponds to the number of frames devided by the encoded frames. An encoding interval value of "1" means that all frames are encoded.</xs:documentation>
+					<xs:documentation>Supported encoding interval range. The encoding interval corresponds to the number of frames divided by the encoded frames. An encoding interval value of "1" means that all frames are encoded.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="H264ProfilesSupported" type="tt:H264Profile" maxOccurs="unbounded">
@@ -1337,7 +1337,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:sequence>
 			<xs:element name="Encoding" type="tt:AudioEncoding">
 				<xs:annotation>
-					<xs:documentation>The enoding used for audio data (either G.711, G.726 or AAC).</xs:documentation>
+					<xs:documentation>The encoding used for audio data (either G.711, G.726 or AAC).</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="BitrateList" type="tt:IntItems">
@@ -1666,7 +1666,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:element name="ZoomStatusSupported" type="xs:boolean">
 				<xs:annotation>
-					<xs:documentation>True if the device is able to stream zoom status inforamtion.</xs:documentation>
+					<xs:documentation>True if the device is able to stream zoom status information.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
@@ -2395,7 +2395,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			</xs:element>
 			<xs:element name="Port" type="xs:int">
 				<xs:annotation>
-					<xs:documentation>The RTP mutlicast destination port. A device may support RTCP. In this case the port value shall be even to allow the corresponding RTCP stream to be mapped to the next higher (odd) destination port number as defined in the RTSP specification.</xs:documentation>
+					<xs:documentation>The RTP multicast destination port. A device may support RTCP. In this case the port value shall be even to allow the corresponding RTCP stream to be mapped to the next higher (odd) destination port number as defined in the RTSP specification.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="TTL" type="xs:int">
@@ -2743,7 +2743,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 		<xs:sequence>
 			<xs:element name="AcceptRouterAdvert" type="xs:boolean" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Indicates whether router advertisment is used.</xs:documentation>
+					<xs:documentation>Indicates whether router advertisement is used.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="DHCP" type="tt:IPv6DHCPConfiguration">
@@ -2768,7 +2768,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			</xs:element>
 			<xs:element name="FromRA" type="tt:PrefixedIPv6Address" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>List of IPv6 addresses configured by using router advertisment.</xs:documentation>
+					<xs:documentation>List of IPv6 addresses configured by using router advertisement.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Extension" type="tt:IPv6ConfigurationExtension" minOccurs="0"/>
@@ -3122,7 +3122,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			</xs:element>
 			<xs:element name="AcceptRouterAdvert" type="xs:boolean" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Indicates whether router advertisment is used.</xs:documentation>
+					<xs:documentation>Indicates whether router advertisement is used.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Manual" type="tt:PrefixedIPv6Address" minOccurs="0" maxOccurs="unbounded">
@@ -3320,7 +3320,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 					<xs:documentation>
 					According to IEEE802.11-2007 H.4.1 a pass-phrase is a sequence of between 8 and 63 ASCII-encoded characters and
 					each character in the pass-phrase must have an encoding in the range of 32 to 126 (decimal),inclusive.<br/>
-					If only Passpharse is supplied the Key shall be derived using the algorithm described in IEEE802.11-2007 section H.4
+					If only Passphrase is supplied the Key shall be derived using the algorithm described in IEEE802.11-2007 section H.4
 				</xs:documentation>
 				</xs:annotation>
 			</xs:element>
@@ -4133,12 +4133,12 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 	<!--===============================-->
 	<xs:complexType name="SystemDateTime">
 		<xs:annotation>
-			<xs:documentation>General date time inforamtion returned by the GetSystemDateTime method.</xs:documentation>
+			<xs:documentation>General date time information returned by the GetSystemDateTime method.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="DateTimeType" type="tt:SetDateTimeType">
 				<xs:annotation>
-					<xs:documentation>Indicates if the time is set manully or through NTP.</xs:documentation>
+					<xs:documentation>Indicates if the time is set manually or through NTP.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="DaylightSavings" type="xs:boolean">
@@ -4454,7 +4454,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 		<xs:sequence>
 			<xs:element name="TLSConfiguration" type="tt:TLSConfiguration" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Confgiuration information for TLS Method.</xs:documentation>
+					<xs:documentation>Configuration information for TLS Method.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Password" type="xs:string" minOccurs="0">
@@ -5418,7 +5418,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			</xs:element>
 			<xs:element name="Home" type="xs:boolean" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>An option to indicate Home postion for tour spots.</xs:documentation>
+					<xs:documentation>An option to indicate Home position for tour spots.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="PanTiltPositionSpace" type="tt:Space2DDescription" minOccurs="0">
@@ -5739,7 +5739,7 @@ If set to 0.0, infinity will be used.</xs:documentation>
 	<!--===============================-->
 	<xs:simpleType name="BacklightCompensationMode">
 		<xs:annotation>
-			<xs:documentation>Enumeration describing the available backlight compenstation modes.</xs:documentation>
+			<xs:documentation>Enumeration describing the available backlight compensation modes.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="OFF">
@@ -6624,7 +6624,7 @@ If set to 0.0, infinity will be used.</xs:documentation>
 		<xs:sequence>
 			<xs:element name="BoundaryType" type="xs:string" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>Supported options of boundary types for adjustment of Ir cut filter auto mode. The opptions shall be chosen from tt:IrCutFilterAutoBoundaryType. </xs:documentation>
+					<xs:documentation>Supported options of boundary types for adjustment of Ir cut filter auto mode. The options shall be chosen from tt:IrCutFilterAutoBoundaryType. </xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="BoundaryOffset" type="xs:boolean" minOccurs="0">
@@ -7146,7 +7146,7 @@ If set to 0.0, infinity will be used.</xs:documentation>
 		<xs:sequence>
 			<xs:element name="SimpleItemDescription" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>Description of a simple item. The type must be of cathegory simpleType (xs:string, xs:integer, xs:float, ...).</xs:documentation>
+					<xs:documentation>Description of a simple item. The type must be of category simpleType (xs:string, xs:integer, xs:float, ...).</xs:documentation>
 				</xs:annotation>
 				<xs:complexType>
 					<xs:attribute name="Name" type="xs:string" use="required">
@@ -7496,7 +7496,7 @@ and sample rate. </xs:documentation>
 			</xs:element>
 			<xs:element name="Area" type="tt:Rectangle">
 				<xs:annotation>
-					<xs:documentation>Describes the location and size of the area on the monitor. The area coordinate values are espressed in normalized units [-1.0, 1.0].</xs:documentation>
+					<xs:documentation>Describes the location and size of the area on the monitor. The area coordinate values are expressed in normalized units [-1.0, 1.0].</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
@@ -7506,7 +7506,7 @@ and sample rate. </xs:documentation>
 	<!--===============================-->
 	<xs:complexType name="Layout">
 		<xs:annotation>
-			<xs:documentation>A layout describes a set of Video windows that are displayed simultaniously on a display. </xs:documentation>
+			<xs:documentation>A layout describes a set of Video windows that are displayed simultaneously on a display. </xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="PaneLayout" type="tt:PaneLayout" maxOccurs="unbounded">
@@ -7542,7 +7542,7 @@ and sample rate. </xs:documentation>
 			</xs:element>
 			<xs:element name="VideoDecodingCapabilities" type="tt:VideoDecoderConfigurationOptions">
 				<xs:annotation>
-					<xs:documentation>This section describes the supported video codesc and their configuration.</xs:documentation>
+					<xs:documentation>This section describes the supported video codecs and their configuration.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
@@ -7911,7 +7911,7 @@ and sample rate. </xs:documentation>
 			</xs:element>
 			<xs:element name="Time" type="xs:dateTime">
 				<xs:annotation>
-					<xs:documentation>The time when the event occured.</xs:documentation>
+					<xs:documentation>The time when the event occurred.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Event" type="wsnt:NotificationMessageHolderType">
@@ -8136,7 +8136,7 @@ and sample rate. </xs:documentation>
 	<xs:complexType name="RecordingSourceInformation">
 		<xs:annotation>
 			<xs:documentation>
-				A set of informative desciptions of a data source. The Search searvice allows a client to filter on recordings based on information in this structure.
+				A set of informative descriptions of a data source. The Search service allows a client to filter on recordings based on information in this structure.
 			</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
@@ -9295,7 +9295,7 @@ and sample rate. </xs:documentation>
 	<!--===============================-->
 	<xs:complexType name="OSDColor">
 		<xs:annotation>
-			<xs:documentation>The value range of "Transparent" could be defined by vendors only should follow this rule: the minimum value means non-transparent and the maximum value maens fully transparent.</xs:documentation>
+				<xs:documentation>The value range of "Transparent" could be defined by vendors only and should follow this rule: the minimum value means non-transparent and the maximum value means fully transparent.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="Color" type="tt:Color"/>
@@ -9449,7 +9449,7 @@ and sample rate. </xs:documentation>
 			</xs:element>
 			<xs:element name="Transparent" type="tt:IntRange" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Range of the transparent level. Larger means more tranparent.</xs:documentation>
+					<xs:documentation>Range of the transparent level. Larger means more transparent.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Extension" type="tt:OSDColorOptionsExtension" minOccurs="0"/>

--- a/wsdl/ver20/analytics/humanbody.xsd
+++ b/wsdl/ver20/analytics/humanbody.xsd
@@ -28,12 +28,12 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:sequence>	
 			<xs:element name="Height" type="xs:int" minOccurs="0"> 
 			<xs:annotation> 
-				<xs:documentation>Describe the Stature of the body, the unit is centimeter.</xs:documentation> 
+				<xs:documentation>Describe the stature of the body, the unit is centimeters.</xs:documentation>
 			</xs:annotation>
 			</xs:element>
 			<xs:element name="BodyShape" type="xs:string" minOccurs="0">
 			<xs:annotation>
-				<xs:documentation>Describle the Shape of the body, acceptable values are defined in bd:BodyShape.</xs:documentation>
+				<xs:documentation>Describe the shape of the body, acceptable values are defined in bd:BodyShape.</xs:documentation>
 			</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
@@ -199,27 +199,27 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:sequence>
 			<xs:element name="Scarf" type="bd:Scarf" minOccurs="0">
 			<xs:annotation>
-				<xs:documentation>Describe the Scarf of the body,acceptable values are defined in bd:Scarf.</xs:documentation>
+				<xs:documentation>Describe the Scarf of the body, acceptable values are defined in bd:Scarf.</xs:documentation>
 			</xs:annotation>
 			</xs:element>
 			<xs:element name="Gloves" type="bd:Gloves" minOccurs="0">
 			<xs:annotation>
-				<xs:documentation>Describe Gloves of the body,acceptable values are defined in bd:Gloves.</xs:documentation>
+				<xs:documentation>Describe Gloves of the body, acceptable values are defined in bd:Gloves.</xs:documentation>
 			</xs:annotation>
 			</xs:element>
 			<xs:element name="Tops" type="bd:Tops" minOccurs="0">
 			<xs:annotation>
-				<xs:documentation>Describe the Tops of the body,acceptable values are defined in bd:Tops.</xs:documentation>
+				<xs:documentation>Describe the Tops of the body, acceptable values are defined in bd:Tops.</xs:documentation>
 			</xs:annotation>
 			</xs:element>
 			<xs:element name="Bottoms" type="bd:Bottoms" minOccurs="0">
 			<xs:annotation>
-				<xs:documentation>Describe the Bottoms of the body,acceptable values are defined in bd:Bottoms.</xs:documentation>
+				<xs:documentation>Describe the Bottoms of the body, acceptable values are defined in bd:Bottoms.</xs:documentation>
 			</xs:annotation>
 			</xs:element>
 			<xs:element name="Shoes" type="bd:Shoes" minOccurs="0">
 			<xs:annotation>
-				<xs:documentation>Describe the Shoes of the body,acceptable values are defined in bd:Shoes.</xs:documentation>
+				<xs:documentation>Describe the Shoes of the body, acceptable values are defined in bd:Shoes.</xs:documentation>
 			</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
@@ -246,7 +246,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:element name="Color" type="tt:ColorDescriptor" minOccurs="0">
 			<xs:annotation>
-				<xs:documentation>Describe the Colour of the Bag, acceptable values are defined in tt:ColorDescriptor.</xs:documentation> 
+				<xs:documentation>Describe the Color of the Bag, acceptable values are defined in tt:ColorDescriptor.</xs:documentation>
 			</xs:annotation> 
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
@@ -257,7 +257,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:sequence>
 			<xs:element name="Color" type="tt:ColorDescriptor" minOccurs="0">
 			<xs:annotation>
-				<xs:documentation>Describe the Color of the Bag, acceptable values are defined in tt:ColorDescriptor.</xs:documentation> 
+				<xs:documentation>Describe the Color of the Umbrella, acceptable values are defined in tt:ColorDescriptor.</xs:documentation>
 			</xs:annotation> 
 			</xs:element>
 			<xs:element name="Open" type="xs:boolean" minOccurs="0">
@@ -328,17 +328,17 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:sequence>
 			<xs:element name="Category" type="xs:string" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Describe the Category of the Weapon, acceptable values are defined in bd:WeaponCategory.</xs:documentation> 
+					<xs:documentation>Describe the Category of the weapon, acceptable values are defined in bd:WeaponCategory.</xs:documentation> 
 				</xs:annotation> 
 			</xs:element>
 			<xs:element name="Color" type="tt:ColorDescriptor" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Describe the Color of the weapon, acceptable values are defined in tt:ColorDescriptor.</xs:documentation> 
+					<xs:documentation>Describe the Color of the weapon, acceptable values are defined in tt:ColorDescriptor.</xs:documentation>
 				</xs:annotation> 
 			</xs:element>
 			<xs:element name="Pose" type="xs:string" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Describes how the weapon is held. Acceptable values are defined in bd:WeaponPose.</xs:documentation> 
+					<xs:documentation>Describes how the weapon is held, acceptable values are defined in bd:WeaponPose.</xs:documentation>
 				</xs:annotation> 
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
@@ -349,12 +349,12 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:sequence>
 			<xs:element name="Bag" type="bd:Bag" minOccurs="0"> 
 			<xs:annotation> 
-				<xs:documentation>Describe the Bag of the body,acceptable values are defined in bd:Bag</xs:documentation> 
+				<xs:documentation>Describe the Bag of the body, acceptable values are defined in bd:Bag</xs:documentation>
 			</xs:annotation> 
 			</xs:element>
 			<xs:element name="Umbrella" type="bd:Umbrella" minOccurs="0"> 
 			<xs:annotation> 
-				<xs:documentation>Describe the Umbrella carried by the body,acceptable values are defined in bd:Umbrella.</xs:documentation> 
+				<xs:documentation>Describe the Umbrella carried by the body, acceptable values are defined in bd:Umbrella.</xs:documentation>
 			</xs:annotation> 
 			</xs:element> 
 			<xs:element name="LiftSomething" type="xs:boolean" minOccurs="0"> 
@@ -364,12 +364,12 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:element name="Box" type="bd:Box" minOccurs="0"> 
 			<xs:annotation> 
-				<xs:documentation>Describe the Box luffed by the body,acceptable values are defined in bd:Box.</xs:documentation> 
+				<xs:documentation>Describe the Box lugged by the body, acceptable values are defined in bd:Box.</xs:documentation>
 			</xs:annotation> 
 			</xs:element> 
 			<xs:element name="Cart" type="bd:Cart" minOccurs="0"> 	
 			<xs:annotation> 
-				<xs:documentation>Describe the Cart pushed by the body,acceptable values are defined in bd:Cart.</xs:documentation> 
+				<xs:documentation>Describe the Cart pushed by the body, acceptable values are defined in bd:Cart.</xs:documentation>
 			</xs:annotation> 
 			</xs:element>
 			<xs:element name="Weapon" type="xs:boolean" minOccurs="0"> 	
@@ -401,7 +401,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:element name="Weapon" type="bd:Weapon" minOccurs="0" maxOccurs="unbounded"> 	
 				<xs:annotation> 
-					<xs:documentation>Describe a waepon the body carries.</xs:documentation> 
+					<xs:documentation>Describe a weapon the body carries.</xs:documentation>
 				</xs:annotation> 
 			</xs:element>			
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
@@ -449,7 +449,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element> 
 			<xs:element name="Activity" type="xs:string" minOccurs="0">
 			<xs:annotation> 
-				<xs:documentation>Describe the activity of the body, Acceptable values are defined in bd:HumanActivity.</xs:documentation> 
+				<xs:documentation>Describe the activity of the body, acceptable values are defined in bd:HumanActivity.</xs:documentation>
 			</xs:annotation> 
 			</xs:element> 				
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- reserved for ONVIF -->

--- a/wsdl/ver20/analytics/humanface.xsd
+++ b/wsdl/ver20/analytics/humanface.xsd
@@ -78,7 +78,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element> 			
 			<xs:element name="Bangs" type="xs:boolean" minOccurs="0"> 
 			<xs:annotation> 
-				<xs:documentation>Describe the bangs of the Hair</xs:documentation> 
+				<xs:documentation>Describe the bangs of the Hair.</xs:documentation>
 			</xs:annotation> 
 			</xs:element> 				
 		</xs:sequence>
@@ -99,8 +99,8 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:sequence>
 			<xs:element name="Width" type="xs:string" minOccurs="0"> 
 			<xs:annotation> 
-				<xs:documentation>Describe the shape of the eyebrow, Short usually means that the width of eye brow is shorter than the length of eye.
-				Long usually means that the width of eye brow is equal to or longer than the length of eye.acceptable values are defined in fc:EyebrowWidth.
+				<xs:documentation>Describe the shape of the eyebrow. Short usually means that the width of the eyebrow is shorter than the length of the eye.
+				Long usually means that the width of eyebrow is equal to or longer than the length of eye. Acceptable values are defined in fc:EyebrowWidth.
 				</xs:documentation> 
 			</xs:annotation> 
 			</xs:element> 	
@@ -233,17 +233,17 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:sequence>
 			<xs:element name="Mustache" type="xs:boolean" minOccurs="0">
 			<xs:annotation> 
-				<xs:documentation>Describe if there is mustache on the face.</xs:documentation> 
+				<xs:documentation>Describe if there is a mustache on the face.</xs:documentation>
 			</xs:annotation>
 			</xs:element> 
 			<xs:element name="Beard" type="xs:boolean" minOccurs="0">
 			<xs:annotation> 
-				<xs:documentation>Describe if there are Beard on the face.</xs:documentation> 
+				<xs:documentation>Describe if there is a beard on the face.</xs:documentation>
 			</xs:annotation>
 			</xs:element> 		
 			<xs:element name="Sideburn" type="xs:boolean" minOccurs="0">
 			<xs:annotation> 
-				<xs:documentation>Describe if there are sideburns on the face.</xs:documentation> 
+				<xs:documentation>Describe if there are sideburns on the face.</xs:documentation>
 			</xs:annotation>
 			</xs:element> 						
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- reserved for ONVIF -->
@@ -309,7 +309,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:sequence>
 			<xs:element name="Wear" type="xs:boolean" minOccurs="0">
 			<xs:annotation> 
-				<xs:documentation>Describe if the object wear a accessory .</xs:documentation> 
+				<xs:documentation>Describe if the object wears an accessory.</xs:documentation>
 			</xs:annotation> 
 			</xs:element> 
 			<xs:element name="Color" type="tt:ColorDescriptor" minOccurs="0">
@@ -331,32 +331,32 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:sequence>
 			<xs:element name="Opticals" type="fc:AccessoryDescription" minOccurs="0">
 			<xs:annotation> 
-				<xs:documentation>Describe if the object wear opticals.</xs:documentation> 
+				<xs:documentation>Describe if the object wears opticals.</xs:documentation>
 			</xs:annotation> 
 			</xs:element> 			
 			<xs:element name="Hat" type="fc:AccessoryDescription" minOccurs="0">
 			<xs:annotation> 
-				<xs:documentation>Describe if the object wear hat.</xs:documentation> 
+				<xs:documentation>Describe if the object wears a hat.</xs:documentation>
 			</xs:annotation> 
 			</xs:element> 
 			<xs:element name="Mask" type="fc:AccessoryDescription" minOccurs="0">
 			<xs:annotation> 
-				<xs:documentation>Describe if the object wear mask.</xs:documentation> 
+				<xs:documentation>Describe if the object wears a mask.</xs:documentation>
 			</xs:annotation> 
 			</xs:element> 
 			<xs:element name="Hijab" type="fc:AccessoryDescription" minOccurs="0">	
 			<xs:annotation> 
-				<xs:documentation>Describe if the object wear hijab.</xs:documentation> 
+				<xs:documentation>Describe if the object wears a hijab.</xs:documentation>
 			</xs:annotation> 
 			</xs:element> 			
 			<xs:element name="Helmet" type="fc:AccessoryDescription" minOccurs="0"> 
 			<xs:annotation> 
-				<xs:documentation>Describe if the object wear Helmet.</xs:documentation> 
+				<xs:documentation>Describe if the object wears a helmet.</xs:documentation>
 			</xs:annotation> 
 			</xs:element> 	
 			<xs:element name="Kerchief" type="fc:AccessoryDescription" minOccurs="0"> 
 			<xs:annotation> 
-				<xs:documentation>Describe if the object wear Kerchief.</xs:documentation> 
+				<xs:documentation>Describe if the object wears a kerchief.</xs:documentation>
 			</xs:annotation> 
 			</xs:element> 	
 			<xs:element name="RightEyePatch" type="fc:AccessoryDescription" minOccurs="0">	
@@ -385,17 +385,17 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:sequence>
 			<xs:element name="Scar" type="xs:boolean" minOccurs="0"> 
 			<xs:annotation> 
-				<xs:documentation>Is there scar on the face.</xs:documentation> 
+				<xs:documentation>Describe if there is a scar on the face.</xs:documentation>
 			</xs:annotation> 
 			</xs:element> 
 			<xs:element name="Mole" type="xs:boolean" minOccurs="0"> 
 			<xs:annotation> 
-				<xs:documentation>Is there mole on the face.</xs:documentation> 
+				<xs:documentation>Describe if there is a mole on the face.</xs:documentation>
 			</xs:annotation> 
 			</xs:element> 						
 			<xs:element name="Tattoo" type="xs:boolean" minOccurs="0"> 
 			<xs:annotation> 
-				<xs:documentation>Is there Tattoo on the face.</xs:documentation> 
+				<xs:documentation>Describe if there is a tattoo on the face.</xs:documentation>
 			</xs:annotation> 
 			</xs:element> 		
 			<xs:element name="Freckles" type="xs:string" minOccurs="0"> 
@@ -431,7 +431,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element> 
 			<xs:element name="FacialShape" type="xs:string" minOccurs="0"> 
 			<xs:annotation> 
-				<xs:documentation>Describe the FacialShape, acceptable values are defined fc:FacialShape.</xs:documentation> 
+				<xs:documentation>Describe the facial shape, acceptable values are defined in fc:FacialShape.</xs:documentation>
 			</xs:annotation> 
 			</xs:element> 
 			<xs:element name="Hair" type="fc:Hair" minOccurs="0"> 
@@ -491,7 +491,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element> 
 			<xs:element name="AdditionalFeatures" type="fc:AdditionalFeatures" minOccurs="0"> 
 			<xs:annotation> 
-				<xs:documentation>Describe the other features, eg scar, mole etc of the face.</xs:documentation> 
+				<xs:documentation>Describe the other features, e.g. scars, moles, etc. of the face.</xs:documentation>
 			</xs:annotation> 
 			</xs:element> 		
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- reserved for ONVIF -->

--- a/wsdl/ver20/analytics/radiometry.xsd
+++ b/wsdl/ver20/analytics/radiometry.xsd
@@ -265,7 +265,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:element name="TemperatureConditionOptions" type="ttr:TemperatureCondition" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>
-						Specifies valid rule conditions for temperature comparisions in radiometric rules.
+						Specifies valid rule conditions for temperature comparisons in radiometric rules.
 					</xs:documentation>
 				</xs:annotation>
 			</xs:element>
@@ -363,7 +363,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:element name="HysteresisTemperature" type="xs:float">
 				<xs:annotation>
 					<xs:documentation>
-						Indicates the width in Kelvin of the temerature hysteresis band to be considered by the rule.
+						Indicates the width in Kelvin of the temperature hysteresis band to be considered by the rule.
 					</xs:documentation>
 				</xs:annotation>
 			</xs:element>

--- a/wsdl/ver20/analytics/rules.xsd
+++ b/wsdl/ver20/analytics/rules.xsd
@@ -53,7 +53,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:element name="SingleSensitivitySupport" type="xs:boolean" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>
-						Indicates the device can only support one sensitivity level for all defines 
+						Indicates the device can only support one sensitivity level for all defined
 						motion detection regions. Changing the sensitivity for one region would be 
 						applied to all regions.
 					</xs:documentation>


### PR DESCRIPTION
Reason: There are multiple spelling errors in the comments and descriptions of the schema (.xsd) files that should be fixed.

Compatibility analysis: Only errors in the description and comments of the different elements that have been fixed. No types or data structures have been updated, so no breaking changes have been introduced. 