### PR TITLE
Clarify RSASSA_PSS usage without base64 encoded ASN.1 parameters.

### DIFF
--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -4158,6 +4158,11 @@
             </tbody>
           </tgroup>
         </table>
+        <para>Note that the signature alogrithm OID for RSA using RSASSA-PSS according to RFC 4055
+          have additional parameters. For the sake of simplicity signature a capability for
+          RSASSA-PSS OID without additional parameters shall signal support for
+          rSASSA-PSS-SHA256-Identifier, rSASSA-PSS-SHA384-Identifier and
+          rSASSA-PSS-SHA512-Identifier as defined in section 6 of RFC 4055.</para>
       </section>
       <section>
         <title>TLS Server Capabilities</title>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -4159,7 +4159,7 @@
           </tgroup>
         </table>
         <para>Note that the signature alogrithm OID for RSA using RSASSA-PSS according to RFC 4055
-          have additional parameters. For the sake of simplicity signature a capability for
+          have additional parameters. For the sake of simplicity the signature capability for
           RSASSA-PSS OID without additional parameters shall signal support for
           rSASSA-PSS-SHA256-Identifier, rSASSA-PSS-SHA384-Identifier and
           rSASSA-PSS-SHA512-Identifier as defined in section 6 of RFC 4055.</para>


### PR DESCRIPTION
Fix for #828: define behavior for RSASSA-PSS OID without parameters to require all three well-defined hashing algorithm with appropriate parameters as defined in RFC 4055.