### PR TITLE
Add minimum length requirements to prefix/postfix in recording targets

### DIFF
--- a/wsdl/ver10/schema/onvif.xsd
+++ b/wsdl/ver10/schema/onvif.xsd
@@ -8296,12 +8296,12 @@ and sample rate. </xs:documentation>
 			</xs:element>
 			<xs:element name="Prefix" type="xs:string" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Path prefix to be inserted in the object key.</xs:documentation>
+					<xs:documentation>Path prefix to be inserted in the object key. A device shall support at least 128 characters.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Postfix" type="xs:string" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Path postfix to be inserted in the object key.</xs:documentation>
+					<xs:documentation>Path postfix to be inserted in the object key. A device shall support at least 128 characters.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="SpanDuration" type="xs:duration" minOccurs="0">


### PR DESCRIPTION
We need to specify some reasonable limits so that the Test Tools have something to validate/enforce.

S3 has a limit of 1024 bytes for Object Names, so we are well within those
Azure has a 2047 limit.