### PR TITLE
Remove TLS 1.0/1.1 refs

### DIFF
--- a/doc/Core.xml
+++ b/doc/Core.xml
@@ -569,10 +569,14 @@
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc4861.txt"></link>&gt;</para>
     <para>RFC 4862, IPv6 Stateless Address Auto configuration</para>
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc4862.txt"></link>&gt;</para>
+    <para>IETF RFC 5246 The Transport Layer Security (TLS) Protocol Version 1.2</para>
+    <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc5246.txt"/>&gt;</para>
     <para>RFC 6750,  The OAuth 2.0 Authorization Framework: Bearer Token Usage</para>
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc6750.txt"/>&gt;</para>
     <para>RFC 7519, JSON Web Token (JWT)</para>
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc7519.txt"/>&gt;</para>
+    <para>IETF RFC 9846 The Transport Layer Security (TLS) Protocol Version 1.3</para>
+    <para role="reference"><link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc9846.txt"/>&gt;</para>
     <para>W3C SOAP Message Transmission Optimization Mechanism,</para>
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.w3.org/TR/soap12-mtom/"></link>&gt;</para>
     <para>W3C SOAP 1.2, Part 1, <emphasis>Messaging Framework</emphasis></para>

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -244,10 +244,6 @@
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
         xlink:href="http://www.onvif.org/specs/core/ONVIF-Core-Specification.pdf"
         >http://www.onvif.org/specs/stream/ONVIF-MediaSigning-Specification.pdf</link>&gt;</para>
-    <para>IETF RFC 2246 The TLS Protocol Version 1.0</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
-        xlink:href="http://www.ietf.org/rfc/rfc2246.txt"
-      >http://www.ietf.org/rfc/rfc2246.txt</link>&gt;</para>
     <para>IETF RFC 2898 PKCS#5 Password-based Cryptography Specification v2.0</para>
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
         xlink:href="http://www.ietf.org/rfc/rfc2898.txt"
@@ -272,10 +268,6 @@
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
         xlink:href="http://www.ietf.org/rfc/rfc4055.txt"
       >http://www.ietf.org/rfc/rfc4055.txt</link>&gt;</para>
-    <para>IETF RFC 4346 The Transport Layer Security (TLS) Protocol Version 1.1</para>
-    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
-        xlink:href="http://www.ietf.org/rfc/rfc4346.txt"
-      >http://www.ietf.org/rfc/rfc4346.txt</link>&gt;</para>
     <para>IETF RFC 5208 Public-Key Cryptography Standards (PKCS) #8: Private-Key Information Syntax
       Specification v1.2</para>
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -3377,8 +3369,7 @@
       <title>TLS Server</title>
       <section>
         <title>Elements of the TLS Server</title>
-        <para>The TLS server security feature implements a TLS server as specified in RFC 2246 and
-          subsequent specifications.</para>
+        <para>The TLS server security feature implements a TLS server as per negotiated TLS version.</para>
         <para>This specification defines how to manage the associations between certification paths
           and the TLS server. All other TLS server configuration actions are outside the scope of
           this specification. In particular, enabling and disabling the TLS server on the device
@@ -3387,10 +3378,10 @@
       </section>
       <section>
         <title>Authorization of TLS authenticated connections</title>
-        <para>If TLS client authentication is enabled, connections shall be authenticated as
-          specified in RFC 2246, and the device shall first of all validate the client TLS
-          certificate. In case of invalid certificate the TLS connection shall be terminated and the
-          device shall ignore any other credentials received on HTTP or WS layer.</para>
+        <para>If TLS client authentication is enabled, connections shall be authenticated using 
+          TLS client certificate authentication mechanism as per negotiated version in the TLS handshake. 
+          The device shall first of all validate the client TLS certificate. In case of invalid certificate 
+          the TLS connection shall be terminated and the device shall ignore any other credentials received on HTTP or WS layer.</para>
         <para>Once a service request is authenticated on the TLS layer, the device shall decide
           based on its access policy whether the requestor is authorized to receive the service. In
           order to authorize the requestor, additional information for the device is
@@ -3421,7 +3412,7 @@
           <para>This operation assigns a key pair and certificate along with a certification path
             (certificate chain) to the TLS server on the device. The TLS server shall use this
             information for key exchange during the TLS handshake, particularly for constructing
-            server certificate messages as specified in RFC 4346, RFC 2246.</para>
+            server certificate messages as per negotiated verion in the TLS handshake.</para>
           <para>Certification paths are identified by their certification path IDs in the keystore.
             The first certificate in the certification path shall be the TLS server
             certificate.</para>
@@ -3431,9 +3422,7 @@
             internal interaction with the keystore.</para>
           <para>If a device chooses to perform a TLS key exchange based on the supplied
             certification path, it shall use the key pair that is associated with the server
-            certificate for key exchange and transmit the certification path to TLS clients as-is,
-            i.e., the device shall not check conformance of the certification path to RFC 4346, RFC
-            2246.</para>
+            certificate for key exchange and transmit the certification path to TLS clients as-is.</para>
           <para>In order to use the server certificate during the TLS handshake, the corresponding
             private key is required. Therefore, if the key pair that is associated with the server
             certificate, i.e., the first certificate in the certification path, does not have an
@@ -3552,8 +3541,7 @@
             suitable internal interaction with the keystore.</para>
           <para>If a device chooses to perform a TLS key exchange based on the new certification
             path, it shall use the key pair that is associated with the server certificate for key
-            exchange and transmit the certification path to TLS clients as-is, i.e., the device
-            shall not check conformance of the certification path to RFC 4346, RFC 2246.</para>
+            exchange and transmit the certification path to TLS clients as-is.</para>
           <para>In order to use the server certificate during the TLS handshake, the corresponding
             private key is required. Therefore, if the key pair that is associated with the server
             certificate, i.e., the first certificate in the certification path, does not have an

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -3380,7 +3380,7 @@
         <title>Authorization of TLS authenticated connections</title>
         <para>If TLS client authentication is enabled, connections shall be authenticated using 
           TLS client certificate authentication mechanism as per negotiated version in the TLS handshake. 
-          The device shall first of all validate the client TLS certificate. In case of invalid certificate 
+          The device shall first validate the client TLS certificate, and in case of invalid certificate 
           the TLS connection shall be terminated and the device shall ignore any other credentials received on HTTP or WS layer.</para>
         <para>Once a service request is authenticated on the TLS layer, the device shall decide
           based on its access policy whether the requestor is authorized to receive the service. In

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -3380,7 +3380,7 @@
         <title>Authorization of TLS authenticated connections</title>
         <para>If TLS client authentication is enabled, connections shall be authenticated using 
           TLS client certificate authentication mechanism as per negotiated version in the TLS handshake. 
-          The device shall first validate the client TLS certificate, and in case of invalid certificate 
+          The device shall first of all validate the client TLS certificate, and in case of invalid certificate 
           the TLS connection shall be terminated and the device shall ignore any other credentials received on HTTP or WS layer.</para>
         <para>Once a service request is authenticated on the TLS layer, the device shall decide
           based on its access policy whether the requestor is authorized to receive the service. In

--- a/doc/Security.xml
+++ b/doc/Security.xml
@@ -326,6 +326,10 @@
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
         xlink:href="http://www.ietf.org/rfc/rfc8705.txt"
       >http://www.ietf.org/rfc/rfc8705.txt</link>&gt;</para>
+    <para>IETF RFC 9846 The Transport Layer Security (TLS) Protocol Version 1.3</para>
+    <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:href="http://www.ietf.org/rfc/rfc9846.txt"
+        >http://www.ietf.org/rfc/rfc9846.txt</link>&gt;</para>
     <para>Unified Modeling Language (UML) </para>
     <para>&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink"
         xlink:href="http://www.omg.org/spec/UML">http://www.omg.org/spec/UML</link>&gt;</para>

--- a/doc/Streaming.xml
+++ b/doc/Streaming.xml
@@ -242,8 +242,6 @@
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.itu.int/rec/dologin_pub.asp?lang=e&amp;id=T-REC-G.726-199012-I!!PDF-E&amp;type=items"/>&gt;</para>
     <para>RSA Laboratories, PKCS #10 v1.7: <emphasis>Certification Request Syntax Standard, RSA Laboratories</emphasis></para>
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="ftp://ftp.rsasecurity.com/pub/pkcs/pkcs-10/pkcs-10v1_7.pdf"/>&gt;</para>
-    <para>IETF RFC 2246, The TLS Protocol Version 1.0</para>
-    <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc2246.txt"/>&gt;</para>
     <para>IETF RFC 2326, Real Time Streaming Protocol (RTSP)</para>
     <para role="reference">&lt;<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.ietf.org/rfc/rfc2326.txt"/>&gt;</para>
     <para>IETF RFC 2396, Uniform Resource Identifiers (URI): General Syntax</para>

--- a/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
+++ b/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
@@ -3316,13 +3316,13 @@
 		<wsdl:operation name="AddServerCertificateAssignment">
 			<wsdl:documentation>
 				This operation assigns a key pair and certificate along with a certification path (certificate chain) to the TLS server on the device.
-				The TLS server shall use this information for key exchange during the TLS handshake, particularly for constructing server certificate messages as specified in RFC 4346 and RFC 2246.<br/>
+				The TLS server shall use this information for key exchange during the TLS handshake, particularly for constructing server certificate messages.<br/>
 				
 				Certification paths are identified by their certification path IDs in the keystore. The first certificate in the certification path must be the TLS server certificate.
 				Since each certificate has exactly one associated key pair, a reference to the key pair that is associated with the server certificate is not supplied explicitly.
 				Devices shall obtain the private key or results of operations under the private key by suitable internal interaction with the keystore.<br/>
 				If a device chooses to perform a TLS key exchange based on the supplied certification path,  it shall use the key pair that is associated with the server certificate for 
-				key exchange and transmit the certification path to TLS clients as-is, i.e., the device shall not check conformance of the certification path to RFC 4346 norRFC 2246.
+				key exchange and transmit the certification path to TLS clients as-is.
 				In order to use the server certificate during the TLS handshake, the corresponding private key is required.
 				Therefore, if the key pair that is associated with the server certificate, i.e., the first certificate in the certification path, does not have an associated private key, 
 				the NoPrivateKey fault is produced and the certification path is not associated to the TLS server.<br/>
@@ -3356,7 +3356,7 @@
 				Since each certificate has exactly one associated key pair, a reference to the key pair that is associated with the new server certificate is not supplied explicitly.
 				Devices shall obtain the private key or results of operations under the private key by suitable internal interaction with the keystore.<br/>
 				If a device chooses to perform a TLS key exchange based on the new certification path,  it shall use the key pair that is associated with the server certificate
-				for key exchange and transmit the certification path to TLS clients as-is, i.e., the device shall not check conformance of the certification path to RFC 4346 norRFC 2246.
+				for key exchange and transmit the certification path to TLS clients as-is.
 				In order to use the server certificate during the TLS handshake, the corresponding private key is required.
 				Therefore, if the key pair that is associated with the server certificate, i.e., the first certificate in the certification path, does not have an associated private key,
 				the NoPrivateKey fault is produced and the certification path is not associated to the TLS server.


### PR DESCRIPTION
This PR is created to resolve https://github.com/onvif/specs/issues/814

Changes include
- remove references of TLS 1.0 RFC
- remove references of TLS 1.1 RFC
- cleaned up negative requirements added when TLS1.0/1.1 was marked deprecated!